### PR TITLE
Brings animated (torque) maps to life

### DIFF
--- a/cartoframes/assets/cartoframes.html
+++ b/cartoframes/assets/cartoframes.html
@@ -44,6 +44,11 @@
        zoom: @@ZOOM@@,
        center: [@@LAT@@, @@LNG@@],
      });
+     if (config.type === 'torque') {
+         L.tileLayer(config.named_map.params.basemap_url, {
+             attribution: "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>"
+         }).addTo(map);
+     };
      const updateMapInfo = () => {
        $('#zoom').text(map.getZoom());
        $('#lat').text(map.getCenter().lat.toFixed(4));

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -700,7 +700,7 @@ class CartoContext(object):
         elif len(base_layers) == 1:
             layers.insert(0, layers.pop(base_layers[0]))
             if layers[0].is_basic() and layers[0].labels == 'front':
-                if time:
+                if time_layers:
                     warn('Basemap labels on top are not currently supported '
                          'for animated maps')
                 else:
@@ -727,8 +727,8 @@ class CartoContext(object):
                 self._debug_print(layer_fields=resp)
                 for k, v in dict_items(resp['fields']):
                     layer.style_cols[k] = v['type']
+                layer.geom_type = self._geom_type(layer)
                 if not base_layers:
-                    layer.geom_type = self._geom_type(layer)
                     geoms.add(layer.geom_type)
                 # update local style schema to help build proper defaults
             layer._setup(layers, idx)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -777,6 +777,18 @@ class CartoContext(object):
             }
 
             if time_layer:
+                # get turbo-carto processed cartocss
+                params.update(dict(callback='cartoframes'))
+                resp = requests.get(
+                        os.path.join(self.creds.base_url(),
+                                     'api/v1/map/named', map_name, 'jsonp'),
+                        params=params,
+                        headers={'Content-Type': 'application/json'})
+
+                # replace previous cartocss with turbo-carto processed version
+                layer.cartocss = json.loads(
+                        resp.text.split('&& cartoframes(')[1]
+                            .strip(');'))['metadata']['layers'][1]['meta']['cartocss']
                 config.update({
                     'order': 1,
                     'options': {

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -679,9 +679,13 @@ class CartoContext(object):
         # If basemap labels are on front, add labels layer
         basemap = layers[0]
         if basemap.is_basic() and basemap.labels == 'front':
-            layers.append(BaseMap(basemap.source,
-                                  labels=basemap.labels,
-                                  only_labels=True))
+            if time:
+                warn('Basemap labels on top are not currently supported for '
+                     'animated maps')
+            else:
+                layers.append(BaseMap(basemap.source,
+                                      labels=basemap.labels,
+                                      only_labels=True))
 
         # Setup layers
         for idx, layer in enumerate(layers):

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -18,7 +18,7 @@ from carto.sql import SQLClient, BatchSQLClient
 from carto.exceptions import CartoException
 
 from .credentials import Credentials
-from .utils import dict_items, normalize_colnames, norm_colname
+from .utils import dict_items, normalize_colnames, norm_colname, geom_conv
 from .layer import BaseMap
 from .maps import non_basemap_layers, get_map_name, get_map_template
 
@@ -700,7 +700,7 @@ class CartoContext(object):
                 # update local style schema to help build proper defaults
                 for k, v in dict_items(resp['fields']):
                     layer.style_cols[k] = v['type']
-                layer.geom_type = resp['rows'][0]['the_geom']
+                layer.geom_type = geom_conv(resp['rows'][0]['the_geom'])
             layer._setup(layers, idx)
 
         nb_layers = non_basemap_layers(layers)

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -303,6 +303,11 @@ class QueryLayer(AbstractLayer):
     def _setup(self, layers, layer_idx):
         basemap = layers[0]
 
+        if self.time and self.geom_type != 'point':
+            raise ValueError('Cannot do time-based maps with data in '
+                             '`{query}` since this table does not contain '
+                             'point geometries'.format(query=self.query))
+
         if self.time:
             # default torque color
             self.color = self.color or '#2752ff'
@@ -316,7 +321,7 @@ class QueryLayer(AbstractLayer):
                 self.scheme = mint(5)
             elif self.style_cols[self.color] in ('date', 'geometry', ):
                 raise ValueError('Cannot style column `{col}` of type '
-                                 '`{type}`. It must be numeric, string, or '
+                                 '`{type}`. It must be numeric, text, or '
                                  'boolean.'.format(
                                      col=self.color,
                                      type=self.style_cols[self.color]))

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -359,7 +359,8 @@ class QueryLayer(AbstractLayer):
                         'cf_value_{}'.format(self.color))
                 self.scheme = {
                         'bins': ','.join(str(i) for i in range(1, 11)),
-                        'name': 'Bold',
+                        'name': (self.scheme.get('name') if self.scheme
+                                 else 'Bold'),
                         'bin_method': '',
                         }
             elif (self.color in self.style_cols and

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -343,9 +343,9 @@ class QueryLayer(AbstractLayer):
                     '    orig.*, __wrap.cf_value_{col}',
                     'FROM ({query}) AS orig, (',
                     '    SELECT',
-                    '        row_number() OVER (',
-                    '            ORDER BY val_{col}_cnt DESC) AS cf_value_{col},',
-                    '        {col}',
+                    '      row_number() OVER (',
+                    '        ORDER BY val_{col}_cnt DESC) AS cf_value_{col},',
+                    '      {col}',
                     '    FROM (',
                     '        SELECT {col}, count({col}) AS val_{col}_cnt',
                     '        FROM ({query}) as orig',
@@ -363,11 +363,11 @@ class QueryLayer(AbstractLayer):
                         'bin_method': '',
                         }
             elif (self.color in self.style_cols and
-                      self.style_cols[self.color] in ('number', )):
-                self.query = '''
-                SELECT *, {col} as value
-                FROM ({query}) as _wrap
-                '''.format(col=self.color, query=self.query)
+                  self.style_cols[self.color] in ('number', )):
+                self.query = ' '.join([
+                    'SELECT *, {col} as value',
+                    'FROM ({query}) as _wrap'
+                ]).format(col=self.color, query=self.query)
                 agg_func = '\'avg({})\''.format(self.color)
             else:
                 agg_func = "'{method}(cartodb_id)'".format(

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -297,11 +297,11 @@ class QueryLayer(AbstractLayer):
     def _validate_columns(self):
         """Validate the options in the styles"""
         geom_cols = {'the_geom', 'the_geom_webmercator', }
-        if set(self.style_cols) & geom_cols:
+        col_overlap = set(self.style_cols) & geom_cols
+        if col_overlap:
             raise ValueError('Style columns cannot be geometry '
                              'columns. `{col}` was chosen.'.format(
-                                 col=','.join(set(self.style_cols.keys())
-                                              & geom_cols)))
+                                 col=','.join(col_overlap)))
 
     def _setup(self, layers, layer_idx):
         basemap = layers[0]

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -15,7 +15,7 @@ def has_time_layer(layers):
 
 def get_map_name(layers, has_zoom):
     """Creates a map named based on supplied parameters"""
-    version = '20170922_dev'
+    version = '20170406'
     num_layers = len(non_basemap_layers(layers))
     has_labels = len(layers) > 1 and layers[-1].is_basemap
     has_time = has_time_layer(layers)
@@ -51,7 +51,7 @@ def get_map_template(layers, has_zoom):
             #       config
             'urlTemplate': layers[0].url,
             # 'urlTemplate': '<%= basemap_url %>',
-            'subdomains': ['a', 'b', 'c', 'd'],
+            'subdomains': "abcd",
         },
     }]
 

--- a/cartoframes/maps.py
+++ b/cartoframes/maps.py
@@ -15,7 +15,7 @@ def has_time_layer(layers):
 
 def get_map_name(layers, has_zoom):
     """Creates a map named based on supplied parameters"""
