### PR TITLE
use explicit None checking to avoid interpreting 0 as False

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -574,8 +574,9 @@ class CartoContext(object):
 
         if len(layers) > 8:
             raise ValueError('map can have at most 8 layers')
-
-        if any([zoom, lat, lng]) != all([zoom, lat, lng]):
+        
+        nullity = [zoom is None, lat is None, lng is None]
+        if any(nullity) and not all(nullity):
             raise ValueError('zoom, lat, and lng must all or none be provided')
 
         # When no layers are passed, set default zoom

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -353,6 +353,13 @@ class TestCartoContext(unittest.TestCase):
         with self.assertRaises(ValueError):
             cc.map(lng=44.3386, lat=68.2733)
 
+        # zoom needs to be specified with lng/lat
+        with self.assertRaises(ValueError):
+            cc.map(lat=68.2733)
+
+        # zero-valued is not None-valued
+        cc.map(lng=0, lat=0, zoom=0)
+
         # only one basemap layer can be added
         with self.assertRaises(ValueError):
             cc.map(layers=[BaseMap('dark'), BaseMap('light')])


### PR DESCRIPTION
This addresses #171 by checking explicitly for None values, rather than just whether or not the value of `zoom,lat,lng` is "truthy". 

TODO:

- [x] Add tests to ensure the `ValueError` is thrown for most configs of zoom/lng/lat