### PR TITLE
ensures even handling of basemap for different input cases

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -195,7 +195,8 @@ class CartoContext:
             raise ValueError('zoom, lat, and lng must all or none be provided')
 
         # When no layers are passed, set default zoom
-        if len(layers) == 0 and zoom is None:
+        if ((len(layers) == 0 and zoom is None) or
+                (len(layers) == 1 and layers[0].is_basemap)):
             [zoom, lat, lng] = [3, 38, -99]
         has_zoom = zoom is not None
 

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -53,6 +53,7 @@ class CartoContext:
         self.is_org = (paths[0] != 'public')
 
         self._map_templates = {}
+        self._srcdoc = None
 
         self._verbose = verbose
 
@@ -371,7 +372,7 @@ class CartoContext:
 
 
     def _get_iframe_srcdoc(self, config, bounds, options, map_options):
-        if not hasattr(self, '_srcdoc'):
+        if not hasattr(self, '_srcdoc') or self._srcdoc is None:
             with open(os.path.join(os.path.dirname(__file__),
                                    'assets/cartoframes.html'), 'r') as f:
                 self._srcdoc = f.read()


### PR DESCRIPTION
Ensures that 
```cc.map(layers=BaseMap())```
and
```cc.map()```

have the same behavior.

closes #75