### PR TITLE
Update pyrestcli requirement

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Andy Eschbacher <andy@carto.com>
 Stuart Lynn <stuartlynn@carto.com>
 David Medina <dmed256@gmail.com>
 Levi J. Wolf <levi.john.wolf@gmail.com>
+Michelle Ho <mho@carto.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/CartoDB/carto-python.git@1.0.0#egg=carto-1.0.0
-pyrestcli
+pyrestcli==0.6.3
 pandas==0.19.2
 webcolors==1.7


### PR DESCRIPTION
Problem:
- `pip install - r requirements` failed to update to newest version of pyrestcli (v0.6.3 as of this writing)
- API calls failed to work because of unexpected "session" keyword 