### PR TITLE
adds column normalization to schema enforcement

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -245,8 +245,8 @@ class CartoContext(object):
 
         # combine chunks into final table
         try:
-            select_base = ('SELECT %(schema)s '
-                           'FROM "{table}"') % dict(schema=_df2pg_schema(df))
+            select_base = 'SELECT {schema} FROM "{{table}}"'.format(
+                schema=_df2pg_schema(df, pgcolnames))
             unioned_tables = '\nUNION ALL\n'.join([select_base.format(table=t)
                                                    for t in subtables])
             self._debug_print(unioned=unioned_tables)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -23,7 +23,7 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 from carto.exceptions import CartoException
 
-from cartoframes.utils import dict_items
+from cartoframes.utils import dict_items, norm_colname
 from cartoframes.layer import BaseMap
 from cartoframes.maps import non_basemap_layers, get_map_name, get_map_template
 
@@ -341,7 +341,8 @@ class CartoContext(object):
         utility_cols = ('the_geom', 'the_geom_webmercator', 'cartodb_id')
         alter_temp = ('ALTER COLUMN "{col}" TYPE {ctype} USING '
                       'NULLIF("{col}", \'\')::{ctype}')
-        alter_cols = ', '.join(alter_temp.format(col=c, ctype=_dtypes2pg(t))
+        alter_cols = ', '.join(alter_temp.format(col=norm_colname(c),
+                                                 ctype=_dtypes2pg(t))
                                for c, t in zip(dataframe.columns,
                                                dataframe.dtypes)
                                if c not in utility_cols)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -179,7 +179,7 @@ class CartoContext(object):
                        lng=lnglat[0],
                        lat=lnglat[1]))
 
-        tqdm.write('Table written to CARTO: '
+        tqdm.write('Table successfully written to CARTO: '
                    '{base_url}dataset/{table_name}'.format(
                        base_url=self.base_url,
                        table_name=final_table_name))

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -23,7 +23,7 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 from carto.exceptions import CartoException
 
-from cartoframes.utils import dict_items, norm_colname
+from cartoframes.utils import dict_items, normalize_colnames
 from cartoframes.layer import BaseMap
 from cartoframes.maps import non_basemap_layers, get_map_name, get_map_template
 
@@ -118,7 +118,6 @@ class CartoContext(object):
 
         return self.query(query, decode_geom=decode_geom)
 
-
     def write(self, df, table_name, temp_dir='/tmp', overwrite=False,
               lnglat=None, encode_geom=False, geom_col=None):
         """Write a DataFrame to a CARTO table.
@@ -133,13 +132,13 @@ class CartoContext(object):
                 CARTO account
             table_name (str): Table to write ``df`` to in CARTO.
             temp_dir (str, optional): Directory for temporary storage of data
-                that is sent to CARTO. Defaults to ``/tmp`` (Unix-like systems).
+                that is sent to CARTO. Default is ``/tmp`` (Unix-like systems).
             overwrite (bool, optional): Behavior for overwriting ``table_name``
                 if it exits on CARTO. Defaults to ``False``.
-            lnglat (tuple, optional): lng/lat pair that can be used for creating
-                a geometry on CARTO. Defaults to ``None``. In some cases,
-                geometry will be created without specifying this. See CARTO's
-                `Import API <https://carto.com/docs/carto-engine/import-api/standard-tables>`__
+            lnglat (tuple, optional): lng/lat pair that can be used for
+                creating a geometry on CARTO. Defaults to ``None``. In some
+                cases, geometry will be created without specifying this. See
+                CARTO's `Import API <https://carto.com/docs/carto-engine/import-api/standard-tables>`__
                 for more information.
             encode_geom (bool, optional): Whether to write `geom_col` to CARTO
                 as `the_geom`.
@@ -155,14 +154,15 @@ class CartoContext(object):
         if not overwrite:
             # error if table exists and user does not want to overwrite
             self._table_exists(table_name)
-
+        pgcolnames = normalize_colnames(df.columns)
         if df.shape[0] > MAX_IMPORT_ROWS:
+            # NOTE: schema is set using different method than in _set_schema
             final_table_name = self._send_batches(df, table_name, temp_dir,
-                                                  geom_col)
+                                                  geom_col, pgcolnames)
         else:
             final_table_name = self._send_dataframe(df, table_name, temp_dir,
-                                                    geom_col)
-            self._set_schema(df, final_table_name)
+                                                    geom_col, pgcolnames)
+            self._set_schema(df, final_table_name, pgcolnames)
 
         # create geometry column from lat/longs if requested
         if lnglat:
@@ -201,7 +201,7 @@ class CartoContext(object):
 
         return False
 
-    def _send_batches(self, df, table_name, temp_dir, geom_col):
+    def _send_batches(self, df, table_name, temp_dir, geom_col, pgcolnames):
         """Batch sending a dataframe
 
         Args:
@@ -212,6 +212,7 @@ class CartoContext(object):
                 written to file that will be sent to CARTO
             geom_col (str): Name of encoded geometry column (if any) that will
                 be dropped or converted to `the_geom` column
+            pgcolnames (list of str): List of SQL-normalized column names
 
         Returns:
             final_table_name (str): Final table name on CARTO that the
@@ -230,8 +231,8 @@ class CartoContext(object):
                 chunk=chunk_num)
             try:
                 # send dataframe chunk, get new name if collision
