### PR TITLE
On prem support for maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,34 @@
-credentials.json
-.DS_Store
+# Python / Jupyter
 *.pyc
 .ipynb_checkpoints/
+
+# Misc
+credentials.json
+
+# OS
+.DS_Store
+
+# Sphinx related
+_build
+.buildinfo
+.doctrees/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+

--- a/cartoframes/assets/cartoframes.html
+++ b/cartoframes/assets/cartoframes.html
@@ -28,8 +28,7 @@
   </head>
   <body>
     <div id="zoom-center">
-      Zoom: <span id="zoom">4</span>, <br />
-      Center (lon, lat): (<span id="lon">No data</span>, <span id="lat">No data</span>)</div>
+      zoom=<span id="zoom">4</span>, center=(<span id="lon">No data</span>, <span id="lat">No data</span>)</div>
     <div id="map"></div>
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
 

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -58,7 +58,6 @@ def read_carto(username=None, api_key=None, onprem_url=None, tablename=None,
        :returns: A pandas DataFrame linked to a CARTO table
        :rtype: cartoframe
     """
-    import cartoframes.maps as maps
     # TODO: if onprem, use the specified template/domain? instead
     # either cdb_client or user credentials have to be specified
     sql = utils.get_auth_client(username=username,
@@ -686,6 +685,7 @@ pd.DataFrame.get_carto_username = get_carto_username
 pd.DataFrame.get_carto_tablename = get_carto_tablename
 pd.DataFrame.get_carto_geomtype = get_carto_geomtype
 pd.DataFrame.get_carto_namedmap = get_carto_namedmap
+pd.DataFrame.get_carto_baseurl = get_carto_baseurl
 pd.DataFrame.get_basemap = maps.get_basemap
 
 # internal state methods

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -192,10 +192,26 @@ def get_carto_datapage(self):
     """
     # TODO: generalize this for onprem
     # e.g., https://eschbacher.carto.com/dataset/research_team
-    url_template = 'https://{username}.carto.com/dataset/{tablename}'
+    import sys
+    if sys.version_info[0] == 3:
+        from urllib.parse import urlparse
+    else:
+        from urlparse import urlparse
 
-    return url_template.format(username=self.get_carto_username(),
-                               tablename=self.get_carto_tablename())
+    parsed_url = urlparse(self.get_carto_baseurl())
+    netloc = parsed_url.netloc
+    scheme = parsed_url.scheme
+    if netloc.endswith('.carto.com'):
+        url_template = '{scheme}://{netloc}/dataset/{tablename}'
+        return url_template.format(scheme=scheme,
+                                   netloc=netloc,
+                                   tablename=self.get_carto_tablename())
+    else:
+        url_template = '{scheme}://{netloc}/user/{user}/dataset/{tablename}'
+        return url_template.format(scheme=scheme,
+                                   netloc=netloc,
+                                   user=self.get_carto_username(),
+                                   tablename=self.get_carto_tablename())
 
 def get_carto_tablename(self):
     """return the username of a cartoframe
@@ -688,6 +704,7 @@ pd.DataFrame.get_carto_geomtype = get_carto_geomtype
 pd.DataFrame.get_carto_namedmap = get_carto_namedmap
 pd.DataFrame.get_carto_baseurl = get_carto_baseurl
 pd.DataFrame.get_basemap = maps.get_basemap
+pd.DataFrame.get_carto_datapage = get_carto_datapage
 
 # map methods
 pd.DataFrame._get_static_snapshot = maps._get_static_snapshot

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -63,7 +63,9 @@ def read_carto(username=None, api_key=None, onprem_url=None, tablename=None,
     sql = utils.get_auth_client(username=username,
                                 api_key=api_key,
                                 baseurl=onprem_url,
+                                org=org,
                                 cdb_client=cdb_client)
+    baseurl = utils.get_baseurl(username=username, baseurl=onprem_url)
 
     # construct query
     if tablename is not None and query is None:
@@ -85,10 +87,10 @@ def read_carto(username=None, api_key=None, onprem_url=None, tablename=None,
         raise ValueError("Either `tablename` or `query` (or both) need to be "
                          "specified.")
 
-    # TODO: find out of there's a max length to clip on
+    # TODO: find out if there's a max length to clip on
     # only make map and set metadata if it's becoming a cartoframe
     if tablename:
-        named_map_name = maps.create_named_map(username, api_key,
+        named_map_name = maps.create_named_map(baseurl, api_key,
                                                tablename=tablename)
         print("Named map name: {}".format(named_map_name))
 
@@ -100,9 +102,7 @@ def read_carto(username=None, api_key=None, onprem_url=None, tablename=None,
                          limit=limit,
                          geomtype=utils.get_geom_type(sql,
                                                       tablename=tablename),
-                         baseurl=utils.get_baseurl(username=username,
-                                                   org=org,
-                                                   baseurl=onprem_url))
+                         baseurl=baseurl)
 
         # save the state for later use
         # NOTE: this doubles the size of the dataframe
@@ -586,7 +586,6 @@ def carto_map(self, interactive=True, color=None, size=None,
 
     """
     import cartoframes.styling as styling
-    import cartoframes.maps as maps
     try:
         # if Python 3
         import urllib.parse as urllib
@@ -643,7 +642,9 @@ def carto_map(self, interactive=True, color=None, size=None,
 
         mapconfig_params['q'] = urllib.quote(
             maps.get_named_mapconfig(self.get_carto_username(),
-                                     self.get_carto_namedmap()))
+                                     self.get_carto_namedmap(),
+                                     baseurl=self.get_carto_baseurl()))
+        if debug: print(mapconfig_params['q'])
 
         baseurl = ('https://rawgit.com/CartoDB/cartoframes/master/'
                    'cartoframes/assets/cartoframes.html')

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -688,6 +688,10 @@ pd.DataFrame.get_carto_namedmap = get_carto_namedmap
 pd.DataFrame.get_carto_baseurl = get_carto_baseurl
 pd.DataFrame.get_basemap = maps.get_basemap
 
