### PR TITLE
warns about changed columns between pandas and postgresql

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -289,10 +289,11 @@ class CartoContext:
             FROM "{table_name}"
             LIMIT 0'''.format(table_name=table_name))['fields'].keys()
         diff_cols = (set(dataframe.columns) ^ set(pgcolumns)) - {'cartodb_id'}
-        cols = ', '.join('`{}`'.format(c) for c in diff_cols)
-        warn('The following columns were renamed because of PostgreSQL '
-             'column normalization requirements: {cols}'.format(cols=cols),
-             stacklevel=2)
+        if diff_cols:
+            cols = ', '.join('`{}`'.format(c) for c in diff_cols)
+            warn('The following columns were renamed because of PostgreSQL '
+                 'column normalization requirements: {cols}'.format(cols=cols),
+                 stacklevel=2)
 
     def sync(self, dataframe, table_name):
         """Depending on the size of the DataFrame or CARTO table, perform

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -278,7 +278,21 @@ class CartoContext:
             '''.format(table_name=table_name,
                        lng=lnglat[0],
                        lat=lnglat[1]))
+        self._column_normalization(df, table_name)
 
+    def _column_normalization(self, dataframe, table_name):
+        """Print a warning if there is a difference between the normalized
+        PostgreSQL column names and the ones in the DataFrame"""
+
+        pgcolumns = self.sql_client.send('''
+            SELECT *
+            FROM "{table_name}"
+            LIMIT 0'''.format(table_name=table_name))['fields'].keys()
+        diff_cols = (set(dataframe.columns) ^ set(pgcolumns)) - {'cartodb_id'}
+        cols = ', '.join('`{}`'.format(c) for c in diff_cols)
+        warn('The following columns were renamed because of PostgreSQL '
+             'column normalization requirements: {cols}'.format(cols=cols),
+             stacklevel=2)
 
     def sync(self, dataframe, table_name):
         """Depending on the size of the DataFrame or CARTO table, perform


### PR DESCRIPTION
Pandas is flexible about column names: it allows spaces, case-sensitivity, and special characters. CARTO's flavor of postgres normalizes column names to all lower case and underscores replacing special characters and spaces. This PR gives a warning to the user about the differences that are resulting once a DataFrame is written to a PostgreSQL table.

closes #118 

cc @mehak-sachdeva 