-                temp_table = self._send_dataframe(chunk, temp_table,
-                                                  temp_dir, geom_col)
+                temp_table = self._send_dataframe(chunk, temp_table, temp_dir,
+                                                  geom_col, pgcolnames)
             except CartoException as err:
                 self._drop_tables(subtables)
                 raise CartoException(err)
@@ -285,8 +286,12 @@ class CartoContext(object):
         _ = self.sql_client.send(query)
         return None
 
-    def _send_dataframe(self, df, table_name, temp_dir, geom_col):
-        """Send a DataFrame to CARTO to be imported as a SQL table
+    def _send_dataframe(self, df, table_name, temp_dir, geom_col, pgcolnames):
+        """Send a DataFrame to CARTO to be imported as a SQL table.
+
+        Note:
+            Schema from ``df`` is not enforced with this method. Use
+            ``self._set_schema`` to enforce the schema.
 
         Args:
             df (pandas.DataFrame): DataFrame that is will be sent to CARTO
@@ -307,7 +312,9 @@ class CartoContext(object):
         tempfile = '{temp_dir}/{table_name}.csv'.format(temp_dir=temp_dir,
                                                         table_name=table_name)
         self._debug_print(tempfile=tempfile)
-        df.drop(geom_col, axis=1, errors='ignore').to_csv(tempfile)
+        df.drop(geom_col, axis=1, errors='ignore').to_csv(path_or_buf=tempfile,
+                                                          na_rep='',
+                                                          header=pgcolnames)
 
         with open(tempfile, 'rb') as f:
             res = self._auth_send('api/v1/imports', 'POST',
@@ -334,34 +341,38 @@ class CartoContext(object):
 
         return final_table_name
 
-    def _set_schema(self, dataframe, table_name):
+    def _set_schema(self, dataframe, table_name, pgcolnames):
         """Update a table associated with a dataframe to have the equivalent
-        schema"""
-        utility_cols = ('the_geom', 'the_geom_webmercator', 'cartodb_id')
+        schema
+
+        Args:
+            dataframe (pandas.DataFrame): Dataframe that CARTO table is cloned
+                from
+            table_name (str): Table name where schema is being altered
+            pgcolnames (list of str): List of column names from ``dataframe``
+                as they appear on the database
+        Returns:
+            None
+        """
+        util_cols = ('the_geom', 'the_geom_webmercator', 'cartodb_id')
         alter_temp = ('ALTER COLUMN "{col}" TYPE {ctype} USING '
                       'NULLIF("{col}", \'\')::{ctype}')
-        alter_cols = ', '.join(alter_temp.format(col=norm_colname(c),
+        # alter non-util columns that are not text type
+        alter_cols = ', '.join(alter_temp.format(col=c,
                                                  ctype=_dtypes2pg(t))
-                               for c, t in zip(dataframe.columns,
+                               for c, t in zip(pgcolnames,
                                                dataframe.dtypes)
-                               if c not in utility_cols)
+                               if c not in util_cols and t != 'object')
         alter_query = 'ALTER TABLE "{table}" {alter_cols};'.format(
             table=table_name,
             alter_cols=alter_cols)
         self._debug_print(alter_query=alter_query)
         try:
             _ = self.sql_client.send(alter_query)
-            changed_cols = ', '.join([
-                '\033[1m{0} -> {1}\033[0m'.format(c, norm_colname(c))
-                for c in dataframe.columns
-                if c != norm_colname(c)])
-            if changed_cols != '':
-                tqdm.write('The following columns were changed in the CARTO '
-                           'copy of this data: {0}'.format(changed_cols))
         except CartoException as err:
-            warn('DataFrame written to CARTO but table schema failed to '
-                 'update to match DataFrame. All columns have data type '
-                 '`text`. CARTO error: `{err}`. Query: {query}'.format(
+            warn('DataFrame written to CARTO but the table schema failed to '
+                 'update to match DataFrame. All columns in CARTO table have '
+                 'data type `text`. CARTO error: `{err}`.'.format(
                      err=err,
                      query=alter_query))
 
@@ -1018,6 +1029,7 @@ def _decode_geom(ewkb):
         return wkb.loads(ba.unhexlify(ewkb))
     return None
 
+
 def _dtypes2pg(dtype):
     """returns equivalent PostgreSQL type for input `dtype`"""
     mapping = {'float64': 'numeric',
@@ -1029,17 +1041,19 @@ def _dtypes2pg(dtype):
                'datetime64[ns]': 'text'}
     return mapping.get(str(dtype), 'text')
 
-def _df2pg_schema(dataframe):
+
+def _df2pg_schema(dataframe, pgcolnames):
     """Print column names with PostgreSQL schema for the SELECT statement of
     a SQL query"""
-    schema = ', '.join(['NULLIF("{col}", \'\')::{t} AS {col}'.format(col=c,
-                                                                     t=_dtypes2pg(t))
-                        for c, t in zip(dataframe.columns, dataframe.dtypes)
-                        if c not in ('the_geom', 'the_geom_webmercator',
-                                     'cartodb_id')])
-    if 'the_geom' in dataframe.columns:
+    schema = ', '.join([
+        'NULLIF("{col}", \'\')::{t} AS {col}'.format(col=c,
+                                                     t=_dtypes2pg(t))
+        for c, t in zip(pgcolnames, dataframe.dtypes)
+        if c not in ('the_geom', 'the_geom_webmercator', 'cartodb_id')])
+    if 'the_geom' in pgcolnames:
         return '"the_geom", ' + schema
     return schema
+
 
 def _drop_tables_query(tables):
     """Generate drop tables query for all tables in list `tables`"""

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -15,3 +15,33 @@ def cssify(css_dict):
                                                      field_value=field_value)
         css += '} '
     return css
+
+def norm_colname(colname):
+    """Given an arbitrary column name, translate to a SQL-normalized column
+    name a la CARTO's Import API will translate to
+
+    Examples
+        * 'Field: 2' -> 'field_2'
+        * '2 Items' -> '_2_items'
+
+    Args:
+        colname (str): Column name that will be SQL normalized
+    Returns:
+        str: SQL-normalized column name
+    """
+    last_char_special = False
+    char_list = []
+    for e in colname:
+        if e.isalnum():
+            char_list.append(e.lower())
+            last_char_special = False
+        else:
+            if not last_char_special:
+                char_list.append('_')
+                last_char_special = True
+            else:
+                last_char_special = False
+    final_name = ''.join(char_list)
+    if final_name[0].isdigit():
+        return '_' + final_name
+    return final_name

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -37,7 +37,7 @@ def normalize_colnames(columns):
         if c != normalized_columns[i]])
     if changed_cols != '':
         tqdm.write('The following columns were changed in the CARTO '
-                   'copy of this data:\n{0}'.format(changed_cols))
+                   'copy of this dataframe:\n{0}'.format(changed_cols))
 
     return normalized_columns
 

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -1,4 +1,5 @@
 import sys
+from tqdm import tqdm
 
 def dict_items(d):
     if sys.version_info >= (3,0):
@@ -15,6 +16,31 @@ def cssify(css_dict):
                                                      field_value=field_value)
         css += '} '
     return css
+
+
+def normalize_colnames(columns):
+    """SQL-normalize columns in `dataframe` to reflect changes made through
+    CARTO's SQL API.
+
+    Args:
+        columns (list of str): List of column names
+
+    Returns:
+        list of str: Normalized column names
+    """
+    normalized_columns = [norm_colname(c) for c in columns]
+    changed_cols = ',\n'.join([
+        '\033[1m{orig}\033[0m -> \033[1m{new}\033[0m'.format(
+            orig=c,
+            new=normalized_columns[i])
+        for i, c in enumerate(columns)
+        if c != normalized_columns[i]])
+    if changed_cols != '':
+        tqdm.write('The following columns were changed in the CARTO '
+                   'copy of this data:\n{0}'.format(changed_cols))
+
+    return normalized_columns
+
 
 def norm_colname(colname):
     """Given an arbitrary column name, translate to a SQL-normalized column

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -378,17 +378,19 @@ class TestCartoContext(unittest.TestCase):
                                         'idnum': int})
         # specify order of columns
         df = df[['id', 'val', 'truth', 'idnum']]
