### PR TITLE
Column's type named in map styling determines type of scheme to style by

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -687,6 +687,16 @@ class CartoContext(object):
 
         # Setup layers
         for idx, layer in enumerate(layers):
+            if not layer.is_basemap:
+                # get schema of style columns
+                resp = self.sql_client.send('''
+                    SELECT {cols} FROM ({query}) AS _wrap LIMIT 0
+                '''.format(cols=','.join(layer.style_cols),
+                           query=layer.query))
+                self._debug_print(layer_fields=resp)
+                # update local style schema to help build proper defaults
+                for k, v in dict_items(resp['fields']):
+                    layer.style_cols[k] = v['type']
             layer._setup(layers, idx)
 
         nb_layers = non_basemap_layers(layers)

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -7,7 +7,7 @@ import pandas as pd
 import webcolors
 
 from cartoframes.utils import cssify
-from cartoframes.styling import BinMethod, mint, get_scheme_cartocss
+from cartoframes.styling import BinMethod, mint, antique, get_scheme_cartocss
 
 # colors map data layers without color specified
 # from cartocolor vivid scheme
@@ -206,8 +206,10 @@ class QueryLayer(AbstractLayer):
                  tooltip=None, legend=None):
 
         self.query = query
-        self.style_cols = set()
+        # style columns as keys, data types as values
+        self.style_cols = dict()
 
+        # TODO: move these if/else branches to individual methods
         # color, scheme = self._get_colorscheme()
         # time = self._get_timescheme()
         # size = self._get_sizescheme()
@@ -215,18 +217,19 @@ class QueryLayer(AbstractLayer):
         # It could be that there is a column named 'blue' for example
         if isinstance(color, dict):
             if 'column' not in color:
-                raise ValueError("color must include a 'column' value")
-            scheme = color.get('scheme', mint(5))
+                raise ValueError("Color must include a 'column' value")
+            # get scheme if exists. if not, one will be chosen later if needed
+            scheme = color.get('scheme')
             color = color['column']
-            self.style_cols.add(color)
+            self.style_cols[color] = None
         elif (color and
               color[0] != '#' and
               color not in webcolors.CSS3_NAMES_TO_HEX):
             # color specified that is not a web color or hex value so its
             #  assumed to be a column name
             color = color
-            self.style_cols.add(color)
-            scheme = mint(5)
+            self.style_cols[color] = None
+            scheme = None
         else:
             # assume it's a color
             color = color
@@ -245,7 +248,7 @@ class QueryLayer(AbstractLayer):
                 raise ValueError('`time` should be a column name or '
                                  'dictionary of styling options.')
 
-            self.style_cols.add(time_column)
+            self.style_cols[time_column] = None
             time = {
                 'column': time_column,
                 'method': 'count',
@@ -273,7 +276,7 @@ class QueryLayer(AbstractLayer):
             size.update(old_size)
             # Since we're accessing min/max, convert range into a list
             size['range'] = list(size['range'])
-            self.style_cols.add(size['column'])
+            self.style_cols[size['column']] = None
 
         self.color = color
         self.scheme = scheme
@@ -284,17 +287,30 @@ class QueryLayer(AbstractLayer):
         self._validate_columns()
 
     def _validate_columns(self):
-        """Validate the options in the styles
-        """
-        geom_cols = {'the_geom', 'the_geom_webmercator'}
-        if self.style_cols & geom_cols:
+        """Validate the options in the styles"""
+        geom_cols = {'the_geom', 'the_geom_webmercator', }
+        if set(self.style_cols) & geom_cols:
             raise ValueError('Style columns cannot be geometry '
                              'columns. `{col}` was chosen.'.format(
-                                 col=','.join(self.style_cols & geom_cols)))
+                                 col=','.join(set(self.style_cols.keys())
+                                              & geom_cols)))
 
     def _setup(self, layers, layer_idx):
         basemap = layers[0]
+        # choose appropriate scheme if not already specified
+        if (self.scheme is None) and (self.color in self.style_cols):
+            if self.style_cols[self.color] in ('string', 'boolean', ):
+                self.scheme = antique(10)
+            elif self.style_cols[self.color] in ('number', ):
+                self.scheme = mint(5)
+            elif self.style_cols[self.color] in ('date', 'geometry', ):
+                raise ValueError('Cannot style column `{col}` of type '
+                                 '`{type}`. It must be numeric, string, or '
+                                 'boolean.'.format(
+                                     col=self.color,
+                                     type=self.style_cols[self.color]))
 
+        # if color not specified, choose a default
         self.color = self.color or DEFAULT_COLORS[layer_idx]
         self.cartocss = self._get_cartocss(basemap)
 

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -1,7 +1,12 @@
 """Unit tests for cartoframes.layers"""
 import unittest
-from cartoframes.layer import BaseMap, QueryLayer
+from cartoframes.layer import BaseMap, QueryLayer, AbstractLayer
 from cartoframes import styling
+
+
+class TestAbstractLayer(unittest.TestCase):
+    def test_class(self):
+        self.assertIsNone(AbstractLayer().__init__())
 
 
 class TestBaseMap(unittest.TestCase):

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -108,6 +108,9 @@ class TestQueryLayer(unittest.TestCase):
 
         for idx, color in enumerate(str_colors):
             qlayer = QueryLayer(self.query, color=color)
+            if color == str_colors[-1]:
+                qlayer.style_cols['cookie_monster'] = 'number'
+                qlayer._setup([BaseMap(), qlayer], 1)
             print(qlayer.color)
             self.assertEqual(qlayer.color, str_colors_ans[idx])
             self.assertEqual(qlayer.scheme, str_scheme_ans[idx])

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -102,19 +102,26 @@ class TestQueryLayer(unittest.TestCase):
             self.assertEqual(qlayer.scheme, dict_colors_scheme[idx])
 
         # check valid string color options
-        str_colors = ['#FF0000', 'aliceblue', 'cookie_monster']
-        str_colors_ans = ['#FF0000', 'aliceblue', 'cookie_monster']
-        str_scheme_ans = [None, None, styling.mint(5)]
+        str_colors = ('#FF0000', 'aliceblue', 'cookie_monster', 'big_bird')
+        str_colors_ans = ('#FF0000', 'aliceblue', 'cookie_monster', 'big_bird')
+        str_scheme_ans = (None, None, styling.mint(5), styling.antique(10))
 
         for idx, color in enumerate(str_colors):
             qlayer = QueryLayer(self.query, color=color)
-            if color == str_colors[-1]:
-                qlayer.style_cols['cookie_monster'] = 'number'
+            if color == 'cookie_monster':
+                qlayer.style_cols[color] = 'number'
                 qlayer._setup([BaseMap(), qlayer], 1)
-            print(qlayer.color)
+            elif color == 'big_bird':
+                qlayer.style_cols[color] = 'string'
+                qlayer._setup([BaseMap(), qlayer], 1)
             self.assertEqual(qlayer.color, str_colors_ans[idx])
             self.assertEqual(qlayer.scheme, str_scheme_ans[idx])
 
+        with self.assertRaises(ValueError,
+                               msg='styling value cannot be a date'):
+            qlayer = QueryLayer(self.query, color='datetime_column')
+            qlayer.style_cols['datetime_column'] = 'date'
+            qlayer._setup([BaseMap(), qlayer], 1)
         # Exception testing
         # color column cannot be a geometry column
         with self.assertRaises(ValueError,


### PR DESCRIPTION
This adds additional steps to the setup, but allows for the proper choosing of qualitative scheme instead of quantitative. Also errors more loudly if a data type such as datetime is input for a color scheme.