### PR TITLE
Refactors credentials to be class-based

### DIFF
--- a/cartoframes/__init__.py
+++ b/cartoframes/__init__.py
@@ -1,3 +1,4 @@
 from .context import CartoContext
+from .credentials import Credentials
 from .layer import BaseMap, QueryLayer, Layer
 from .styling import BinMethod

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -23,6 +23,7 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 from carto.exceptions import CartoException
 
+from .credentials import Credentials
 from .utils import dict_items, normalize_colnames
 from .layer import BaseMap
 from .maps import non_basemap_layers, get_map_name, get_map_template
@@ -77,13 +78,12 @@ class CartoContext(object):
     """
     def __init__(self, base_url=None, api_key=None, session=None, verbose=0):
 
-        self.api_key, self.base_url = _process_credentials(api_key,
-                                                           base_url)
-        self.auth_client = APIKeyAuthClient(base_url=self.base_url,
-                                            api_key=self.api_key,
+        self.creds = Credentials(key=api_key, base_url=base_url)
+        self.auth_client = APIKeyAuthClient(base_url=self.creds.base_url(),
+                                            api_key=self.creds.key(),
                                             session=session)
         self.sql_client = SQLClient(self.auth_client)
-        self.username = self.auth_client.username
+        self.creds.username(self.auth_client.username)
         self.is_org = self._is_org_user()
 
         self._map_templates = {}
@@ -192,7 +192,7 @@ class CartoContext(object):
 
         tqdm.write('Table successfully written to CARTO: '
                    '{base_url}dataset/{table_name}'.format(
-                       base_url=self.base_url,
+                       base_url=self.creds.base_url(),
                        table_name=final_table_name))
 
     def delete(self, table_name):
@@ -295,7 +295,8 @@ class CartoContext(object):
                 SELECT CDB_CartoDBFYTable('{org}', '{table_name}');
                 '''.format(table_name=table_name,
                            unioned_tables=unioned_tables,
-                           org=self.username if self.is_org else 'public',
+                           org=(self.creds.username()
+                                if self.is_org else 'public'),
                            drop_tables=drop_tables)
             self._debug_print(query=query)
             _ = self.sql_client.send(query)
@@ -410,7 +411,8 @@ class CartoContext(object):
                 raise CartoException('Over CARTO account storage limit for '
                                      'user `{}`. Try subsetting your '
                                      'DataFrame or dropping columns to reduce '
-                                     'the data size.'.format(self.username))
+                                     'the data size.'.format(
+                                         self.creds.username()))
             elif import_job['error_code'] == 6668:
                 raise CartoException('Too many rows in DataFrame. Try '
                                      'subsetting DataFrame before writing to '
@@ -480,7 +482,8 @@ class CartoContext(object):
                 SELECT CDB_CartodbfyTable('{org}', '{table_name}');
             '''.format(table_name=table_name,
                        query=query,
-                       org=(self.username if self.is_org else 'public'))
+                       org=(self.creds.username()
+                            if self.is_org else 'public'))
             self._debug_print(create_table_query=create_table_query)
 
             create_table_res = self.sql_client.send(create_table_query)
@@ -663,7 +666,7 @@ class CartoContext(object):
             options.update(self._get_bounds(nb_layers))
 
         map_name = self._send_map_template(layers, has_zoom=has_zoom)
-        api_url = '{base_url}api/v1/map'.format(base_url=self.base_url)
+        api_url = '{base_url}api/v1/map'.format(base_url=self.creds.base_url())
 
         static_url = ('{api_url}/static/named/{map_name}'
                       '/{width}/{height}.png?{params}').format(
@@ -677,7 +680,7 @@ class CartoContext(object):
 
         # TODO: write this as a private method
         if interactive:
-            netloc = urlparse(self.base_url).netloc
+            netloc = urlparse(self.creds.base_url()).netloc
             domain = 'carto.com' if netloc.endswith('.carto.com') else netloc
 
             def safe_quotes(text, escape_single_quotes=False):
@@ -690,9 +693,9 @@ class CartoContext(object):
                 return text
 
             config = {
-                'user_name': self.username,
-                'maps_api_template': self.base_url[:-1],
-                'sql_api_template': self.base_url[:-1],
+                'user_name': self.creds.username(),
+                'maps_api_template': self.creds.base_url()[:-1],
+                'sql_api_template': self.creds.base_url()[:-1],
                 'tiler_protocol': 'https',
                 'tiler_domain': domain,
                 'tiler_port': '80',
@@ -716,7 +719,7 @@ class CartoContext(object):
                     'order': 1,
                     'options': {
                         'query': time_layer.query,
-                        'user_name': self.username,
+                        'user_name': self.creds.username(),
                         'tile_style': time_layer.torque_cartocss,
                     }
                 })
@@ -748,7 +751,7 @@ class CartoContext(object):
                      img_html=img_html)
             return IPython.display.HTML(html)
         elif HAS_MATPLOTLIB:
-            raw_data = mpi.imread(static_url)
+            raw_data = mpi.imread(static_url, format='png')
             if ax is None:
                 dpi = mpi.rcParams['figure.dpi']
                 mpl_size = (size[0] / dpi, size[1] / dpi)
@@ -858,7 +861,7 @@ class CartoContext(object):
         augment_query = '''
             select obs_augment_table('{username}.{tablename}',
                                      '{cols_meta}');
-        '''.format(username=self.username,
+        '''.format(username=self.creds.username(),
                    tablename=table_name,
                    cols_meta=json.dumps(metadata))
         _ = self.sql_client.send(augment_query)
@@ -974,37 +977,6 @@ class CartoContext(object):
                                                      str_value[-50:])
             print('{key}: {value}'.format(key=key,
                                           value=str_value))
-
-
-def _process_credentials(api_key, base_url):
-    """process credentials"""
-    # use stored api key (if present)
-    if (api_key is None) or (base_url is None):
-        from cartoframes import credentials as cfcreds
-        creds = cfcreds.credentials()
-        api_key = creds['api_key'] if api_key is None else api_key
-        base_url = creds['base_url'] if base_url is None else base_url
-        if (api_key == '') and (base_url == ''):
-            raise ValueError('No credentials are stored on this '
-                             'installation and none were provided. Use '
-                             '`cartoframes.credentials.set_credentials` '
-                             'to store your access URL and API key for '
-                             'this installation.')
-        if api_key == '':
-            raise ValueError('API key was not provided and no key is '
-                             'stored. Use '
-                             '`cartoframes.credentials.set_key` to set a '
-                             'default API key for this installation.')
-        if base_url == '':
-            raise ValueError('Base URL was not provided and no URL is '
-                             'stored. Use '
-                             '`cartoframes.credentials.set_url` to set a '
-                             'default base URL for this installation.')
-
-    # Make sure there is a trailing / for urljoin
-    if not base_url.endswith('/'):
-        base_url += '/'
-    return api_key, base_url
 
 
 def _add_encoded_geom(df, geom_col):

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -76,9 +76,10 @@ class CartoContext(object):
         :obj:`CartoContext`: A CartoContext object that is authenticated
         against the user's CARTO account.
     """