+        pgcols = ['id', 'val', 'truth', 'idnum']
         ans = ('NULLIF("id", \'\')::text AS id, '
                'NULLIF("val", \'\')::numeric AS val, '
                'NULLIF("truth", \'\')::boolean AS truth, '
                'NULLIF("idnum", \'\')::numeric AS idnum')
 
-        self.assertEqual(ans, _df2pg_schema(df))
+        self.assertEqual(ans, _df2pg_schema(df, pgcols))
 
         # add the_geom
         df['the_geom'] = 'Point(0 0)'
         ans = '\"the_geom\", ' + ans
-        self.assertEqual(ans, _df2pg_schema(df))
+        pgcols.append('the_geom')
+        self.assertEqual(ans, _df2pg_schema(df, pgcols))
 
     def test_drop_tables_query(self):
         """context._drop_tables_query"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -10,11 +10,12 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 import pandas as pd
 
+
 class TestCartoContext(unittest.TestCase):
     """Tests for cartoframes.CartoContext"""
     def setUp(self):
         if (os.environ.get('APIKEY') is None or
-            os.environ.get('USERNAME') is None):
+                os.environ.get('USERNAME') is None):
             try:
                 creds = json.loads(open('test/secret.json').read())
             except OSError:
@@ -27,20 +28,23 @@ class TestCartoContext(unittest.TestCase):
         else:
             self.apikey = os.environ['APIKEY']
             self.username = os.environ['USERNAME']
-        self.baseurl = 'https://{username}.carto.com/'.format(username=self.username)
+        self.baseurl = 'https://{username}.carto.com/'.format(
+            username=self.username)
         self.valid_columns = set(['the_geom', 'the_geom_webmercator', 'lsad10',
-                                  'name10', 'geoid10', 'affgeoid10', 'pumace10',
-                                  'statefp10', 'awater10', 'aland10','updated_at',
-                                  'created_at'])
+                                  'name10', 'geoid10', 'affgeoid10',
+                                  'pumace10', 'statefp10', 'awater10',
+                                  'aland10', 'updated_at', 'created_at'])
         self.auth_client = APIKeyAuthClient(base_url=self.baseurl,
                                             api_key=self.apikey)
         self.sql_client = SQLClient(self.auth_client)
         self.test_read_table = 'cb_2013_puma10_500k'
         self.test_write_table = 'cartoframes_test_table_{ver}'.format(
             ver=sys.version[0:3].replace('.', '_'))
+        self.test_write_batch_table = (
+            'cartoframes_test_batch_table_{ver}'.format(
+                ver=sys.version[0:3].replace('.', '_')))
         self.test_query_table = 'cartoframes_test_query_table_{ver}'.format(
             ver=sys.version[0:3].replace('.', '_'))
-
 
     def tearDown(self):
         """restore to original state"""
@@ -50,7 +54,9 @@ class TestCartoContext(unittest.TestCase):
         self.sql_client.send('''
             DROP TABLE IF EXISTS "{}"
             '''.format(self.test_query_table))
-
+        self.sql_client.send('''
+            DROP TABLE IF EXISTS "{}"
+        '''.format(self.test_write_batch_table))
         # TODO: remove the named map templates
 
     def add_map_template(self):
@@ -148,6 +154,29 @@ class TestCartoContext(unittest.TestCase):
         # number of geoms should equal number of rows
         self.assertEqual(resp['rows'][0]['num_rows'],
                          resp['rows'][0]['num_geoms'])
+
+        # test batch writes
+        n_rows = 550000
+        df = pd.DataFrame({'vals': [random.random() for r in range(n_rows)]})
+
+        cc.write(df, self.test_write_batch_table)
+
+        resp = self.sql_client.send('''
+            SELECT count(*) AS num_rows FROM {table}
+            '''.format(table=self.test_write_batch_table))
+        # number of rows same in dataframe and carto table
+        self.assertEqual(n_rows, resp['rows'][0]['num_rows'])
+
+        cols = self.sql_client.send('''
+            SELECT * FROM {table} LIMIT 1
+        '''.format(table=self.test_write_batch_table))
+        expected_schema = {'vals': {'type': 'number'},
+                           'the_geom': {'type': 'geometry'},
+                           'the_geom_webmercator': {'type': 'geometry'},
+                           'cartodb_id': {'type': 'number'}}
+        # table should be properly created
+        # util columns + new column of type number
+        self.assertDictEqual(cols['fields'], expected_schema)
 
     def test_cartocontext_table_exists(self):
         """CartoContext._table_exists"""

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -119,3 +119,5 @@ class TestUtils(unittest.TestCase):
         for c, a in zip(cols, ans):
             # changed cols should match answers
             self.assertEqual(norm_colname(c), a)
+            # already sql-normed cols should match themselves
+            self.assertEqual(norm_colname(a), a)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for cartoframes.utils"""
 import unittest
