### PR TITLE
Conditional styling

### DIFF
--- a/cartoframes/cartoframes.html
+++ b/cartoframes/cartoframes.html
@@ -13,11 +13,23 @@
         padding: 0;
         margin: 0;
       }
+      #zoom-center {
+        position: absolute;
+        right: 0;
+        top: 0;
+        background-color: rgba(255, 255, 255, 0.7);
+        width: 200px;
+        z-index: 100;
+        padding: 4px;
+      }
     </style>
 
     <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
+    <div id="zoom-center">
+      Zoom: <span id="zoom">4</span>, <br />
+      Center: (<span id="lat">38</span>, <span id="lon">-122</span>)</div>
     <div id="map"></div>
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
 
@@ -34,13 +46,29 @@
     }
 
     $(function(){
+      function adjustLongitude(val) {
+        if (val > 180) {
+          return (val + 180) % 360 - 180;
+        } else if (val < -180) {
+          return (val + 180) % 360 + 180;
+        } else {
+          return val;
+        }
+      };
+
+      function updateMapInfo(mapobj) {
+          $("#zoom").text(map.getZoom());
+          $("#lat").text(map.getCenter().lat.toFixed(4));
+          $("#lon").text(adjustLongitude(map.getCenter().lng).toFixed(4));
+      };
 
         console.log(window.location);
         var params = getJsonFromUrl();
         var urlsearch = JSON.parse(decodeURIComponent(params.q)),
             username = params.username,
             tablename = params.tablename,
-            bounds = params.bounds;
+            bounds = params.bounds,
+            baseurl = params.baseurl;
         new_bounds = bounds.split(',');
         new_bounds = [[new_bounds[0], new_bounds[1]],
                       [new_bounds[2], new_bounds[3]]];
@@ -58,6 +86,10 @@
           .addTo(map)
           .done(function(layers) {
               map.fitBounds(new_bounds);
+              updateMapInfo(map);
+              map.on('move', function() {
+                updateMapInfo(map);
+              });
           })
           .error(function(err) {
             console.log("ERROR: ", err);

--- a/cartoframes/cartoframes.html
+++ b/cartoframes/cartoframes.html
@@ -29,7 +29,7 @@
   <body>
     <div id="zoom-center">
       Zoom: <span id="zoom">4</span>, <br />
-      Center: (<span id="lat">38</span>, <span id="lon">-122</span>)</div>
+      Center (lon, lat): (<span id="lon">No data</span>, <span id="lat">No data</span>)</div>
     <div id="map"></div>
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
 
@@ -46,7 +46,8 @@
     }
 
     $(function(){
-      function adjustLongitude(val) {
+
+     function adjustLongitude(val) {
         if (val > 180) {
           return (val + 180) % 360 - 180;
         } else if (val < -180) {
@@ -68,10 +69,16 @@
             username = params.username,
             tablename = params.tablename,
             bounds = params.bounds,
-            baseurl = params.baseurl;
+            baseurl = params.baseurl,
+            show_position_data = params.show_position_data;
         new_bounds = bounds.split(',');
         new_bounds = [[new_bounds[0], new_bounds[1]],
                       [new_bounds[2], new_bounds[3]]];
+        console.log(show_position_data);
+        console.log(typeof(show_position_data));
+        if (show_position_data == 'False' || show_position_data == 'false') {
+          $("#zoom-center").hide();
+        };
         // console.log("NEW BOUNDS", new_bounds);
         // console.log(typeof(new_bounds));
         // console.log("USERNAME", username);
@@ -86,10 +93,12 @@
           .addTo(map)
           .done(function(layers) {
               map.fitBounds(new_bounds);
-              updateMapInfo(map);
-              map.on('move', function() {
+              if (show_position_data == true) {
                 updateMapInfo(map);
-              });
+                map.on('move', function() {
+                  updateMapInfo(map);
+                });
+              };
           })
           .error(function(err) {
             console.log("ERROR: ", err);

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -565,7 +565,7 @@ def carto_map(self, interactive=True, color=None, size=None,
     if self.get_carto_geomtype() is None:
         raise ValueError("Cannot make a map because geometries are all null.")
 
-    basemap_url, basemap_style = self.get_basemap(basemap, debug=debug)
+    basemap_url, basemap_style = self.get_basemap(basemap)
 
     if cartocss is None:
         css = styling.CartoCSS(self, size=size, color=color,

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -227,7 +227,6 @@ def get_carto(self, key):
 
     :param key: key of item to fetch from metadata. One of `carto_named_map`, `carto_geomtype`, `carto_username`, `carto_table`.
     :type key: string
-
     :returns: Value stored in cartoframe metadata
     :rtype: any
     """
@@ -499,34 +498,50 @@ def carto_map(self, interactive=True, color=None, size=None,
 
     :param interactive: (optional) Value on whether to show an interactive map (True) or static map (False)
     :type interactive: boolean
-    :param color: (optional)
+    :param color: (optional) Styles the map by color (e.g., a choropleth for polygon geometries).
 
-        * If color is a string, can be a column name or a hex value (beginning with a ``#``). When a hex value, all geometries are colored the same. If the column name, use CARTO's TurtoCarto to create qualitative or category mapping.
+        * If color is a string, can be one of two options:
+
+            - a column name. With this option, CARTO's `TurtoCarto <https://carto.com/blog/styling-with-turbo-carto>`__ is used to create qualitative or category mapping based on the data type.
+            - a hex value (beginning with a ``#``) or in the set of `CSS3 named colors <https://www.w3schools.com/colors/colors_names.asp>`__. With this option, all geometries are colored the same.
+
         * If color is a dict, parse the parameters to custom style the map. Values are:
 
             - `colname` (required): column name to base the styling on
-            - `ramp` (optional): If text, type of color ramp to use. See https://github.com/CartoDB/CartoColor/blob/master/cartocolor.js for a full list. If list/tuple, set of hex values.
+            - `ramp` (optional): If text, type of color ramp to use. See the `CartoColor repository <https://github.com/CartoDB/CartoColor/blob/master/cartocolor.js>`__ for a full list. If list/tuple, set of hex values.
             - `ramp_provider` (optional): Specify the source of the `ramp` (either `cartocolor` or `colorbrewer`)
             - `num_bins`: Number of divisions for the ramp
             - `quant_method`: Quantification method for dividing the data into classes. Options are `jenks`, `quantiles`, `equal`, or `headtails`. By choosing a custom ramp
 
     :type color: dict, string
-    :param size: (optional) Only works with point geometries. A future version will allow more sizing options for lines.
+    :param size: (optional) Styles point data by size. Only works with point geometries.
 
         * If size is an integer, all points are sized by the same value specified.
-        * If size is a column name, this option sizes points from a default minimum value of 4 pixels to 15 pixels.
+        * If size is a column name, this option sizes points from a default minimum value of 5 pixels to 25 pixels.
         * If size is a dict, size points by the following values if entered. Defaults will be used if they are not requested.
 
-          - colname: column to base the styling off of
-          - max: maximum marker width (default 15)
-          - min: minimum marker width (default 4)
-          - quant_method: type of quantification to use. Options are `jenks`, `quantiles`, `equal`, or `headtails`.
+          - `colname`: column to base the styling off of
+          - `max`: maximum marker width (default 25)
+          - `min`: minimum marker width (default 5)
+          - `quant_method`: type of quantification to use. Options are `jenks`, `quantiles`, `equal`, or `headtails`.
 
     :type size: integer, string, dict
     :param cartocss: Complete CartoCSS style to apply to your map. This will override `size` and `color` attributes if present.
     :type cartocss: string
-    :param basemap: (optional) XYZ URL template for the basemap. See https://leaflet-extras.github.io/leaflet-providers/preview/ for examples.
-    :type basemap: string
+    :param options: This can be one of the following:
+
+    * XYZ URL for a custom basemap. See `this list <https://leaflet-extras.github.io/leaflet-providers/preview/>`__ for examples.
+    * `CARTO basemap <https://carto.com/location-data-services/basemaps/>`__ styles
+
+      - Specific description: `light_all`, `light_nolabels`, `dark_all`, or `dark_nolabels`
+      - General descrption: `light` or `dark`. Specifying one of these results in the best basemap for the map geometries.
+
+    * Dictionary with the following keys:
+
+      - `style`: (required) descrption of the map type (`light` or `dark`)
+      - `labels`: (optional) Show labels (`True`) or not (`False`). If this option is not included, the best basemap will be chosen based on what was entered for `style` and the geometry type of the basemap.
+
+    :type options: string or dict
     :param figsize: (optional) Tuple of dimensions (width, height) for output embed or image. Default is (647, 400).
     :type figsize: tuple
     :param center: (optional) A (longitude, latitude) coordinate pair of the center view of a map

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -544,11 +544,11 @@ def carto_map(self, interactive=True, color=None, size=None,
     if self.get_carto_geomtype() is None:
         raise ValueError("Cannot make a map because geometries are all null.")
 
-    basemap_url = self.get_basemap(basemap, debug=debug)
+    basemap_url, basemap_style = self.get_basemap(basemap, debug=debug)
 
     if cartocss is None:
         css = styling.CartoCSS(self, size=size, color=color,
-                               cartocss=cartocss, basemap=basemap)
+                               cartocss=cartocss, basemap=basemap_style)
         cartocss = css.get_cartocss()
 
     if debug: print(cartocss)

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -20,6 +20,7 @@ Features to add: see issues in the repository https://github.com/CartoDB/cartofr
 # TODO: hook into pandas.core?
 import pandas as pd
 import cartoframes.utils as utils
+import cartoframes.maps as maps
 import carto
 
 
@@ -543,9 +544,11 @@ def carto_map(self, interactive=True, color=None, size=None,
     if self.get_carto_geomtype() is None:
         raise ValueError("Cannot make a map because geometries are all null.")
 
+    basemap_url = self.get_basemap(basemap, debug=debug)
+
     if cartocss is None:
-        css = styling.CartoCSS(self, size=size,
-                               color=color, cartocss=cartocss)
+        css = styling.CartoCSS(self, size=size, color=color,
+                               cartocss=cartocss, basemap=basemap)
         cartocss = css.get_cartocss()
 
     if debug: print(cartocss)
@@ -553,7 +556,7 @@ def carto_map(self, interactive=True, color=None, size=None,
     # create static map
     # TODO: use carto-python client to create static map (not yet
     #       implemented)
-    url = self._get_static_snapshot(cartocss, basemap, figsize, debug=False)
+    url = self._get_static_snapshot(cartocss, basemap_url, figsize, debug=False)
     img = '<img src="{url}" />'.format(url=url)
 
     if interactive is False:
@@ -566,7 +569,7 @@ def carto_map(self, interactive=True, color=None, size=None,
         mapconfig_params = {'username': self.get_carto_username(),
                             'tablename': self.get_carto_tablename(),
                             'cartocss': cartocss,
-                            'basemap': basemap,
+                            'basemap': basemap_url,
                             'bounds': bnd_str}
 
         mapconfig_params['q'] = urllib.quote(
@@ -614,6 +617,7 @@ pd.DataFrame.get_carto_username = get_carto_username
 pd.DataFrame.get_carto_tablename = get_carto_tablename
 pd.DataFrame.get_carto_geomtype = get_carto_geomtype
 pd.DataFrame.get_carto_namedmap = get_carto_namedmap
+pd.DataFrame.get_basemap = maps.get_basemap
 
 # internal state methods
 pd.DataFrame.carto_registered = carto_registered

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -494,7 +494,7 @@ def make_cartoframe(self, username, api_key, tablename,
 
 def carto_map(self, interactive=True, color=None, size=None,
               cartocss=None, basemap=None, figsize=(647, 400),
-              center=None, zoom=None, debug=False):
+              center=None, zoom=None, show_position_data=True, debug=False):
     """Produce and return CARTO maps. Can be interactive or static.
 
     :param interactive: (optional) Value on whether to show an interactive map (True) or static map (False)
@@ -583,7 +583,8 @@ def carto_map(self, interactive=True, color=None, size=None,
                             'tablename': self.get_carto_tablename(),
                             'cartocss': cartocss,
                             'basemap': basemap_url,
-                            'bounds': bnd_str}
+                            'bounds': bnd_str,
+                            'show_position_data': show_position_data}
 
         mapconfig_params['q'] = urllib.quote(
             maps.get_named_mapconfig(self.get_carto_username(),

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -530,22 +530,24 @@ def carto_map(self, interactive=True, color=None, size=None,
     :type cartocss: string
     :param options: This can be one of the following:
 
-    * XYZ URL for a custom basemap. See `this list <https://leaflet-extras.github.io/leaflet-providers/preview/>`__ for examples.
-    * `CARTO basemap <https://carto.com/location-data-services/basemaps/>`__ styles
+        * XYZ URL for a custom basemap. See `this list <https://leaflet-extras.github.io/leaflet-providers/preview/>`__ for examples.
+        * `CARTO basemap <https://carto.com/location-data-services/basemaps/>`__ styles
 
-      - Specific description: `light_all`, `light_nolabels`, `dark_all`, or `dark_nolabels`
-      - General descrption: `light` or `dark`. Specifying one of these results in the best basemap for the map geometries.
+          - Specific description: `light_all`, `light_nolabels`, `dark_all`, or `dark_nolabels`
+          - General descrption: `light` or `dark`. Specifying one of these results in the best basemap for the map geometries.
 
-    * Dictionary with the following keys:
+        * Dictionary with the following keys:
 
-      - `style`: (required) descrption of the map type (`light` or `dark`)
-      - `labels`: (optional) Show labels (`True`) or not (`False`). If this option is not included, the best basemap will be chosen based on what was entered for `style` and the geometry type of the basemap.
+          - `style`: (required) descrption of the map type (`light` or `dark`)
+          - `labels`: (optional) Show labels (`True`) or not (`False`). If this option is not included, the best basemap will be chosen based on what was entered for `style` and the geometry type of the basemap.
 
     :type options: string or dict
     :param figsize: (optional) Tuple of dimensions (width, height) for output embed or image. Default is (647, 400).
     :type figsize: tuple
     :param center: (optional) A (longitude, latitude) coordinate pair of the center view of a map
     :type center: tuple
+    :param show_position_data: Whether to show the center and zoom on an interactive map. This can be useful for finding views for static maps.
+    :type show_position_data: boolean
     :returns: an interactive or static CARTO map optionally styled
     :rtype: HTML embed
 

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -210,7 +210,7 @@ def get_named_mapconfig(username, mapname, ):
     return mapconfig
 
 
-def get_basemap(self, inputoption, debug=False):
+def get_basemap(self, options, debug=False):
     """
     {'style': 'dark',
      'labels': True} --> []
@@ -226,33 +226,36 @@ def get_basemap(self, inputoption, debug=False):
                      'dark_nolabels',)
     label_options = ('dark', 'light',)
 
-    if isinstance(inputoption, str):
-        if inputoption[0:4] == 'http':
+    if isinstance(options, str):
+        if options[0:4] == 'http':
             # input is already a basemap
-            return inputoption
-        elif inputoption in style_options:
+            return (options, None)
+        elif options in style_options:
             # choose one of four carto types
-            return template % {'style': inputoption}
+            return (template % {'style': options},
+                    'dark' if 'dark_' in options else 'light')
         else:
             raise ValueError("Text inputs must be an XYZ basemap format, or "
                              "one of: {}.".format(','.join(style_options)))
-    elif (isinstance(inputoption, dict) and
-          'style' in inputoption and
-          inputoption['style'] in label_options):
-        if ('labels' in inputoption and
-                inputoption['labels'] is True):
-            return [template % {'style': inputoption['style'] + '_nolabels'},
-                    template % {'style': inputoption['style'] + '_only_labels'}]
-        elif inputoption['labels'] is False:
-            return template % {'style': inputoption['style'] + '_nolabels'}
+    elif (isinstance(options, dict) and
+          'style' in options and
+          options['style'] in label_options):
+        if ('labels' in options and
+                options['labels'] is True):
+            return ([template % {'style': options['style'] + '_nolabels'},
+                    template % {'style': options['style'] + '_only_labels'}],
+                    options['style'])
+        elif options['labels'] is False:
+            return (template % {'style': options['style'] + '_nolabels'},
+                    options['style'])
         else:
-            return
+            raise NameError('Could not work with basemap parameters.')
     else:
         if self.get_carto_geomtype() in ('point', 'line'):
-            return template % {'style': 'dark_all'}
+            return template % {'style': 'dark_all'}, 'dark'
         elif self.get_carto_geomtype() == 'polygon':
             return [template % {'style': 'dark_all'},
-                    template % {'style': 'dark_only_labels'}]
+                    template % {'style': 'dark_only_labels'}], 'dark'
         else:
-            return template % {'style': 'dark_all'}
+            return template % {'style': 'dark_all'}, 'dark'
     return None

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -198,3 +198,41 @@ def get_named_mapconfig(username, mapname):
       "subdomains": [ "a", "b", "c" ]
       }''' % map_args
     return mapconfig
+
+
+def get_basemap(self, inputoption, debug=False):
+    """
+    {'style': 'dark',
+     'labels': 'bottom'} --> []
+
+
+
+    """
+
+    template = ('http://cartodb-basemaps-{s}.global.ssl.fastly.net/'
+                '%(style)s/{z}/{x}/{y}.png')
+    style_options = ('light_all', 'dark_all', 'light_nolabels',
+                     'dark_nolabels',)
+
+    if isinstance(inputoption, str):
+        if inputoption[0:4] == 'http':
+            # input is already a basemap
+            return inputoption
+        elif inputoption in style_options:
+            # choose one of four carto types
+            return template % {'style': inputoption}
+        else:
+            raise ValueError("Text inputs must be an XYZ basemap format, or "
+                             "one of: {}.".format(','.join(style_options)))
+    elif isinstance(inputoption, dict):
+        if 'url' in inputoption:
+            return inputoption['url']
+    else:
+        if self.get_carto_geomtype() in ('point', 'line'):
+            return template % {'style': 'dark_all'}
+        elif self.get_carto_geomtype() == 'polygon':
+            return [template % {'style': 'dark_all'},
+                    template % {'style': 'dark_only_labels'}]
+        else:
+            return template % {'style': 'dark_all'}
+    return None

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -30,7 +30,7 @@ def get_auth_client(username=None, api_key=None,
             BASEURL = baseurl
         auth_client = APIKeyAuthClient(BASEURL, api_key)
         sql = SQLClient(auth_client)
-    elif (username is None) and (api_key is None):
+    elif (username is None) or (api_key is None):
         sql = SQLClient(cdb_client)
     else:
         raise Exception("`username` and `api_key` or `cdb_client` has to be "

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -11,7 +11,7 @@ def get_auth_client(username=None, api_key=None,
     :type username: string
     :param api_key: API key of CARTO user ``username``
     :type api_key: string
-    :param baseurl: Base URL for CARTO instance (usually suitable or on prem)
+    :param baseurl: Base URL for CARTO instance (usually suitable for on prem)
     :type baseurl: string
     :param cdb_client: CARTO Python SDK Authentication client
     :type cdb_client: object
@@ -22,7 +22,6 @@ def get_auth_client(username=None, api_key=None,
     from carto.sql import SQLClient
     from carto.auth import APIKeyAuthClient
     if cdb_client is None:
-
         if baseurl is None:
             BASEURL = 'https://{username}.carto.com/api/'.format(
                 username=username)
@@ -73,9 +72,12 @@ def create_table_query(tablename, schema, username, is_org_user=False,
 def map_dtypes(pgtype):
     """
     Map PostgreSQL data types (key) to NumPy/pandas dtypes (value)
+
     :param pgtype: string PostgreSQL/CARTO datatype to map to pandas data type
     Output
-    :param : string data type used in pandas
+    :type pgtype: string
+    :returns: pandas data type
+    :rtype: string
     """
     # may not be a complete list, could not find CARTO SQL API documentation
     # about data types
@@ -220,9 +222,12 @@ def transform_schema(pgschema):
 def get_username(baseurl):
     """
     Retrieve the username from the baseurl.
-    :param baseurl: string Must be of format https://{username}.carto.com/api/
-
     NOTE: Not compatible with onprem, etc.
+
+    :param baseurl: string Must be of format https://{username}.carto.com/api/
+    :type baseurl: string
+    :returns: CARTO username
+    :rtype: string
     """
     # TODO: make this more robust
     import re
@@ -235,6 +240,8 @@ def get_geom_type(carto_sql_client, tablename):
 
         :param sql_auth_client: object SQL Auth client from CARTO Python SDK
         :param tablename: string Name of table for cartoframe
+        :returns: Geometry type. One of 'point', 'line', 'polygon', or None
+        :rtype: string
     """
     geomtypes = {'ST_Point': 'point',
                  'ST_MultiPoint': 'point',
@@ -274,6 +281,7 @@ def df_from_query(query, carto_sql_client, is_org_user, username,
         :param username: string CARTO username
 
         :returns: cartoframe created from ``query``
+        :rtype: cartoframe
     """
     if tablename:
         create_table = '''
@@ -310,6 +318,9 @@ def df_from_query(query, carto_sql_client, is_org_user, username,
 def df_from_table(query, carto_sql_client, index=None):
     """
     Create a pandas DataFrame from a CARTO table
+
+    :returns: DataFrame associated with a CARTO table
+    :rtype: cartoframe
     """
     resp = carto_sql_client.send(query)
     schema = transform_schema(resp['fields'])
@@ -319,6 +330,9 @@ def df_from_table(query, carto_sql_client, index=None):
         return pd.DataFrame(resp['rows']).astype(schema)
 
 def upsert_table(self, df_diff, n_batch=5000, debug=False):
+    """
+    Insert or update vales in a database
+    """
 
     n_items = len(df_diff)
     queries = []


### PR DESCRIPTION
* more flexible basemap options (CARTO's Positron (`light`) and Dark Matter (`dark`) basemaps and all label combinations)
* support for interaction between basemaps and cartography
    * cartography updates based on whether basemap is light or dark
* support for basemap based on geometry type:
    * labels on top for polygon datasets
    * labels on bottom for points and lines
* helper tool for zoom/center in interactive html embed

![automatic_cartography](https://cloud.githubusercontent.com/assets/1041056/23912258/6d1df8e2-08df-11e7-9551-d0d5fe8343a8.gif)

closes #46 closes #43 closes #13