### PR TITLE
adds frequency indicator to pandas datetime type

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -346,7 +346,7 @@ class CartoContext:
         self._debug_print(select_res=select_res)
 
         pg2dtypes = {
-            'date': 'datetime64',
+            'date': 'datetime64[ns]',
             'number': 'float64',
             'string': 'object',
             'boolean': 'bool',


### PR DESCRIPTION
pandas>=0.20.1 warns about not specifying the frequency of the datetime format.

closes #122 