-from cartoframes.utils import dict_items, cssify, norm_colname
+from cartoframes.utils import (dict_items, cssify, norm_colname,
+                               normalize_colnames)
 from collections import OrderedDict
 
 
@@ -51,6 +52,11 @@ class TestUtils(unittest.TestCase):
                 ('line-opacity', '0.25'),
                 ('line-comp-op', 'hard-light')]))
         ])
+
+        self.cols = ['Unnamed: 0', '201moore', 'Acadia 1.2.3',
+                     'old_soaker', '_testingTesting', ]
+        self.cols_ans = ['unnamed_0', '_201moore', 'acadia_1_2_3',
+                         'old_soaker', '_testingtesting', ]
 
     def test_dict_items(self):
         """utils.dict_items"""
@@ -112,12 +118,17 @@ class TestUtils(unittest.TestCase):
 
     def test_norm_colname(self):
         """utils.norm_colname"""
-        cols = ['Unnamed: 0', '201moore', 'Acadia 1.2.3', 'old_soaker',
-                '_testingTesting', ]
-        ans = ['unnamed_0', '_201moore', 'acadia_1_2_3', 'old_soaker',
-               '_testingtesting', ]
-        for c, a in zip(cols, ans):
+        for c, a in zip(self.cols, self.cols_ans):
             # changed cols should match answers
             self.assertEqual(norm_colname(c), a)
             # already sql-normed cols should match themselves
             self.assertEqual(norm_colname(a), a)