+# map methods
+pd.DataFrame._get_static_snapshot = maps._get_static_snapshot
+pd.DataFrame.get_bounds = maps.get_bounds
+
 # internal state methods
 pd.DataFrame.carto_registered = carto_registered
 pd.DataFrame.carto_insync = carto_insync

--- a/cartoframes/core.py
+++ b/cartoframes/core.py
@@ -602,6 +602,7 @@ def carto_map(self, interactive=True, color=None, size=None,
 
     """
     import cartoframes.styling as styling
+    import random
     try:
         # if Python 3
         import urllib.parse as urllib
@@ -629,7 +630,7 @@ def carto_map(self, interactive=True, color=None, size=None,
     # create static map
     # TODO: use carto-python client to create static map (not yet
     #       implemented)
-    mapview = {}
+    mapview = {'rand': random.random()}
     if zoom:
         mapview['zoom'] = zoom
     if center:

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -2,7 +2,6 @@
 Functions and methods for interactive and static maps
 """
 
-import pandas as pd
 
 def create_named_map(username, api_key, tablename):
     """Create a default named map for later use
@@ -117,11 +116,6 @@ def _get_static_snapshot(self, cartocss, basemap, figsize=(647, 400),
         mapname=self.get_carto_namedmap(),
         api_key=self.get_carto_api_key())
 
-    # endpoint = ("https://{username}.carto.com/api/v1/map/named/"
-    #             "{map_name}").format(
-    #                 username=self.get_carto_username(),
-    #                 map_name=self.get_carto_namedmap())
-
     resp = requests.put(endpoint,
                         data=new_template,
                         headers={'Content-Type': 'application/json'})
@@ -148,9 +142,6 @@ def _get_static_snapshot(self, cartocss, basemap, figsize=(647, 400),
                           params=urlencode(mapview))
     else:
         resp.raise_for_status()
-
-pd.DataFrame._get_static_snapshot = _get_static_snapshot
-pd.DataFrame.get_bounds = get_bounds
 
 
 def get_named_map_template():

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -39,8 +39,7 @@ def create_named_map(baseurl, api_key, tablename):
                                                  api_key=api_key)
     resp = requests.post(api_endpoint,
                          data=filled_template,
-                         headers={'Content-Type': 'application/json'},
-                         verify=False)
+                         headers={'Content-Type': 'application/json'})
     if resp.status_code == requests.codes.ok:
         return json.loads(resp.text)['template_id']
     else:
@@ -119,8 +118,7 @@ def _get_static_snapshot(self, cartocss, basemap, figsize=(647, 400),
 
     resp = requests.put(endpoint,
                         data=new_template,
-                        headers={'Content-Type': 'application/json'},
-                        verify=False)
+                        headers={'Content-Type': 'application/json'})
     # TODO: replace with bounding box extent instead
     #       do this in the map creation/updating?
     # https://carto.com/docs/carto-engine/maps-api/named-maps#arguments

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -112,9 +112,10 @@ def _get_static_snapshot(self, cartocss, basemap, figsize=(647, 400),
     args = dict(map_params, **bounds)
     new_template = get_named_map_template() % args
     if debug: print(new_template)
-    endpoint = "{baseurl}/api/v1/map/named/{mapname}".format(
+    endpoint = "{baseurl}v1/map/named/{mapname}?api_key={api_key}".format(
         baseurl=self.get_carto_baseurl(),
-        mapname=self.get_carto_namedmap())
+        mapname=self.get_carto_namedmap(),
+        api_key=self.get_carto_api_key())
 
     # endpoint = ("https://{username}.carto.com/api/v1/map/named/"
     #             "{map_name}").format(

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -3,7 +3,7 @@ private functions used in cartoframes methods
 """
 import pandas as pd
 
-def get_auth_client(username=None, api_key=None,
+def get_auth_client(username=None, api_key=None, org=None,
                     baseurl=None, cdb_client=None):
     """Instantiates a SQL Client from the CARTO Python SDK (v1.0.0)
 
@@ -22,11 +22,7 @@ def get_auth_client(username=None, api_key=None,
     from carto.sql import SQLClient
     from carto.auth import APIKeyAuthClient
     if cdb_client is None:
-        if baseurl is None:
-            BASEURL = 'https://{username}.carto.com/api/'.format(
-                username=username)
-        else:
-            BASEURL = baseurl
+        BASEURL = get_baseurl(username=username, org=org, baseurl=baseurl)
         auth_client = APIKeyAuthClient(BASEURL, api_key)
         sql = SQLClient(auth_client)
     elif (username is None) or (api_key is None):
@@ -36,6 +32,23 @@ def get_auth_client(username=None, api_key=None,
                         "specified.")
     return sql
 
+
+def get_baseurl(username=None, org=None, baseurl=None):
+    """"""
+    if baseurl is None and org is None:
+        if username:
+            return 'https://{username}.carto.com/api/'.format(username=username)
+        else:
+            raise Exception("`username` required if `org` or `baseurl` are not "
+                            " specified")
+    elif baseurl is None:
+        return 'https://{org}.carto.com/u/{username}/api'.format(
+            org=org,
+            username=username)
+    else:
+        return baseurl
+
+    return None
 
 def create_table_query(tablename, schema, username, is_org_user=False,
                        debug=False):

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -21,12 +21,13 @@ def get_auth_client(username=None, api_key=None, org=None,
     """
     from carto.sql import SQLClient
     from carto.auth import APIKeyAuthClient
-    if cdb_client is None:
-        BASEURL = get_baseurl(username=username, baseurl=baseurl)
-        auth_client = APIKeyAuthClient(BASEURL, api_key)
-        sql = SQLClient(auth_client)
-    elif (username is None) or (api_key is None):
+
+    if cdb_client:
         sql = SQLClient(cdb_client)
+    elif username is not None and api_key is not None:
+        BASEURL = get_baseurl(username=username, baseurl=baseurl)
+        auth_client = APIKeyAuthClient(BASEURL, api_key, org=org)
+        sql = SQLClient(auth_client)
     else:
         raise Exception("`username` and `api_key` or `cdb_client` has to be "
                         "specified.")

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -22,7 +22,7 @@ def get_auth_client(username=None, api_key=None, org=None,
     from carto.sql import SQLClient
     from carto.auth import APIKeyAuthClient
     if cdb_client is None:
-        BASEURL = get_baseurl(username=username, org=org, baseurl=baseurl)
+        BASEURL = get_baseurl(username=username, baseurl=baseurl)
         auth_client = APIKeyAuthClient(BASEURL, api_key)
         sql = SQLClient(auth_client)
     elif (username is None) or (api_key is None):
@@ -33,20 +33,19 @@ def get_auth_client(username=None, api_key=None, org=None,
     return sql
 
 
-def get_baseurl(username=None, org=None, baseurl=None):
+def get_baseurl(username=None, baseurl=None):
     """"""
-    if baseurl is None and org is None:
+    if baseurl is None:
         if username:
             return 'https://{username}.carto.com/api/'.format(username=username)
         else:
             raise Exception("`username` required if `org` or `baseurl` are not "
-                            " specified")
-    elif baseurl is None:
-        return 'https://{org}.carto.com/u/{username}/api'.format(
-            org=org,
-            username=username)
+                            "specified")
     else:
-        return baseurl
+        outs = '{baseurl}/user/{username}/api/'.format(baseurl=baseurl,
+                                                       username=username)
+        print(outs)
+        return outs
 
     return None
 


### PR DESCRIPTION
This adds on-prem support for cartoframe maps (interactive, static).

@dmed256, here's my version of maps support for both on-prem and cloud-hosted carto versions. Once we get the Maps API supported in the CARTO Python SDK, this code will be a lot easier. I don't do anything too drastic with the Authentication information, so hopefully your refactoring will be easy to reconcile with this.

BTW, I was wrong about the URL formats, only two are:
* `{onpremhost}/user/{user}`
* `https://{user}.carto.com`

closes https://github.com/CartoDB/cartoframes/issues/49