### PR TITLE
adds skipfields for the_geom_webmercator

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -265,8 +265,6 @@ class CartoContext(object):
             self._debug_print(err=err)
             return False
 
-        return False
-
     def _send_batches(self, df, table_name, temp_dir, geom_col, pgcolnames):
         """Batch sending a dataframe in chunks that are then recombined.
 
@@ -539,8 +537,8 @@ class CartoContext(object):
             select_res = self.sql_client.send(
                 'SELECT * FROM {table_name}'.format(table_name=new_table_name))
         else:
-            skipfields=('the_geom_webmercator'
-                        if 'the_geom_webmercator' not in query else None)
+            skipfields = ('the_geom_webmercator'
+                          if 'the_geom_webmercator' not in query else None)
             select_res = self.sql_client.send(query, skipfields=skipfields)
 
         self._debug_print(select_res=select_res)
@@ -632,10 +630,6 @@ class CartoContext(object):
         # TODO: add layers preprocessing method like
         #       layers = process_layers(layers)
         #       that uses up to layer limit value error
-        if not hasattr(IPython, 'display'):
-            raise NotImplementedError('Nope, cannot display maps at the '
-                                      'command line.')
-
         if layers is None:
             layers = []
         elif not isinstance(layers, collections.Iterable):
@@ -948,13 +942,9 @@ class CartoContext(object):
     def _send_map_template(self, layers, has_zoom):
         map_name = get_map_name(layers, has_zoom=has_zoom)
         if map_name not in self._map_templates:
-            try:
-                self._auth_send('api/v1/map/named', 'POST',
-                                headers={'Content-Type': 'application/json'},
-                                data=get_map_template(layers,
-                                                      has_zoom=has_zoom))
-            except ValueError('map already exists'):
-                pass
+            self._auth_send('api/v1/map/named', 'POST',
+                            headers={'Content-Type': 'application/json'},
+                            data=get_map_template(layers, has_zoom=has_zoom))
 
             self._map_templates[map_name] = True
         return map_name

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -547,7 +547,7 @@ class CartoContext(object):
 
         fields = select_res['fields']
         if select_res['total_rows'] == 0:
-            return pd.DataFrame(columns=fields.keys() - {'cartodb_id'})
+            return pd.DataFrame(columns=set(fields.keys()) - {'cartodb_id'})
 
         df = pd.DataFrame(data=select_res['rows'])
         for field in fields:

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -128,7 +128,7 @@ class CartoContext(object):
             CARTO.
         """
         query = 'SELECT * FROM "{table_name}"'.format(table_name=table_name)
-        if limit:
+        if limit is not None:
             if isinstance(limit, int) and (limit >= 0):
                 query += ' LIMIT {limit}'.format(limit=limit)
             else:
@@ -546,8 +546,8 @@ class CartoContext(object):
         self._debug_print(select_res=select_res)
 
         fields = select_res['fields']
-        if not len(fields):
-            return pd.DataFrame()
+        if select_res['total_rows'] == 0:
+            return pd.DataFrame(columns=fields.keys() - {'cartodb_id'})
 
         df = pd.DataFrame(data=select_res['rows'])
         for field in fields:

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -539,7 +539,9 @@ class CartoContext(object):
             select_res = self.sql_client.send(
                 'SELECT * FROM {table_name}'.format(table_name=new_table_name))
         else:
-            select_res = self.sql_client.send(query)
+            skipfields=('the_geom_webmercator'
+                        if 'the_geom_webmercator' not in query else None)
+            select_res = self.sql_client.send(query, skipfields=skipfields)
 
         self._debug_print(select_res=select_res)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-carto>=1.0.1
+carto>=1.1.0
 pyrestcli>=0.6.3
 pandas>=0.19.2
 webcolors==1.7

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -702,6 +702,14 @@ class TestCartoContext(unittest.TestCase):
                                       verbose=False)
         self.assertIsNone(cc._debug_print(resp=test_str))
 
+    def test_data_obs_functions(self):
+        """context.data_x"""
+        cc = cartoframes.CartoContext(base_url=self.baseurl,
+                                      api_key=self.apikey)
+
+        self.assertIsNone(cc.data_boundaries())
+        self.assertIsNone(cc.data_discovery())
+
 
 class TestBatchJobStatus(unittest.TestCase):
     """Tests for cartoframes.BatchJobStatus"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -364,8 +364,8 @@ class TestCartoContext(unittest.TestCase):
             LIMIT 0
             ''')
 
-        # no rows or columns
-        self.assertTupleEqual(df_empty.shape, (0, 0))
+        # no rows, one column
+        self.assertTupleEqual(df_empty.shape, (0, 1))
 
         # is a DataFrame
         self.assertIsInstance(df_empty, pd.DataFrame)

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -158,12 +158,18 @@ class TestCartoContext(unittest.TestCase):
 
         # normal table
         df = cc.read(self.test_read_table)
-        self.assertTrue(set(df.columns) == self.valid_columns)
+        self.assertSetEqual(set(df.columns), self.valid_columns)
         self.assertTrue(len(df) == 169)
 
         # read with limit
         df = cc.read(self.test_read_table, limit=10)
         self.assertEqual(len(df), 10)
+        self.assertIsInstance(df, pd.DataFrame)
+
+        # read empty table/dataframe
+        df = cc.read(self.test_read_table, limit=0)
+        self.assertSetEqual(set(df.columns), self.valid_columns)
+        self.assertEqual(len(df), 0)
         self.assertIsInstance(df, pd.DataFrame)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -55,7 +55,7 @@ class TestCartoContext(unittest.TestCase):
         self.test_read_table = 'cb_2013_us_csa_500k'
         self.valid_columns = set(['affgeoid', 'aland', 'awater', 'created_at',
                                   'csafp', 'geoid', 'lsad', 'name', 'the_geom',
-                                  'the_geom_webmercator', 'updated_at'])
+                                  'updated_at'])
         # for writing to carto
         self.test_write_table = 'cartoframes_test_table_{ver}_{mpl}'.format(
             ver=pyver,
@@ -385,7 +385,7 @@ class TestCartoContext(unittest.TestCase):
         self.assertEqual(len(df), 100)
         # should have requested columns + utility columns from CARTO
         self.assertSetEqual({'link', 'body', 'displayname', 'friendscount',
-                             'the_geom', 'the_geom_webmercator'},
+                             'the_geom', },
                             set(df.columns),
                             msg='Should have the columns requested')
 


### PR DESCRIPTION
Skips reading `the_geom_webmercator` for all read operations, and only query operations that specifically have the column name in the query.

Other minor bug fixes.

Closes #154 