### PR TITLE
[WIP] Noninteractive maps with Matplotlib using Static Maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
     - '3.5'
     - '3.6'
 install:
-    - pip install .
-    - pip install -r requirements.txt
-    - pip install shapely coveralls
+    - pip install . # intsall package
+    - pip install -r requirements.txt # install requires
+    - pip install shapely coveralls matplotlib # only for testing
 script:
     - nosetests --verbose --with-coverage --cover-package=cartoframes
 after_success:

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -506,7 +506,8 @@ class CartoContext(object):
 
 
     def map(self, layers=None, interactive=True,
-            zoom=None, lat=None, lng=None, size=(800, 400)):
+            zoom=None, lat=None, lng=None, size=(800, 400),
+            ax=None):
         """Produce a CARTO map visualizing data layers.
 
         Example:
@@ -724,8 +725,21 @@ class CartoContext(object):
                      width=size[0],
                      height=size[1],
                      img_html=img_html)
+            return IPython.display.HTML(html)
+        else:
+            try:
+                import matplotlib.image as mpi
+                import matplotlib.pyplot as plt
+            except ImportError:
+                warn('Matplotlib not detected. Saving image directly to disk')
+                raise NotImplementedError
+            raw_data = mpi.imread(static_url)
+            if ax is None:
+                ax = plt.gca()
+            ax.imshow(raw_data)
+            ax.axis('off')
+            return ax
 
-        return IPython.display.HTML(html)
 
 
     def data_boundaries(self, df=None, table_name=None):

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -662,7 +662,7 @@ class CartoContext(object):
                           params=urlencode(params))
 
         html = '<img src="{url}" />'.format(url=static_url)
-        return static_url
+        #return static_url
         # TODO: write this as a private method
         if interactive:
             netloc = urlparse(self.base_url).netloc
@@ -739,10 +739,8 @@ class CartoContext(object):
             raw_data = mpi.imread(static_url)
             if ax is None:
                 w,h = size
-                dpi = plt.rcParams['figure.dpi']
+                dpi = 1
                 mpl_size = w/dpi, h/dpi # divide by arbitrary dpi to set figure size
-                # mpl_size = w, h 
-                # dpi = 1
                 fig = plt.figure(figsize=mpl_size, dpi=dpi, frameon=False)
                 fig.subplots_adjust(left=0,right=1, top=1, bottom=0)
                 ax = plt.gca()

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -748,8 +748,7 @@ class CartoContext(object):
             ax.axis('off')
             return ax
         else:
-            warn('Matplotlib not detected. Saving image directly to disk')
-
+            return IPython.display.HTML(html)
 
     def data_boundaries(self, df=None, table_name=None):
         """Not currently implemented"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -218,15 +218,22 @@ class TestCartoContext(unittest.TestCase):
     def test_cartocontext_map(self):
         """CartoContext.map"""
         from cartoframes import Layer, QueryLayer, BaseMap
+        import matplotlib
+        matplotlib.use('agg')
+        import matplotlib.pyplot as plt
         import IPython
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
 
         # test with no layers - should produce basemap
+        basemap_only_static_mpl = cc.map(interactive=False)
+        cartoframes.context.HAS_MATPLOTLIB = False
         basemap_only_static = cc.map(interactive=False)
         basemap_only_interactive = cc.map(interactive=True)
 
-        # are of instance of IPython HTML class
+        # are of the correct type instances
+        self.assertIsInstance(basemap_only_static_mpl,
+                              plt.Axes)
         self.assertIsInstance(basemap_only_static,
                               IPython.core.display.HTML)
         self.assertIsInstance(basemap_only_interactive,


### PR DESCRIPTION
This adds the essential chunk to plot maps on a matplotlib axis in non-interactive mode. 

Still need to handle the case where `matplotlib` isn't available (if this is considered a possibility) by saving the png directly to disk, as suggested in #142

This also addresses #142 in a roundabout way, since the user can just `plt.savefig()` to save the cartomap. 

Also, we may want to figure out how to make the default aspect ratio/figure match a little better, since `imshow` provides a lot of padding around the actual image if the aspect ratio doesn't fit the figure aspect ratio. 

### ToDos

- [ ] remove padding
- [ ] fit aspect ratio / dpi / width & height so there is not degradation of image quality
- [ ] centralized check for matplotlib