+
+    def test_normalize_colnames(self):
+        """utils.normalize_colnames"""
+        self.assertListEqual(normalize_colnames(self.cols),
+                             self.cols_ans,
+                             msg='unnormalized should be SQL-normalized')
+        self.assertListEqual(normalize_colnames(self.cols_ans),
+                             self.cols_ans,
+                             msg='already normalize columns should not change')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 """Unit tests for cartoframes.utils"""
 import unittest
-from cartoframes.utils import dict_items, cssify
+from cartoframes.utils import dict_items, cssify, norm_colname
 from collections import OrderedDict
 
 class TestUtils(unittest.TestCase):
@@ -86,3 +86,12 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(complex_stylecss,
                          "#layer['mapnik::geometry_type'=1] {  marker-width: 5; marker-fill: yellow; marker-fill-opacity: 1; marker-allow-overlap: true; marker-line-width: 0.5; marker-line-color: black; marker-line-opacity: 1;} #layer['mapnik::geometry_type'=2] {  line-width: 1.5; line-color: black;} #layer['mapnik::geometry_type'=3] {  polygon-fill: blue; polygon-opacity: 0.9; polygon-gamma: 0.5; line-color: #FFF; line-width: 0.5; line-opacity: 0.25; line-comp-op: hard-light;} ",
                          msg="multi-layer styling")
