### PR TITLE
Adds basic batching of dataframe uploads

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -196,8 +196,9 @@ class CartoContext(object):
         # send dataframe chunks to carto
         for chunk_num, df_chunk in tqdm(df.groupby([i // MAX_IMPORT_ROWS
                                                     for i in range(df.shape[0])])):
-            temp_table = '{orig}_temp_{chunk}'.format(orig=table_name,
-                                                      chunk=chunk_num)
+            temp_table = '{orig}_cartoframes_temp_{chunk}'.format(
+                orig=table_name[:40],
+                chunk=chunk_num)
             # send dataframe chunk
             temp_table = self._send_dataframe(df_chunk, temp_table,
                                               temp_dir, geom_col, lnglat)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -154,46 +154,9 @@ class CartoContext(object):
             self._table_exists(table_name)
 
         if df.shape[0] > MAX_IMPORT_ROWS:
-            subtables = []
-            # send dataframe chunks to carto
-            for chunk_num, df_chunk in tqdm(df.groupby([i // MAX_IMPORT_ROWS
-                                                        for i in range(df.shape[0])])):
-                temp_table = '{orig}_temp_{chunk}'.format(orig=table_name,
-                                                          chunk=chunk_num)
-                # send dataframe chunk
-                temp_table = self._send_dataframe(df_chunk, temp_table,
-                                                  temp_dir, geom_col, lnglat)
-                subtables.append(temp_table)
-                self._debug_print(chunk_num=chunk_num,
-                                  chunk_shape=str(df_chunk.shape),
-                                  temp_table=temp_table)
-
-            unioned_tables = '\n UNION ALL \n'.join(['SELECT * FROM {}'.format(t)
-                                                     for t in subtables])
-            drop_tables = '\n'.join(['DROP TABLE IF EXISTS {};'.format(t)
-                                     for t in subtables])
-            try:
-                query = '''
-                    DROP TABLE IF EXISTS {table_name};
-                    CREATE TABLE {table_name} As
-                    {unioned_tables};
-                    ALTER TABLE {table_name} DROP COLUMN IF EXISTS cartodb_id;
-                    {drop_tables}
-                    SELECT CDB_CartoDBFYTable('{org}', '{table_name}');
-                    '''.format(table_name=table_name,
-                               unioned_tables=unioned_tables,
-                               org=self.username if self.is_org else 'public',
-                               drop_tables=drop_tables)
-                self._debug_print(query=query)
-                resp = self.sql_client.send(query)
-            except Exception as err:
-                print(err)
-                print(resp)
-                raise Exception("Failed to upload dataframe")
-
-            final_table_name = table_name
+            final_table_name = self._send_batches(df, table_name, temp_dir,
+                                                  geom_col, lnglat)
         else:
-            # send dataframe to carto, report back tablename
             final_table_name = self._send_dataframe(df, table_name, temp_dir,
                                                     geom_col, lnglat)
 
@@ -226,6 +189,52 @@ class CartoContext(object):
             return False
 
         return False
+
+    def _send_batches(self, df, table_name, temp_dir, geom_col, lnglat):
+        """Batch sending a dataframe"""
+        subtables = []
+        # send dataframe chunks to carto
+        for chunk_num, df_chunk in tqdm(df.groupby([i // MAX_IMPORT_ROWS
+                                                    for i in range(df.shape[0])])):
+            temp_table = '{orig}_temp_{chunk}'.format(orig=table_name,
+                                                      chunk=chunk_num)
+            # send dataframe chunk
+            temp_table = self._send_dataframe(df_chunk, temp_table,
+                                              temp_dir, geom_col, lnglat)
+            subtables.append(temp_table)
+            self._debug_print(chunk_num=chunk_num,
+                              chunk_shape=str(df_chunk.shape),
+                              temp_table=temp_table)
+
+        unioned_tables = '\n UNION ALL \n'.join(['SELECT * FROM {}'.format(t)
+                                                 for t in subtables])
+        drop_tables = '\n'.join(['DROP TABLE IF EXISTS {};'.format(t)
+                                 for t in subtables])
+        try:
+            query = '''
+                DROP TABLE IF EXISTS {table_name};
+                CREATE TABLE {table_name} As
+                {unioned_tables};
+                ALTER TABLE {table_name} DROP COLUMN IF EXISTS cartodb_id;
+                {drop_tables}
+                SELECT CDB_CartoDBFYTable('{org}', '{table_name}');
+                '''.format(table_name=table_name,
+                           unioned_tables=unioned_tables,
+                           org=self.username if self.is_org else 'public',
+                           drop_tables=drop_tables)
+            self._debug_print(query=query)
+            _ = self.sql_client.send(query)
+        except CartoException as err:
+            try:
+                drops = '\n'.join('DROP TABLE IF EXISTS {}'.format(t)
+                                  for t in subtables)
+                _ = self.sql_client.send(drops)
+            except CartoException as err:
+                raise CartoException('Failed to drop all subtables: '
+                                     '{}'.format(', '.join(subtables)))
+            raise Exception('Failed to upload dataframe: {}'.format(err))
+
+        return table_name
 
     def _send_dataframe(self, df, table_name, temp_dir, geom_col, lnglat):
         """Send a DataFrame to CARTO to be imported as a SQL table"""
