### PR TITLE
exposes import api params through CartoContext.write

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -137,7 +137,7 @@ class CartoContext(object):
         return self.query(query, decode_geom=decode_geom)
 
     def write(self, df, table_name, temp_dir='/tmp', overwrite=False,
-              lnglat=None, encode_geom=False, geom_col=None):
+              lnglat=None, encode_geom=False, geom_col=None, **kwargs):
         """Write a DataFrame to a CARTO table.
 
         Example:
@@ -191,7 +191,8 @@ class CartoContext(object):
                                                   geom_col, pgcolnames)
         else:
             final_table_name = self._send_dataframe(df, table_name, temp_dir,
-                                                    geom_col, pgcolnames)
+                                                    geom_col, pgcolnames,
+                                                    kwargs)
             self._set_schema(df, final_table_name, pgcolnames)
 
         # create geometry column from long/lats if requested
@@ -352,7 +353,8 @@ class CartoContext(object):
 
         return table_name
 
-    def _send_dataframe(self, df, table_name, temp_dir, geom_col, pgcolnames):
+    def _send_dataframe(self, df, table_name, temp_dir, geom_col, pgcolnames,
+                        kwargs):
         """Send a DataFrame to CARTO to be imported as a SQL table.
 
         Note:
@@ -384,9 +386,11 @@ class CartoContext(object):
                                                           encoding='utf-8')
 
         with open(tempfile, 'rb') as f:
+            params = {'type_guessing': 'false'}
+            params.update(kwargs)
             res = self._auth_send('api/v1/imports', 'POST',
                                   files={'file': f},
-                                  params={'type_guessing': 'false'},
+                                  params=params,
                                   stream=True)
             self._debug_print(res=res)
 

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -73,3 +73,10 @@ def norm_colname(colname):
     if final_name[0].isdigit():
         return '_' + final_name
     return final_name
+
+
+def importify_params(param_arg):
+    """Convert parameter arguments to what CARTO's Import API expects"""
+    if isinstance(param_arg, bool):
+        return str(param_arg).lower()
+    return param_arg

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -16,6 +16,7 @@ from carto.sql import SQLClient
 import pandas as pd
 
 WILL_SKIP = False
+warnings.simplefilter('ignore')
 
 
 class TestCartoContext(unittest.TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 """Unit tests for cartoframes.utils"""
 import unittest
 from cartoframes.utils import (dict_items, cssify, norm_colname,
-                               normalize_colnames)
+                               normalize_colnames, importify_params)
 from collections import OrderedDict
 
 
@@ -132,3 +132,10 @@ class TestUtils(unittest.TestCase):
         self.assertListEqual(normalize_colnames(self.cols_ans),
                              self.cols_ans,
                              msg='already normalize columns should not change')
+
+    def test_importify_params(self):
+        """utils.importify_params"""
+        params = [True, False, 'true', 'Gulab Jamon', ]
+        ans = ('true', 'false', 'true', 'gulab jamon', )
+        for idx, p in enumerate(params):
+            self.assertTrue(importify_params(p), ans[idx])


### PR DESCRIPTION
This enables users to have, for example, a country column with country names. CARTO will then turn that into geometries for the country column.