+
+    def test_norm_colname(self):
+        """utils.norm_colname"""
+        cols = ['Unnamed: 0', '201moore', 'Acadia 1.2.3', 'old_soaker',
+                '_testingTesting',]
+        ans = ['unnamed_0', '_201moore', 'acadia_1_2_3', 'old_soaker',
+                '_testingtesting',]
+        for c, a in zip(cols, ans):
+            self.assertEqual(norm_colname(c), a)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,39 +3,42 @@ import unittest
 from cartoframes.utils import dict_items, cssify, norm_colname
 from collections import OrderedDict
 
+
 class TestUtils(unittest.TestCase):
     """Tests for functions in utils module"""
     def setUp(self):
         self.point_style = {
             "#layer['mapnik::geometry_type'=1]": OrderedDict([
-                                                     ('marker-width', "6"),
-                                                     ('marker-fill', "yellow"),
-                                                     ('marker-fill-opacity', "1"),
-                                                     ('marker-allow-overlap', "true"),
-                                                     ('marker-line-width', "0.5"),
-                                                     ('marker-line-color', "black"),
-                                                     ("marker-line-opacity", "1")])
+                                              ('marker-width', "6"),
+                                              ('marker-fill', "yellow"),
+                                              ('marker-fill-opacity', "1"),
+                                              ('marker-allow-overlap', "true"),
+                                              ('marker-line-width', "0.5"),
+                                              ('marker-line-color', "black"),
+                                              ("marker-line-opacity", "1")])
             }
 
-        self.polygon_style = {"#layer['mapnik::geometry_type'=3]": OrderedDict([
-                                    ('polygon-fill', 'ramp([column], (#ffc6c4, #ee919b, #cc607d, #9e3963, #672044), quantiles)'),
-                                    ('polygon-opacity', '0.9'),
-                                    ('polygon-gamma', '0.5'),
-                                    ('line-color', '#FFF'),
-                                    ('line-width', '0.5'),
-                                    ('line-opacity', '0.25'),
-                                    ('line-comp-op', 'hard-light')])
-                                }
+        self.polygon_style = {
+                "#layer['mapnik::geometry_type'=3]": OrderedDict([
+                    ('polygon-fill', ('ramp([column], (#ffc6c4, #ee919b, '
+                                      '#cc607d, #9e3963, #672044), '
+                                      'quantiles)')),
+                    ('polygon-opacity', '0.9'),
+                    ('polygon-gamma', '0.5'),
+                    ('line-color', '#FFF'),
+                    ('line-width', '0.5'),
+                    ('line-opacity', '0.25'),
+                    ('line-comp-op', 'hard-light')])}
 
         self.complex_style = OrderedDict([
             ("#layer['mapnik::geometry_type'=1]", OrderedDict([
-                                                     ('marker-width', "5"),
-                                                     ('marker-fill', "yellow"),
-                                                     ('marker-fill-opacity', '1'),
-                                                     ('marker-allow-overlap', 'true'),
-                                                     ('marker-line-width', '0.5'),
-                                                     ('marker-line-color', "black"),
-                                                     ('marker-line-opacity', '1')])),
+                                              ('marker-width', "5"),
+                                              ('marker-fill', "yellow"),
+                                              ('marker-fill-opacity', '1'),
+                                              ('marker-allow-overlap', 'true'),
+                                              ('marker-line-width', '0.5'),
+                                              ('marker-line-color', "black"),
+                                              ('marker-line-opacity', '1')])),
             ("#layer['mapnik::geometry_type'=2]", OrderedDict([
                 ('line-width', '1.5'),
                 ('line-color', "black")])),