-    def __init__(self, base_url=None, api_key=None, session=None, verbose=0):
+    def __init__(self, base_url=None, api_key=None, creds=None, session=None,
+                 verbose=0):
 
-        self.creds = Credentials(key=api_key, base_url=base_url)
+        self.creds = Credentials(creds=creds, key=api_key, base_url=base_url)
         self.auth_client = APIKeyAuthClient(base_url=self.creds.base_url(),
                                             api_key=self.creds.key(),
                                             session=session)

--- a/cartoframes/credentials.py
+++ b/cartoframes/credentials.py
@@ -9,11 +9,18 @@ _DEFAULT_PATH = os.path.join(_USER_CONFIG_DIR,
                              'cartocreds.json')
 
 class Credentials(object):
-    """Credentials class for managing and storing user CARTO credentials.
+    """Credentials class for managing and storing user CARTO credentials. The
+    arguments are listed in order of precedence: :obj:`Credentials` instances
+    are first, `key` and `base_url`/`username` are taken next, and `config_file`
+    (if given) is taken last. If no arguments are passed, then there will be an
+    attempt to retrieve credentials from a previously saved session. One of the
+    above scenarios needs to be met to successfully instantiate a
+    :obj:`Credentials` object.
 
     Args:
-        key (str): API key of user's CARTO account
-        username (str): Username of CARTO account
+        creds (:obj:`cartoframes.Credentials`, optional): Credentials instance
+        key (str, optional): API key of user's CARTO account
+        username (str, optional): Username of CARTO account
         base_url (str, optional): Base URL used for API calls. This is usually
             of the form `https://eschbacher.carto.com/` for user `eschbacher`.
             On premises installations (and others) have a different URL
