### PR TITLE
adds newstyle class to abstract layer object

### DIFF
--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -13,7 +13,7 @@ DEFAULT_COLORS = ['#F9CA34', '#4ABD9A', '#4A5798', '#DF5E26',
                   '#F9CA34', '#4ABD9A', '#4A5798', '#DF5E26']
 
 
-class AbstractLayer:
+class AbstractLayer(object):
     """Abstract Layer object"""
     is_basemap = False
 


### PR DESCRIPTION
@dmed256, the lack of 'new style class' (the `object` in `class AbstractLayer(object)`) was causing `Layer` to not instantiate in Python 2. I'm still a little fuzzy on the need for the new style class between python 2 and 3. Could you take a look?

closes #89 