@@ -72,26 +75,47 @@ class TestUtils(unittest.TestCase):
         # point style
         point_stylecss = cssify(self.point_style)
         self.assertEqual(point_stylecss,
-                         "#layer['mapnik::geometry_type'=1] {  marker-width: 6; marker-fill: yellow; marker-fill-opacity: 1; marker-allow-overlap: true; marker-line-width: 0.5; marker-line-color: black; marker-line-opacity: 1;} ",
+                         ("#layer['mapnik::geometry_type'=1] {  "
+                          "marker-width: 6; marker-fill: yellow; "
+                          "marker-fill-opacity: 1; marker-allow-overlap: "
+                          "true; marker-line-width: 0.5; marker-line-color: "
+                          "black; marker-line-opacity: 1;} "),
                          msg="point style")
 
         # polygon style
         polygon_stylecss = cssify(self.polygon_style)
         self.assertEqual(polygon_stylecss,
-                         "#layer['mapnik::geometry_type'=3] {  polygon-fill: ramp([column], (#ffc6c4, #ee919b, #cc607d, #9e3963, #672044), quantiles); polygon-opacity: 0.9; polygon-gamma: 0.5; line-color: #FFF; line-width: 0.5; line-opacity: 0.25; line-comp-op: hard-light;} ",
+                         ("#layer['mapnik::geometry_type'=3] {  "
+                          "polygon-fill: ramp([column], (#ffc6c4, #ee919b, "
+                          "#cc607d, #9e3963, #672044), quantiles); "
+                          "polygon-opacity: 0.9; polygon-gamma: 0.5; "
+                          "line-color: #FFF; line-width: 0.5; line-opacity: "
+                          "0.25; line-comp-op: hard-light;} "),
                          msg="polygon style")
 
         # complex style
         complex_stylecss = cssify(self.complex_style)
         self.assertEqual(complex_stylecss,
-                         "#layer['mapnik::geometry_type'=1] {  marker-width: 5; marker-fill: yellow; marker-fill-opacity: 1; marker-allow-overlap: true; marker-line-width: 0.5; marker-line-color: black; marker-line-opacity: 1;} #layer['mapnik::geometry_type'=2] {  line-width: 1.5; line-color: black;} #layer['mapnik::geometry_type'=3] {  polygon-fill: blue; polygon-opacity: 0.9; polygon-gamma: 0.5; line-color: #FFF; line-width: 0.5; line-opacity: 0.25; line-comp-op: hard-light;} ",
+                         ("#layer['mapnik::geometry_type'=1] {  "
+                          "marker-width: 5; marker-fill: yellow; "
+                          "marker-fill-opacity: 1; marker-allow-overlap: "
+                          "true; marker-line-width: 0.5; marker-line-color: "
+                          "black; marker-line-opacity: 1;} "
+                          "#layer['mapnik::geometry_type'=2] {  "
+                          "line-width: 1.5; line-color: black;} "
+                          "#layer['mapnik::geometry_type'=3] {  "
+                          "polygon-fill: blue; polygon-opacity: 0.9; "
+                          "polygon-gamma: 0.5; line-color: #FFF; line-width: "
+                          "0.5; line-opacity: 0.25; "
+                          "line-comp-op: hard-light;} "),
                          msg="multi-layer styling")
 
     def test_norm_colname(self):
         """utils.norm_colname"""
         cols = ['Unnamed: 0', '201moore', 'Acadia 1.2.3', 'old_soaker',
-                '_testingTesting',]
+                '_testingTesting', ]
         ans = ['unnamed_0', '_201moore', 'acadia_1_2_3', 'old_soaker',
-                '_testingtesting',]
+               '_testingtesting', ]
         for c, a in zip(cols, ans):
+            # changed cols should match answers
             self.assertEqual(norm_colname(c), a)


### PR DESCRIPTION
`pandas.DataFrame` column names were not being normalized to SQL column names, so it causes the `_set_schema` method to fail, resulting in a table with all columns set to string/text type. This PR attempts to re-create the column renaming that happens when a CSV is imported to CARTO with the Import API.

- [x] add tests
- [x] better warning about column name changes that shows explicit mapping
- [x] check to see if there is a better technique than this ad hoc function (or if there's a function from CARTO's stack that I can use instead)

TODO:
- [x] change column names before uploading to avoid unexpected column-renaming via the Import API

cc @iamwfx 