@@ -36,8 +43,13 @@ class Credentials(object):
             cc = CartoContext(creds=creds)
 
     """
-    def __init__(self, key=None, username=None, base_url=None, cred_file=None):
-        if (key and username) or (key and base_url):
+    def __init__(self, creds=None, key=None, username=None, base_url=None,
+                 cred_file=None):
+        if creds and isinstance(creds, Credentials):
+            self._key = creds.key()
+            self._username = creds.username()
+            self._base_url = creds.base_url()
+        elif (key and username) or (key and base_url):
             self._key = key
             self._username = username
             if base_url:

--- a/cartoframes/credentials.py
+++ b/cartoframes/credentials.py
@@ -1,8 +1,7 @@
-"""API key utility functions
-"""
+"""API key utility functions"""
 import os
 import json
-import warnings
+# import warnings
 import appdirs
 
 _USER_CONFIG_DIR = appdirs.user_config_dir('cartoframes')
@@ -19,7 +18,7 @@ def create_config_dir():
 class Credentials(object):
     """Credentials class for managing and storing user CARTO credentials"""
     def __init__(self, key=None, username=None, base_url=None, cred_file=None):
-        if key and username:
+        if (key and username) or (key and base_url):
             self._key = key
             self._username = username
             if base_url:
@@ -27,15 +26,17 @@ class Credentials(object):
             else:
                 self._base_url = 'https://{}.carto.com/'.format(self._username)
         elif cred_file:
-            self.retrieve(cred_file)
+            self._retrieve(cred_file)
         else:
             try:
                 creds = json.loads(open(_DEFAULT_PATH).read())
                 self._key = creds['key']
                 self._base_url = creds['base_url']
+                self._username = creds.get('username')
             except:
                 raise RuntimeError('Could not load CARTO credentials. Try '
-                                   'setting them instead.')
+                                   'setting them with the `key` and '
+                                   '`username` arguments.')
 
     def __repr__(self):
         return ('Credentials(username={username}, '
@@ -48,14 +49,16 @@ class Credentials(object):
         """Saves user credentials to user directory"""
         create_config_dir()
         with open(_DEFAULT_PATH, 'w') as f:
-            json.dump({'key': self._key, 'base_url': self._base_url}, f)
+            json.dump({'key': self._key, 'base_url': self._base_url,
+                       'username': self._username}, f)
 
-    def retrieve(self, config_file=None):
+    def _retrieve(self, config_file=None):
         """retrives credentials"""
         with open(config_file or _DEFAULT_PATH, 'r') as f:
             creds = json.load(f)
         self._key = creds.get('key')
         self._base_url = creds.get('base_url')
+        self._username = creds.get('username')
 
     def delete(self, config_file=None):
         """Deletes the credentials file
