### PR TITLE
encodes to utf-8 to avoid issues between py2/3

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -377,7 +377,8 @@ class CartoContext(object):
         self._debug_print(tempfile=tempfile)
         df.drop(geom_col, axis=1, errors='ignore').to_csv(path_or_buf=tempfile,
                                                           na_rep='',
-                                                          header=pgcolnames)
+                                                          header=pgcolnames,
+                                                          encoding='utf-8')
 
         with open(tempfile, 'rb') as f:
             res = self._auth_send('api/v1/imports', 'POST',

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Unit tests for cartoframes.layers"""
 import unittest
 import os
@@ -255,7 +257,7 @@ class TestCartoContext(unittest.TestCase):
         self.assertDictEqual(cols['fields'], expected_schema)
 
         # test properly encoding
-        df = pd.DataFrame({'vals':[1,2,3],'strings':['a','\xf4','ô']})
+        df = pd.DataFrame({'vals':[1,2],'strings':['a','\xf4']})
         cc.write(df, self.test_write_table, overwrite=True)
 
         # check if table exists

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -254,6 +254,18 @@ class TestCartoContext(unittest.TestCase):
         # util columns + new column of type number
         self.assertDictEqual(cols['fields'], expected_schema)
 
+        # test properly encoding
+        df = pd.DataFrame({'vals':[1,2,3],'strings':['a','\xf4','ô']})
+        cc.write(df, self.test_write_table, overwrite=True)
+
+        # check if table exists
+        resp = self.sql_client.send('''
+            SELECT *
+            FROM {table}
+            LIMIT 0
+            '''.format(table=self.test_write_table))
+        self.assertIsNotNone(resp)
+
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_cartocontext_table_exists(self):
         """CartoContext._table_exists"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -257,7 +257,7 @@ class TestCartoContext(unittest.TestCase):
         self.assertDictEqual(cols['fields'], expected_schema)
 
         # test properly encoding
-        df = pd.DataFrame({'vals':[1,2],'strings':['a','\xf4']})
+        df = pd.DataFrame({'vals':[1,2],'strings':['a','ô']})
         cc.write(df, self.test_write_table, overwrite=True)
 
         # check if table exists


### PR DESCRIPTION
@michellemho, could you double check this to make sure it handles the errors you encountered in #220?

closes #220 