-    version = '20170406'
+    version = '20170922_dev'
     num_layers = len(non_basemap_layers(layers))
     has_labels = len(layers) > 1 and layers[-1].is_basemap
     has_time = has_time_layer(layers)
@@ -51,7 +51,7 @@ def get_map_template(layers, has_zoom):
             #       config
             'urlTemplate': layers[0].url,
             # 'urlTemplate': '<%= basemap_url %>',
-            'subdomains': "abcd",
+            'subdomains': ['a', 'b', 'c', 'd'],
         },
     }]
 

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -22,7 +22,7 @@ def get_scheme_cartocss(column, scheme_info):
     else:
         color_scheme = 'cartocolor({})'.format(scheme_info['name'])
 
-    return "ramp([{column}], {color_scheme}, {bin_method}({bins}))".format(
+    return "ramp([{column}], {color_scheme}, {bin_method}({bins}), <=)".format(
         column=column,
         color_scheme=color_scheme,
         bin_method=scheme_info['bin_method'],

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -75,18 +75,6 @@ def norm_colname(colname):
     return final_name
 
 
-def geom_conv(pggeom):
-    pgtypes = {
-        'ST_Point': 'point',
-        'ST_MultiPoint': 'point',
-        'ST_LineString': 'line',
-        'ST_MultiLineString': 'line',
-        'ST_MultiPolygon': 'polygon',
-        'ST_Polygon': 'polygon'
-        }
-    return pgtypes.get(pggeom)
-
-
 def importify_params(param_arg):
     """Convert parameter arguments to what CARTO's Import API expects"""
     if isinstance(param_arg, bool):

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -73,3 +73,15 @@ def norm_colname(colname):
     if final_name[0].isdigit():
         return '_' + final_name
     return final_name
+
+
+def geom_conv(pggeom):
+    pgtypes = {
+        'ST_Point': 'point',
+        'ST_MultiPoint': 'point',
+        'ST_LineString': 'line',
+        'ST_MultiLineString': 'line',
+        'ST_MultiPolygon': 'polygon',
+        'ST_Polygon': 'polygon'
+        }
+    return pgtypes.get(pggeom)

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -522,6 +522,9 @@ class TestCartoContext(unittest.TestCase):
             cc.map(layers=[Layer(self.torque_table, time='cartodb_id'),
                            Layer(self.torque_table, color='cartodb_id')])
 
+        with self.assertRaises(ValueError):
+            cc.map(layers=Layer(self.test_read_table, time='cartodb_id'))
+
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_get_bounds(self):
         """CartoContext._get_bounds"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -57,6 +57,9 @@ class TestCartoContext(unittest.TestCase):
         self.valid_columns = set(['affgeoid', 'aland', 'awater', 'created_at',
                                   'csafp', 'geoid', 'lsad', 'name', 'the_geom',
                                   'updated_at'])
+        # torque table
+        self.torque_table = 'tweets_obama'
+
         # for writing to carto
         self.test_write_table = 'cartoframes_test_table_{ver}_{mpl}'.format(
             ver=pyver,
@@ -507,9 +510,17 @@ class TestCartoContext(unittest.TestCase):
         from cartoframes import Layer
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
-        html_map = cc.map(layers=Layer(self.test_read_table,
+        html_map = cc.map(layers=Layer(self.torque_table,
                                        time='cartodb_id'))
         self.assertIsInstance(html_map, IPython.core.display.HTML)
+
+        with self.assertRaises(ValueError):
+            cc.map(layers=Layer(self.torque_table, time='cartodb_id'),
+                   interactive=False)
+
+        with self.assertRaises(ValueError):
+            cc.map(layers=[Layer(self.torque_table, time='cartodb_id'),
+                           Layer(self.torque_table, color='cartodb_id')])
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_get_bounds(self):

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -514,15 +514,29 @@ class TestCartoContext(unittest.TestCase):
                                        time='cartodb_id'))
         self.assertIsInstance(html_map, IPython.core.display.HTML)
 
-        with self.assertRaises(ValueError):
+        # category map
+        cat_map = cc.map(layers=Layer(self.torque_table,
+                                      time='actor_postedtime',
+                                      color='twitter_lang'))
+        self.assertRegexpMatches(
+                cat_map.__html__(),
+                '.*CDB_Math_Mode\(cf_value_twitter_lang\).*')
+
+        with self.assertRaises(
+                ValueError,
+                msg='cannot create static torque maps currently'):
             cc.map(layers=Layer(self.torque_table, time='cartodb_id'),
                    interactive=False)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(
+                ValueError,
+                msg='cannot have more than one torque layer'):
             cc.map(layers=[Layer(self.torque_table, time='cartodb_id'),
                            Layer(self.torque_table, color='cartodb_id')])
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(
+                ValueError,
+                msg='cannot do a torque map off a polygon dataset'):
             cc.map(layers=Layer(self.test_read_table, time='cartodb_id'))
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -12,6 +12,7 @@ from carto.exceptions import CartoException
 from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient
 import pandas as pd
+import IPython
 
 WILL_SKIP = False
 
@@ -415,7 +416,6 @@ class TestCartoContext(unittest.TestCase):
             import matplotlib.pyplot as plt
         except ImportError:
             plt = None
-        import IPython
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
 
@@ -501,9 +501,15 @@ class TestCartoContext(unittest.TestCase):
             cc.map(layers=[Layer(self.test_read_table, time='cartodb_id'),
                            Layer(self.test_read_table, time='cartodb_id')])
 
-        # time layers are not implemented yet
-        with self.assertRaises(NotImplementedError):
-            cc.map(layers=Layer(self.test_read_table, time='cartodb_id'))
+    @unittest.skipIf(WILL_SKIP, 'no cartocredentials, skipping')
+    def test_cartocontext_map_time(self):
+        """CartoContext.map time options"""
+        from cartoframes import Layer
+        cc = cartoframes.CartoContext(base_url=self.baseurl,
+                                      api_key=self.apikey)
+        html_map = cc.map(layers=Layer(self.test_read_table,
+                                       time='cartodb_id'))
+        self.assertIsInstance(html_map, IPython.core.display.HTML)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_get_bounds(self):

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -90,7 +90,7 @@ class TestCartoContext(unittest.TestCase):
                   self.test_write_batch_table,
                   self.test_write_lnglat_table,
                   self.test_query_table,
-                  self.mixed_case_table, )
+                  self.mixed_case_table.lower(), )
 
         if self.apikey and self.baseurl:
             cc = cartoframes.CartoContext(base_url=self.baseurl,

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -156,7 +156,7 @@ class TestQueryLayer(unittest.TestCase):
         # normal behavior for point geometries
         ql._setup([BaseMap(), ql], 1)
         self.assertDictEqual(ql.scheme,
-                             dict(name='Bold', bin_method='',
+                             dict(name='Antique', bin_method='',
                                   bins=','.join(str(i) for i in range(1, 11))))
         # expect category maps query
         self.assertRegexpMatches(ql.query,

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -162,7 +162,8 @@ class TestQueryLayer(unittest.TestCase):
                     'method': 'count',
                     'cumulative': False,
                     'frames': 256,
-                    'duration': 30}
+                    'duration': 30,
+                    'trails': 2}
         # pass a valid column name
         qlayer = QueryLayer(self.query, time='time_col')
         self.assertEqual(qlayer.time, time_ans)
@@ -175,7 +176,8 @@ class TestQueryLayer(unittest.TestCase):
                     'method': 'avg',
                     'frames': 256,
                     'duration': 10,
-                    'cumulative': False}
+                    'cumulative': False,
+                    'trails': 2}
 
         self.assertEqual(qlayer.time, time_ans)
 

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -161,6 +161,7 @@ class TestQueryLayer(unittest.TestCase):
                         color='colorcol')
         # category type
         ql.style_cols['colorcol'] = 'string'
+        ql.style_cols['timecol'] = 'date'
 
         # if non-point geoms are present (or None), raise an error
         with self.assertRaises(
@@ -190,6 +191,7 @@ class TestQueryLayer(unittest.TestCase):
                         color='colorcol')
         # category type
         ql.style_cols['colorcol'] = 'number'
+        ql.style_cols['timecol'] = 'date'
         ql.geom_type = 'point'
 
         # normal behavior for point geometries
@@ -221,6 +223,18 @@ class TestQueryLayer(unittest.TestCase):
         with self.assertRaises(ValueError,
                                msg='`time` key has to be a str or dict'):
             QueryLayer(self.query, time=7)
+
+        with self.assertRaises(ValueError):
+            ql = QueryLayer('select * from watermelon', time='seeds')
+            ql.style_cols['seeds'] = 'string'
+            ql.geom_type = 'point'
+            ql._setup([BaseMap(), ql], 1)
+
+        with self.assertRaises(ValueError):
+            ql = QueryLayer('select * from watermelon', time='seeds')
+            ql.style_cols['seeds'] = 'date'
+            ql.geom_type = 'polygon'
+            ql._setup([BaseMap(), ql], 1)
 
     def test_querylayer_time_default(self):
         """layer.QueryLayer time defaults"""

--- a/test/test_styling.py
+++ b/test/test_styling.py
@@ -100,17 +100,17 @@ class TestColorScheme(unittest.TestCase):
         """styling.get_scheme_cartocss"""
         # test on category
         self.assertEqual(get_scheme_cartocss('acadia', self.vivid),
-                         'ramp([acadia], cartocolor(Vivid), category(4))')
+                         'ramp([acadia], cartocolor(Vivid), category(4), <=)')
         # test on quantative
         self.assertEqual(get_scheme_cartocss('acadia', self.purp),
-                         'ramp([acadia], cartocolor(Purp), quantiles(4))')
+                         'ramp([acadia], cartocolor(Purp), quantiles(4), <=)')
         # test on custom
         self.assertEqual(
                 get_scheme_cartocss('acadia',
                                     styling.custom(('#FFF', '#888', '#000'),
                                                    bins=3,
                                                    bin_method='equal')),
-                'ramp([acadia], (#FFF,#888,#000), equal(3))')
+                'ramp([acadia], (#FFF,#888,#000), equal(3), <=)')
 
     def test_scheme(self):
         """styling._scheme"""


### PR DESCRIPTION
This PR brings torque maps to cartoframes. 

## Examples
### Basic usage
![torque-cartoframes](https://user-images.githubusercontent.com/1041056/30779023-c9721942-a0b1-11e7-8dc0-efe740c869a2.gif)

### Torque Category and Numeric classification
![torque-cartoframes](https://user-images.githubusercontent.com/1041056/31156593-52fdc994-a883-11e7-941e-8e0b3ce81884.gif)

## Modifications / enhancements
- configures `cartoframes/assets/cartoframes.html` to use the basemap instead of relying on the named maps basemap (which seems to not be directly loadable with torque named maps)
- fixes order of cartocss generated so `Map {...}` code appears before `#layer {...}`
- restricts maps to basemap + animated layer for now
- some general code cleanups
- better handling of errors with maps api POSTs
- cleans up `cumulative` options (True/False only)
- new defaults for torque styles (size = 4 as opposed to static sizes of 10 / colors of `#2752ff`)
- constructs turbo carto style, sends it to carto, gets processed version since torque can't directly handle turbo carto styles

## Restrictions
- torque maps can only be one-layered (no static layers)
- currently cannot combine size and color attributes with torque (what to do with trails, etc.)
- the torque tiles are pulled from the named map, but no raster layers are pulled, so basemaps have to be setup elsewhere. i'm currently restricting basemaps to no-label and labels on bottom for now.

## Problems still to work through
- [x] torque category maps
- [x] numeric classification
- [ ] boolean values are not working for category classification

## ToDos

- [x] add validation that time column is only numeric or timestamp
- [ ] more ad hoc tests on different datasets

cc @makella 