@@ -64,15 +67,29 @@ class Credentials(object):
             config_file (str): Path to configuration file. Defaults to delete
                 the user default location if `None`.
         """
-        os.remove(config_file or _DEFAULT_PATH)
+        path_to_remove = config_file or _DEFAULT_PATH
+        try:
+            os.remove(path_to_remove)
+            print('Credentials at {} successfully removed.'.format(
+                path_to_remove))
+        except OSError as err:
+            print('No credential file to be removed at {}.'.format(
+                path_to_remove))
 
     def set(self, key=None, username=None, base_url=None):
-        """
+        """Update the credentials of a Credentials instead with new values.
 
         Args:
-            creds (dict): Dictionary with keys `username` and/or `key` to set
-                new user credentials
-            update (bool): Update credentials
+            key (str): API key of user account. Defaults to previous value if
+                not specified.
+            username (str): User name of account. This parameter is optional if
+                ``base_url`` is not specified, but defaults to the previous
+                value if not set.
+            base_url (str): Base URL of user account. This parameter is
+                optional if ``username`` is specified and on CARTO's
+                cloud-based account. Generally of the form
+                ``https://your_user_name.carto.com/`` for cloud-based accounts.
+                If on-prem or otherwise, contact your admin.
         """
         self.__init__(key=(key or self._key),
                       username=(username or self._username),
@@ -90,8 +107,12 @@ class Credentials(object):
         """Return username if no argument is passed. Updates username to
         `username` if it is passed.
 
+        Args:
+            username (str): Optionally update the username credential.
+
         Note:
-            This does not update the `base_url` attribute.
+            This does not update the `base_url` attribute. Use
+            `Credentials.set` to have that updated with `username`.
         """
         if username:
             self._username = username
@@ -99,7 +120,7 @@ class Credentials(object):
             return self._username
 
     def base_url(self, base_url=None):
-        """return base_url"""
+        """Return base_url"""
         if base_url:
             self._base_url = base_url
         else:

--- a/cartoframes/credentials.py
+++ b/cartoframes/credentials.py
@@ -3,206 +3,104 @@
 import os
 import json
 import warnings
+import appdirs
+
+_USER_CONFIG_DIR = appdirs.user_config_dir('cartoframes')
+_DEFAULT_PATH = os.path.join(_USER_CONFIG_DIR,
+                             'cartocreds.json')
 
 
-_FILEPATH = os.path.dirname(os.path.abspath(__file__))
-_TARGETPATH = os.path.join(_FILEPATH, 'CARTOCREDS.json')
+def create_config_dir():
+    """create directory if not exists"""
+    if not os.path.exists(_USER_CONFIG_DIR):
+        os.makedirs(_USER_CONFIG_DIR)
 
 
-def set_credentials(base_url='', api_key='', overwrite=False):
-    """Save the CARTO API base URL and API key so that users can access it via
-    cartoframes.credentials.credentials(). This lets users bind their CARTO
-    access credentials to a given installation.
+class Credentials(object):
+    """Credentials class for managing and storing user CARTO credentials"""
+    def __init__(self, key=None, username=None, base_url=None, cred_file=None):
+        if key and username:
+            self._key = key
+            self._username = username
+            if base_url:
+                self._base_url = base_url
+            else:
+                self._base_url = 'https://{}.carto.com/'.format(self._username)
+        elif cred_file:
+            self.retrieve(cred_file)
+        else:
+            try:
+                creds = json.loads(open(_DEFAULT_PATH).read())
+                self._key = creds['key']
+                self._base_url = creds['base_url']
+            except:
+                raise RuntimeError('Could not load CARTO credentials. Try '
+                                   'setting them instead.')
 
-    Args:
-        base_url (str): CARTO API base URL. Defaults to an empty string. Format
-            is `https://{username}.carto.com/` for cloud users.
-        api_key (str): CARTO api key. Defaults to an empty string.
-        overwrite (bool): Whether to overwrite the existing credentials.
-            Defaults to False.
+    def __repr__(self):
+        return ('Credentials(username={username}, '
+                'key={key}, '
+                'base_url={base_url})').format(username=self._username,
+                                               key=self._key,
+                                               base_url=self._base_url)
 
-    Returns:
-        str: Path to the location of the API key file.
+    def save(self):
+        """Saves user credentials to user directory"""
+        create_config_dir()
+        with open(_DEFAULT_PATH, 'w') as f:
+            json.dump({'key': self._key, 'base_url': self._base_url}, f)
 
-    Raises:
-        EnvironmentError: if overwriting is prohibited and the file exists
-    """
-    _ = _check_overwrite('base_url', overwrite)
-    stored = _check_overwrite('api_key', overwrite)
-    stored['base_url'] = base_url
-    stored['api_key'] = api_key
-    with open(_TARGETPATH, 'w') as outfile:
-        json.dump(stored, outfile)
-    return _TARGETPATH
-
-
-def set_base_url(base_url, overwrite=False):
-    """Save the CARTO API base_url so that users can access it via
-    cartoframes.credentials.access_base_url(). This lets users bind their API
-    base_url to a given installation.
-
-    Args:
-        base_url (str): CARTO access URL
-        overwrite (bool): Whether to overwrite the existing key. Defaults to
-        False.
-
-    Returns:
-        str: Path to location of the credentials file. Raises FileError if
-        overwriting is prohibited and the file exists.
-    """
-    stored = _check_overwrite('base_url', overwrite)
-    stored['base_url'] = base_url
-    with open(_TARGETPATH, 'w') as outfile:
-        json.dump(stored, outfile)
-    return _TARGETPATH
-
-
-def set_api_key(key, overwrite=False):
-    """Save the CARTO API key so that users can access it via
-    `cartoframes.credentials.api_key()`. This lets users bind an API key to a
-    given installation.
-
-    Args:
-        key (str): CARTO API key
-        overwrite (bool): Whether to overwrite existing key. Defaults to False.
-
-    Returns:
-        str: Path to the location of the API key file. Raises FileError if
-        overwriting is prohibited and the file exists.
-    """
-    stored = _check_overwrite('api_key', overwrite)
-    stored['api_key'] = key
-    with open(_TARGETPATH, 'w') as outfile:
-        json.dump(stored, outfile)
-    return _TARGETPATH
-
-
-def api_key():
-    """Returns stored API key that was set with `cartoframes.credentials.set_key`
-
-    Returns:
-        str: CARTO API key
-    """
-    return _load_api_key()
-
-
-def base_url():
-    """Returns stored base_url that was set with
-    `cartoframes.credentials.set_base_url`
-
-    Returns:
-        str: CARTO API base URL
-    """
-    return _load_base_url()
-
-
-def credentials():
-    """Returns stored credentials that was set with
-    `cartoframes.credentials.set_credentials`
-
-    Returns:
-        dict: Dictionary containing CARTO API base_url and API key.
-    """
-
-    return _load_creds()
-
-
-def _load_creds():
-    """Load both URL and api_key from the credentials file
-
-    Returns:
-        dict: Dictionary containing keys `base_url` and `api_key`, values are
-        strings. If the credential is not set, the value may be an empty
-        string.
-    """
-    try:
-        with open(_TARGETPATH, 'r') as f:
+    def retrieve(self, config_file=None):
+        """retrives credentials"""
+        with open(config_file or _DEFAULT_PATH, 'r') as f:
             creds = json.load(f)
-    except EnvironmentError:
-        raise EnvironmentError('No credentials are stored with this '
-                               'installation.  Set credentials using '
-                               '`cartoframes.credentials.set_credentials`.')
+        self._key = creds.get('key')
+        self._base_url = creds.get('base_url')
 
-    return dict(base_url=creds['base_url'].strip(),
-                api_key=creds['api_key'].strip())
+    def delete(self, config_file=None):
+        """Deletes the credentials file
 
+        Args:
+            config_file (str): Path to configuration file. Defaults to delete
+                the user default location if `None`.
+        """
+        os.remove(config_file or _DEFAULT_PATH)
 
-def _load_api_key():
-    """Load API key from the credentials file
+    def set(self, key=None, username=None, base_url=None):
+        """
 
-    Returns:
-        str: The api key for the site. If the credential is not set, the string
-            may be an empty string.
-    """
-    return _load_creds()['api_key']
+        Args:
+            creds (dict): Dictionary with keys `username` and/or `key` to set
+                new user credentials
+            update (bool): Update credentials
+        """
+        self.__init__(key=(key or self._key),
+                      username=(username or self._username),
+                      base_url=base_url)
 
+    def key(self, key=None):
+        """Return API key if no arguemnt is passed. Updates key to `key`
+        if it is passed."""
+        if key:
+            self._key = key
+        else:
+            return self._key
 
-def _load_base_url():
-    """Load base_url from the credentials file
+    def username(self, username=None):
+        """Return username if no argument is passed. Updates username to
+        `username` if it is passed.
 
-    Returns:
-        str: The base_url for CARTO API access. If the credential is not set,
-            the string may be an empty string.
-    """
-    return _load_creds()['base_url']
+        Note:
+            This does not update the `base_url` attribute.
+        """
+        if username:
+            self._username = username
+        else:
+            return self._username
 
-
-def _remove_creds():
-    """Remove the credential file."""
-    try:
-        os.remove(_TARGETPATH)
-    except EnvironmentError:
-        warnings.warn('No credential file found')
-
-
-def _clear_attribute(name):
-    """Unsets an arbitrary attribute from the credential file.
-
-    Args:
-        name (str): name of the credential to remove from the credential file.
-            Can be one of `api_key` or `base_url`.
-    """
-    with open(_TARGETPATH, 'r') as f:
-        creds = json.load(f)
-    if name not in creds:
-        raise KeyError('`{}` not found in stored credentials.'.format(name))
-    creds[name] = ''
-    with open(_TARGETPATH, 'w') as f:
-        json.dump(creds, f)
-
-
-def _clear_base_url():
-    """Unsets the base_url attribute of the credential file."""
-    return _clear_attribute('base_url')
-
-
-def _clear_api_key():
-    """Unsets the api_key attribute of the credential file"""
-    return _clear_attribute('api_key')
-
-
-def _check_overwrite(attribute, overwrite, path=_TARGETPATH):
-    """Checks if an attribute is present in the credential file. If it is
-    present and the overwrite flag is not set, raises an EnvironmentError.
-    Otherwise, returns the stored credentials.
-
-    Args:
-        attribute (str): The name of the attribute in the credential file to
-            verify
-        overwrite (bool): A flag denoting whether overwriting a set attribute
-            is allowed. If False and the attribute is not empty, a TypeError is
-            raised.
-        path (str): The path to the credential file.
-
-    Returns:
-        dict: the dictionary of stored credentials
-    """
-    if os.path.isfile(path):
-        with open(path, 'r') as infile:
-            stored = json.load(infile)
-        if stored[attribute] != '' and not overwrite:
-            raise TypeError('CARTO `{}` already set and overwrite flag is '
-                            'not set'.format(attribute))
-        return stored
-    else:
-        return dict(api_key='', base_url='')
+    def base_url(self, base_url=None):
+        """return base_url"""
+        if base_url:
+            self._base_url = base_url
+        else:
+            return self._base_url

--- a/examples/Basic Usage.ipynb
+++ b/examples/Basic Usage.ipynb
@@ -10,21 +10,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import cartoframes\n",
-    "from cartoframes.credentials import set_credentials\n",
+    "from cartoframes import Credentials\n",
     "import pandas as pd\n",
     "\n",
-    "# BASEURL are in the format:\n",
-    "#  https://USERNAME.carto.com  -- for all cloud users, even if in a multiuser organization\n",
-    "#  for on premise installs, contact your admin\n",
-    "BASEURL = 'https://eschbacher.carto.com' # <-- replace with your username \n",
+    "USERNAME = 'eschbacher' # <-- replace with your username \n",
     "APIKEY = 'abcdefghijklmnopqrstuvwxyz' # <-- your CARTO API key\n",
-    "set_credentials(base_url=BASEURL, api_key=APIKEY, overwrite=True)\n",
-    "\n",
-    "cc = cartoframes.CartoContext()"
+    "creds = Credentials(username=USERNAME, \n",
+    "                    key=APIKEY)\n",
+    "cc = cartoframes.CartoContext(creds=creds)"
    ]
   },
   {
@@ -648,7 +648,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df = df[(df['pickup_longitude'] != 0) | (df['pickup_latitude'] != 0)]\n",
@@ -702,7 +704,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/examples/Shapely, Geopandas, and Cartoframes.ipynb
+++ b/examples/Shapely, Geopandas, and Cartoframes.ipynb
@@ -12,7 +12,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import cartoframes as cf\n",
@@ -23,11 +25,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "cxn = cf.CartoContext() # remember, store your credentials \n",
-    "                        # using cf.credentials.set_credentials!"
+    "                        # using cartoframes.Credentials(...).save()!"
    ]
   },
   {
@@ -40,7 +44,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df = cxn.read('nat')"
@@ -563,7 +569,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "cxn.write(gdf,\n",
@@ -582,7 +590,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "gdf['geometry'] = gdf.geometry.apply(lambda x: x.buffer(2))\n",
@@ -593,6 +603,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -905,7 +916,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,16 @@ setup(
         'Programming Language :: Python :: 3.6'
     ],
     keywords='carto data science maps spatial pandas',
-    packages=['cartoframes'],
-    install_requires=['pandas>=0.20.1',
-                      'webcolors>=1.7.0',
-                      'carto>=1.0.1',
-                      'tqdm>=4.14.0',],
+    packages=[
+        'cartoframes',
+        ],
+    install_requires=[
+        'pandas>=0.20.1',
+        'webcolors>=1.7.0',
+        'carto>=1.0.1',
+        'tqdm>=4.14.0',
+        'appsdir>=1.4.3',
+        ],
     extras_require={
         ':python_version == "2.7"': [
             'IPython>=5.0.0,<6.0.0',
@@ -57,8 +62,12 @@ setup(
             ]},
     package_dir={'cartoframes': 'cartoframes'},
     package_data={
-        '': ['LICENSE',
-             'CONTRIBUTORS',],
-        'cartoframes': ['assets/*',],
+        '': [
+            'LICENSE',
+            'CONTRIBUTORS',
+            ],
+        'cartoframes': [
+            'assets/*',
+            ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'webcolors>=1.7.0',
         'carto>=1.0.1',
         'tqdm>=4.14.0',
-        'appsdir>=1.4.3',
+        'appdirs>=1.4.3',
         ],
     extras_require={
         ':python_version == "2.7"': [

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -106,6 +106,24 @@ class TestCartoContext(unittest.TestCase):
         # self.assertTrue(cc.sql_client.__dict__ == self.sql_client.__dict__)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
+    def test_cartocontext_credentials(self):
+        """CartoContext.__init__ Credentials argument"""
+        creds = cartoframes.Credentials(username=self.username,
+                                        key=self.apikey)
+        cc = cartoframes.CartoContext(creds=creds)
+        self.assertIsInstance(cc, cartoframes.CartoContext)
+        self.assertEqual(cc.creds.username(), self.username)
+        self.assertEqual(cc.creds.key(), self.apikey)
+
+        # CartoContext pulls from saved credentials
+        saved_creds = cartoframes.Credentials(username=self.username,
+                                              key=self.apikey)
+        saved_creds.save()
+        cc_saved = cartoframes.CartoContext()
+        self.assertEqual(cc_saved.creds.key(), self.apikey)
+
+
+    @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_cartocontext_isorguser(self):
         """CartoContext._is_org_user"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -11,7 +11,6 @@ from carto.exceptions import CartoException
 from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 import pandas as pd
-import warnings
 
 WILL_SKIP = False
 
@@ -98,9 +97,9 @@ class TestCartoContext(unittest.TestCase):
         """CartoContext.__init__"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
-        self.assertTrue(cc.api_key == self.apikey)
-        self.assertTrue(cc.base_url == self.baseurl)
-        self.assertTrue(cc.username == self.username)
+        self.assertTrue(cc.creds.key() == self.apikey)
+        self.assertTrue(cc.creds.base_url() == self.baseurl)
+        self.assertTrue(cc.creds.username() == self.username)
         self.assertTrue(not cc.is_org)
         # TODO: how to test instances of a class?
         # self.assertTrue(cc.auth_client.__dict__ == self.auth_client.__dict__)
@@ -225,8 +224,8 @@ class TestCartoContext(unittest.TestCase):
         """CartoContext.delete"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
-        data = {'col1': [1,2,3],
-                'col2': ['a','b','c']}
+        data = {'col1': [1, 2, 3],
+                'col2': ['a', 'b', 'c']}
         df = pd.DataFrame(data)
 
         cc.write(df, self.test_delete_table)
@@ -234,7 +233,8 @@ class TestCartoContext(unittest.TestCase):
 
         # check that querying recently deleted table raises an exception
         with self.assertRaises(CartoException):
-            cc.sql_client.send('select * from {}'.format(self.test_delete_table))
+            cc.sql_client.send('select * from {}'.format(
+                self.test_delete_table))
 
         # try to delete a table that does not exists
         with warnings.catch_warnings(record=True) as w:

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -1,58 +1,155 @@
 """Unit tests for cartoframes.keys"""
 import unittest
-from cartoframes import credentials, context
+import json
+import os
+import time
+from cartoframes import Credentials
+from cartoframes.credentials import _USER_CONFIG_DIR
 
 
-class TestKeyStore(unittest.TestCase):
+class TestCredentials(unittest.TestCase):
     """Tests for functions in keys module"""
     def setUp(self):
-        self.key = 'thisisakey'
-        self.base_url = 'https://test.carto.com'
+        os.rmdir(_USER_CONFIG_DIR)
+        self.key = 'seaturtlexyz'
+        self.username = 'loggerhead'
+        self.base_url = 'https://loggerhead.carto.com/'
+        self.onprem_base_url = 'https://turtleland.com/user/{}'.format(
+                self.username)
+        self.default = {
+                'key': 'default_key',
+                'username': 'default_username',
+                'base_url': 'https://default_username.carto.com/'
+                }
+        self.default_cred = Credentials(**self.default)
+        self.default_cred.save()
 
-    def test_key_null(self):
-        """Test case where API key does not exist"""
-        credentials._remove_creds()
-        with self.assertRaises(EnvironmentError):
-            context.CartoContext()
-        credentials.set_credentials()
-        with self.assertRaises(ValueError):
-            context.CartoContext(base_url=self.base_url)
-        with self.assertRaises(ValueError):
-            context.CartoContext(api_key=self.key)
-        with self.assertRaises(ValueError):
-            context.CartoContext()
+    def tearDown(self):
+        self.default_cred.delete()
 
-    def test_key_setting(self):
-        """Test case where API key is valid"""
-        credentials._remove_creds()
-        credentials.set_api_key(self.key)
-        context.CartoContext(base_url=self.base_url)
-        with self.assertRaises(TypeError):
-            credentials.set_api_key(self.key, overwrite=False)
-        credentials.set_api_key(self.key[::-1], overwrite=True)
-        self.assertEqual(credentials.api_key(), self.key[::-1])
+    def test_credentials(self):
+        """credentials.Credentials common usage"""
+        creds = Credentials(key=self.key,
+                            username=self.username)
 
-    def test_base_url_setting(self):
-        """Test case where API base url is valid"""
-        credentials._remove_creds()
-        credentials.set_base_url(self.base_url)
-        context.CartoContext(api_key=self.key)
-        with self.assertRaises(TypeError):
-            credentials.set_base_url(self.base_url, overwrite=False)
-        credentials.set_base_url(self.base_url[::-1], overwrite=True)
-        self.assertEqual(credentials.base_url(), self.base_url[::-1])
+        self.assertEqual(creds.key(), self.key)
+        self.assertEqual(creds.username(), self.username)
+        self.assertEqual(creds.base_url(), self.base_url)
 
-    def test_set_credentials(self):
-        """Test case where API url is valid"""
-        credentials._remove_creds()
-        credentials.set_credentials(base_url=self.base_url, api_key=self.key)
-        context.CartoContext()
-        with self.assertRaises(TypeError):
-            credentials.set_credentials(base_url=self.base_url[::-1],
-                                        api_key=self.key[::-1],
-                                        overwrite=False)
-        credentials.set_credentials(base_url=self.base_url[::-1],
-                                    api_key=self.key[::-1], overwrite=True)
-        self.assertEqual(credentials.credentials(),
-                         dict(api_key=self.key[::-1],
-                              base_url=self.base_url[::-1]))
+    def test_credentials_baseurl(self):
+        """credentials.Credentials carto.com base_url"""
+        creds = Credentials(key=self.key,
+                            base_url=self.base_url)
+
+        self.assertEqual(creds.key(), self.key)
+        self.assertEqual(creds.username(), None)
+        self.assertEqual(creds.base_url(), self.base_url)
+
+    def test_credentials_onprem_baseurl(self):
+        """credentials.Credentials on-prem-style base_url"""
+        creds = Credentials(key=self.key,
+                            username=self.username,
+                            base_url=self.onprem_base_url)
+
+        self.assertEqual(creds.key(), self.key)
+        self.assertEqual(creds.username(), self.username)
+        self.assertEqual(creds.base_url(), self.onprem_base_url)
+
+    def test_credentials_no_args(self):
+        """credentials.Creentials load default cred file"""
+        creds = Credentials()
+
+        self.assertEqual(creds.key(), self.default['key'])
+        self.assertEqual(creds.username(), self.default['username'])
+        self.assertEqual(creds.base_url(), self.default['base_url'])
+
+    def test_credentials_invalid_key(self):
+        """credentials.Credentials invalid key"""
+        self.default_cred.delete()
+        with self.assertRaises(RuntimeError,
+                               msg='Did not specify key'):
+            Credentials(username=self.username)
+
+    def test_credentials_cred_file(self):
+        """credentials.Credentials cred_file"""
+        local_cred_file = './test_cred_file_{}.json'.format(
+                str(time.time())[-4:])
+
+        # create a credential file with arbitrary name
+        with open(local_cred_file, 'w') as f:
+            json.dump({'base_url': self.base_url,
+                       'key': self.key},
+                      f)
+        creds = Credentials(cred_file=local_cred_file)
+        self.assertEqual(creds.key(), self.key)
+        self.assertEqual(creds.base_url(), self.base_url)
+        creds.delete(local_cred_file)
+
+    def test_credentials_set(self):
+        """credentials.Credentials.set"""
+        new_creds = {
+                'username': 'andy',
+                'key': 'abcdefg'
+                }
+        self.default_cred.set(**new_creds)
+
+    def test_credentials_retrieve(self):
+        """credentials.Credentials.retrieve"""
+        local_cred_file = './test_cred_file_{}.json'.format(
+                str(time.time())[-4:])
+
+        # create a credential file with arbitrary name
+        with open(local_cred_file, 'w') as f:
+            json.dump({'base_url': self.base_url,
+                       'key': self.key},
+                      f)
+        self.default_cred._retrieve(local_cred_file)
+        self.assertEqual(self.default_cred.key(), self.key)
+        self.assertEqual(self.default_cred.username(), None)
+        self.assertEqual(self.default_cred.base_url(), self.base_url)
+
+    def test_credentials_delete(self):
+        """credentials.Credentials.delete"""
+
+        local_cred_file = './test_cred_file_{}.json'.format(
+                str(time.time())[-4:])
+
+        # create a credentials file
+        with open(local_cred_file, 'w') as f:
+            json.dump({'base_url': self.base_url,
+                       'key': self.key},
+                      f)
+
+        # check if it's there
+        self.assertTrue(os.path.isfile(local_cred_file))
+
+        # load credentials file
+        creds = Credentials(cred_file=local_cred_file)
+
+        # delete credentials file
+        creds.delete(local_cred_file)
+
+        # ensure it's deleted
+        self.assertTrue(not os.path.isfile(local_cred_file))
+
+        self.assertIsNone(creds.delete('non_existent_file'))
+
+    def test_credentials_username(self):
+        """credentials.Credentials.username"""
+        self.default_cred.username('updated_username')
+        self.assertEqual(self.default_cred.username(),
+                         'updated_username')
+
+    def test_credentials_base_url(self):
+        """credentials.Credentials.base_url"""
+        new_base_url = 'https://updated_username.carto.com/'
+        self.default_cred.base_url(new_base_url)
+        self.assertEqual(self.default_cred.base_url(),
+                         new_base_url)
+
+    def test_credentials_repr(self):
+        """credentials.Credentials.__repr__"""
+        ans = ('Credentials(username=default_username, '
+               'key=default_key, '
+               'base_url=https://default_username.carto.com/)')
+        self.assertEqual(str(self.default_cred), ans)

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -110,6 +110,13 @@ class TestCredentials(unittest.TestCase):
                 }
         self.default_cred.set(**new_creds)
 
+    def test_credentials_key(self):
+        """credentials.Credentials.key"""
+
+        creds = Credentials(key='abcdefg', username='andy')
+        creds.key('hijklmop')
+        self.assertEqual(creds.key(), 'hijklmnop')
+
     def test_credentials_retrieve(self):
         """credentials.Credentials.retrieve"""
         local_cred_file = './test_cred_file_{}.json'.format(

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -10,7 +10,8 @@ from cartoframes.credentials import _USER_CONFIG_DIR
 class TestCredentials(unittest.TestCase):
     """Tests for functions in keys module"""
     def setUp(self):
-        os.rmdir(_USER_CONFIG_DIR)
+        if os.path.exists(_USER_CONFIG_DIR):
+            os.rmdir(_USER_CONFIG_DIR)
         self.key = 'seaturtlexyz'
         self.username = 'loggerhead'
         self.base_url = 'https://loggerhead.carto.com/'

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -4,12 +4,16 @@ import json
 import os
 import time
 from cartoframes import Credentials
-from cartoframes.credentials import _USER_CONFIG_DIR
+from cartoframes.credentials import _USER_CONFIG_DIR, _DEFAULT_PATH
 
 
 class TestCredentials(unittest.TestCase):
     """Tests for functions in keys module"""
     def setUp(self):
+        # remove default credential file
+        if os.path.exists(_DEFAULT_PATH):
+            os.remove(_DEFAULT_PATH)
+        # delete path for user config data
         if os.path.exists(_USER_CONFIG_DIR):
             os.rmdir(_USER_CONFIG_DIR)
         self.key = 'seaturtlexyz'
@@ -27,6 +31,8 @@ class TestCredentials(unittest.TestCase):
 
     def tearDown(self):
         self.default_cred.delete()
+        if os.path.exists(_USER_CONFIG_DIR):
+            os.rmdir(_USER_CONFIG_DIR)
 
     def test_credentials(self):
         """credentials.Credentials common usage"""

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -43,6 +43,16 @@ class TestCredentials(unittest.TestCase):
         self.assertEqual(creds.username(), self.username)
         self.assertEqual(creds.base_url(), self.base_url)
 
+    def test_credentials_constructor(self):
+        """credentials.Credentials object constructor"""
+        creds1 = Credentials(key='abc123', username='jackson-5')
+        creds2 = Credentials(creds=creds1)
+
+        self.assertEqual(creds1.key(), creds2.key())
+        self.assertEqual(creds1.username(), creds2.username())
+        self.assertEqual(creds1.base_url(), creds2.base_url())
+
+
     def test_credentials_baseurl(self):
         """credentials.Credentials carto.com base_url"""
         creds = Credentials(key=self.key,

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -114,7 +114,7 @@ class TestCredentials(unittest.TestCase):
         """credentials.Credentials.key"""
 
         creds = Credentials(key='abcdefg', username='andy')
-        creds.key('hijklmop')
+        creds.key('hijklmnop')
         self.assertEqual(creds.key(), 'hijklmnop')
 
     def test_credentials_retrieve(self):


### PR DESCRIPTION
Credentials are now class-based instead of a module of functions. This cleans up the code quite a bit (reduction of around 120 lines from the source code), and much easier logic.

TODO:

- [x] context.CartoContext should accept a `Credentials` parameter

Closes #207 and closes #208 

cc @javitonino 