### PR TITLE
add string conversion to norm_colname

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -494,34 +494,24 @@ class CartoContext(object):
 
         self._debug_print(select_res=select_res)
 
-        # TODO: replace this with a function
-        pg2dtypes = {
-            'date': 'object',
-            'number': 'float64',
-            'string': 'object',
-            'boolean': 'bool',
-            'geometry': 'object',
-        }
-
         fields = select_res['fields']
-        schema = {
-            field: pg2dtypes.get(fields[field]['type'], 'object')
-                   if field != 'cartodb_id' else 'int64'
-            for field in fields
-        }
-        if not schema.keys():
-            return None
-        self._debug_print(fields=fields, schema=schema)
+        if not len(fields):
+            return pd.DataFrame()
 
-        df = pd.DataFrame(
-            data=select_res['rows'],
-            columns=[k for k in fields]).astype(schema)
+        df = pd.DataFrame(data=select_res['rows'])
+        for field in fields:
+            if fields[field]['type'] == 'date':
+                df[field] = pd.to_datetime(df[field], errors='ignore')
+
+        self._debug_print(columns=df.columns,
+                          dtypes=df.dtypes)
 
         if 'cartodb_id' in fields:
             df.set_index('cartodb_id', inplace=True)
 
         if decode_geom:
             df['geometry'] = df.the_geom.apply(_decode_geom)
+
         return df
 
 
@@ -605,8 +595,9 @@ class CartoContext(object):
 
         if len(layers) > 8:
             raise ValueError('map can have at most 8 layers')
-
-        if any([zoom, lat, lng]) != all([zoom, lat, lng]):
+        
+        nullity = [zoom is None, lat is None, lng is None]
+        if any(nullity) and not all(nullity):
             raise ValueError('zoom, lat, and lng must all or none be provided')
 
         # When no layers are passed, set default zoom
@@ -1075,15 +1066,29 @@ def _decode_geom(ewkb):
 
 
 def _dtypes2pg(dtype):
-    """returns equivalent PostgreSQL type for input `dtype`"""
-    mapping = {'float64': 'numeric',
-               'int64': 'numeric',
-               'float32': 'numeric',
-               'int32': 'numeric',
-               'object': 'text',
-               'bool': 'boolean',
-               'datetime64[ns]': 'text'}
+    """Returns equivalent PostgreSQL type for input `dtype`"""
+    mapping = {
+        'float64': 'numeric',
+        'int64': 'numeric',
+        'float32': 'numeric',
+        'int32': 'numeric',
+        'object': 'text',
+        'bool': 'boolean',
+        'datetime64[ns]': 'date',
+    }
     return mapping.get(str(dtype), 'text')
+
+
+def _pg2dtypes(pgtype):
+    """Returns equivalent dtype for input `pgtype`."""
+    mapping = {
+        'date': 'datetime64[ns]',
+        'number': 'float64',
+        'string': 'object',
+        'boolean': 'bool',
+        'geometry': 'object',
+    }
+    return mapping.get(str(pgtype), 'object')
 
 
 def _df2pg_schema(dataframe, pgcolnames):

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -186,7 +186,6 @@ class TestCartoContext(unittest.TestCase):
         with self.assertRaises(NameError):
             cc._table_exists(self.test_read_table)
 
-
     def test_cartocontext_send_dataframe(self):
         """CartoContext._send_dataframe"""
         pass
@@ -201,38 +200,64 @@ class TestCartoContext(unittest.TestCase):
         """cartoframes.CartoContext.query"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
+
+        cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )
         df = cc.query('''
-            SELECT link, body, displayname, friendscount
+            SELECT {cols}, '02-06-1429'::date as invalid_df_date
             FROM tweets_obama
             LIMIT 100
-            ''')
+            '''.format(cols=','.join(cols)))
+
+        # ensure columns are in expected order
+        df = df[list(cols) + ['invalid_df_date']]
+
         # same number of rows
         self.assertEqual(len(df), 100,
                          msg='Expected number or rows')
+
         # same type of object
         self.assertIsInstance(df, pd.DataFrame,
-                              'Should be a pandas DataFrame')
+                              msg='Should be a pandas DataFrame')
+
         # same column names
-        self.assertSetEqual({'link', 'body', 'displayname', 'friendscount'},
+        requested_cols = {'link', 'body', 'displayname', 'friendscount',
+                          'postedtime', 'invalid_df_date', }
+        self.assertSetEqual(requested_cols,
                             set(df.columns),
                             msg='Should have the columns requested')
+        # should have expected schema
+        expected_dtypes = ('object', 'object', 'object', 'int64',
+                           'datetime64[ns]', 'object', )
+        self.assertTupleEqual(expected_dtypes,
+                              tuple(str(d) for d in df.dtypes),
+                              msg='Should have expected schema')
+
+        # empty response
+        df_empty = cc.query('''
+            SELECT 1
+            LIMIT 0
+            ''')
+
+        # no rows or columns
+        self.assertTupleEqual(df_empty.shape, (0, 0))
+
+        # is a DataFrame
+        self.assertIsInstance(df_empty, pd.DataFrame)
 
         # table already exists, should throw CartoException
         with self.assertRaises(CartoException):
-            df_create_table = cc.query('''
+            _ = cc.query('''
                 SELECT link, body, displayname, friendscount
                 FROM tweets_obama
                 LIMIT 100
-                ''',
-                table_name='tweets_obama')
+                ''', table_name='tweets_obama')
 
         # create a table from a query
         _ = cc.query('''
             SELECT link, body, displayname, friendscount
             FROM tweets_obama
             LIMIT 100
-            ''',
-            table_name=self.test_query_table)
+            ''', table_name=self.test_query_table)
 
         # read newly created table into a dataframe
         df = cc.read(self.test_query_table)
@@ -327,6 +352,13 @@ class TestCartoContext(unittest.TestCase):
         # zoom needs to be specified with lng/lat
         with self.assertRaises(ValueError):
             cc.map(lng=44.3386, lat=68.2733)
+
+        # zoom needs to be specified with lng/lat
+        with self.assertRaises(ValueError):
+            cc.map(lat=68.2733)
+
+        # zero-valued is not None-valued
+        cc.map(lng=0, lat=0, zoom=0)
 
         # only one basemap layer can be added
         with self.assertRaises(ValueError):


### PR DESCRIPTION
If the dataframe column names are integers, normalizing the column name will fail because integers are not iterable.