@@ -306,7 +315,7 @@ class CartoContext(object):
                                         table_name=table_name,
                                         err=err,
                                         new_table=import_job['table_name']))
-            return table_name
+        return table_name
 
     def _column_normalization(self, dataframe, table_name, geom_col):
         """Print a warning if there is a difference between the normalized

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -239,9 +239,10 @@ class CartoContext(object):
                                   for t in subtables)
                 _ = self.sql_client.send(drops)
             except CartoException as err:
-                raise CartoException('Failed to drop all subtables: '
-                                     '{}'.format(', '.join(subtables)))
-            raise Exception('Failed to upload dataframe: {}'.format(err))
+                warn('Failed to drop the following subtables from CARTO '
+                     'account: {}'.format(', '.join(subtables)))
+            finally:
+                raise Exception('Failed to upload dataframe: {}'.format(err))
 
         return table_name
 

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -299,11 +299,21 @@ class CartoContext(object):
     def _handle_import(self, import_job, table_name):
         """Handle state of import job"""
         if import_job['state'] == 'failure':
-            raise CartoException('Error code: `{}`. See CARTO Import '
-                                 'API error documentation for more '
-                                 'information: https://carto.com/docs/'
-                                 'carto-engine/import-api/import-errors'
-                                 ''.format(import_job['error_code']))
+            if import_job['error_code'] == 8001:
+                raise CartoException('Over CARTO account storage limit for '
+                                     'user `{}`. Try subsetting your '
+                                     'DataFrame or dropping columns to reduce '
+                                     'the data size.'.format(self.username))
+            elif import_job['error_code'] == 6668:
+                raise CartoException('Too many rows in DataFrame. Try '
+                                     'subsetting DataFrame before writing to '
+                                     'CARTO.')
+            else:
+                raise CartoException('Error code: `{}`. See CARTO Import '
+                                     'API error documentation for more '
+                                     'information: https://carto.com/docs/'
+                                     'carto-engine/import-api/import-errors'
+                                     ''.format(import_job['error_code']))
         elif import_job['state'] == 'complete':
             self._debug_print(final_table=import_job['table_name'])
             if import_job['table_name'] != table_name:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     packages=['cartoframes'],
     install_requires=['pandas>=0.20.1',
                       'webcolors>=1.7.0',
-                      'pyrestcli>=0.6.3',],
+                      'pyrestcli>=0.6.3',
+                      'tqdm>=4.14.0',],
     package_data={
         '': ['LICENSE', 'CONTRIBUTORS',],
     },


### PR DESCRIPTION
Carto's Import API has limits on the number of rows for an imported table (500k for free accounts, more for paid ones). Oftentimes, DataFrames are much larger than this so we can batch the DataFrames into chunks and combine them on the server.

With this PR, users can now send DataFrames of 'any size', given that there is enough space on the Carto account, and other errors are not encountered (max number of columns, etc.). More on [limitations](https://carto.com/docs/faqs/carto-engine-usage-limits) and [errors](https://carto.com/docs/carto-engine/import-api/import-errors). 

## To do

- [x] prototype the functionality
- [x] modularize so `cc.write` is easier to read again (wrap up the batch calls into a private method)
- [x] rollback in case of failures: delete all the uploaded batches so they're not clouding the accounts
- [x] ~hashes~ uniqueish name for chunk table names to avoid table name collision, and ensure tablename length is shorter than 64 characters (max length in postgresql)
- [x] standardize schema. Or is this a larger question about how `_send_dataframe` operates. E.g., should table import with all cols as text, then alter table using the inverse of the `pg2dtype` mapping? Handled in 7f87e0d, from issue #147

## Handle in future pull requests

- #148: see if async can be used without blowing up the complexity. Basic example [here](https://gist.github.com/nhumrich/933445f9de156b02950f3dacdd3ba9bb#file-asyncio_await_example-py), but may require py.version >= 3.5
    - async uploads (three max)
    - async table unions / inserts
- More advanced output on the status. While I don't think it's possible to get the percent uploaded, we can print the status of the import job: _enqueued, pending, uploading, unpacking, importing, guessing, complete, or failure_

Closes #111, closes #147

cc @ljwolf 