### PR TITLE
changes to color scheme docstring

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -17,11 +17,11 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient, BatchSQLClient
 from carto.exceptions import CartoException
 
-from cartoframes.credentials import Credentials
-from cartoframes.utils import (dict_items, normalize_colnames, norm_colname,
+from .credentials import Credentials
+from .utils import (dict_items, normalize_colnames, norm_colname,
                     importify_params, join_url)
-from cartoframes.layer import BaseMap
-from cartoframes.maps import non_basemap_layers, get_map_name, get_map_template
+from .layer import BaseMap
+from .maps import non_basemap_layers, get_map_name, get_map_template
 
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlencode

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -17,11 +17,11 @@ from carto.auth import APIKeyAuthClient
 from carto.sql import SQLClient, BatchSQLClient
 from carto.exceptions import CartoException
 
-from .credentials import Credentials
-from .utils import (dict_items, normalize_colnames, norm_colname,
+from cartoframes.credentials import Credentials
+from cartoframes.utils import (dict_items, normalize_colnames, norm_colname,
                     importify_params, join_url)
-from .layer import BaseMap
-from .maps import non_basemap_layers, get_map_name, get_map_template
+from cartoframes.layer import BaseMap
+from cartoframes.maps import non_basemap_layers, get_map_name, get_map_template
 
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlencode

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -184,7 +184,8 @@ class QueryLayer(AbstractLayer):
             values described:
 
             - column (str): Column to base coloring from.
-            - scheme (dict, optional): Dictionary definition of color scheme from
+            - scheme (dict, optional): Dictionary definition of color scheme,
+              or a scheme such as `styling.sunset(7)` from the
               styling module of cartoframes that exposes `CartoColors
               <https://github.com/CartoDB/CartoColor/wiki/CARTOColor-Scheme-Names>`__.
               Defaults to mint scheme.

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -98,17 +98,17 @@ class BaseMap(AbstractLayer):
 
 
 class QueryLayer(AbstractLayer):
-    """cartoframes Data Layer based on an arbitrary query to the user's CARTO
+    """cartoframes data layer based on an arbitrary query to the user's CARTO
     database. This layer class is useful for offloading processing to the cloud
     to do some of the following:
 
-    * pull down a snapshot of the data (e.g., selecting only important columns
-      instead of all columns in the dataset)
-    * doing spatial processing using `PostGIS <http://postgis.net/>`__ and
-      `PostgreSQL <https://www.postgresql.org/>`__, which is the database
+    * Visualizing spatial operations using `PostGIS <http://postgis.net/>`__
+      and `PostgreSQL <https://www.postgresql.org/>`__, which is the database
       underlying CARTO
-    * performing arbitrary relational database queries (e.g., complex JOINs
+    * Performing arbitrary relational database queries (e.g., complex JOINs
       in SQL instead of in pandas)
+    * Visualizing a subset of the data (e.g., ``SELECT * FROM table LIMIT
+      1000``)
 
     Used in the `layers` keyword in `CartoContext.map()
     <#context.CartoContext.map>`__.
@@ -150,54 +150,56 @@ class QueryLayer(AbstractLayer):
                        Layer('fantastic_sql_table')])
 
     Args:
-        query (str): Query that is fed into a pandas DataFrame. At a minimum,
-            all queries need to have the columns `cartodb_id`, `the_geom`, and
-            `the_geom_webmercator`. Read more in
-            `CARTO's docs
-            <https://carto.com/docs/tips-and-tricks/geospatial-analysis>`__
-            for more information.
-        time (dict or str, optional): Style to apply to layer.
+        query (str): Query to expose data on a map layer. At a minimum, a
+            query needs to have the columns `cartodb_id`, `the_geom`, and
+            `the_geom_webmercator` for the map to display. Read more about
+            queries in `CARTO's docs
+            <https://carto.com/docs/tips-and-tricks/geospatial-analysis>`__.
+
+        time (dict or str, optional): Time-based style to apply to layer.
+
+            If `time` is a :obj:`str`, it must be the name of a column which
+            has a data type of `datetime` or `float`.
+
             If `time` is a :obj:`dict`, the following keys are options:
 
-            - column (str, required): Column for animating map from. Data must
+            - column (`str`, required): Column for animating map, which must
               be of type `datetime` or `float`.
-            - method (str, optional): Type of aggregation method for operating
-              on `Torque TileCubes <https://github.com/CartoDB/torque>`__. Must
-              be one of ``avg``, ``sum``, or another `PostgreSQL aggregate
-              functions
+            - method (`str`, optional): Type of aggregation method for
+              operating on `Torque TileCubes
+              <https://github.com/CartoDB/torque>`__. Must be one of ``avg``,
+              ``sum``, or another `PostgreSQL aggregate functions
               <https://www.postgresql.org/docs/9.5/static/functions-aggregate.html>`__
               with a numeric output. Defaults to ``count``.
-            - cumulative (bool, optional): Whether to accumulate points over
+            - cumulative (`bool`, optional): Whether to accumulate points over
               time (``True``) or not (``False``, default)
-            - frames (int, optional): Number of frames in the animation.
+            - frames (`int`, optional): Number of frames in the animation.
               Defaults to 256.
-            - duration (int, optional): Number of seconds in the animation.
+            - duration (`int`, optional): Number of seconds in the animation.
               Defaults to 30.
-            - trails (int, optional): Number of trails after the incidence of
+            - trails (`int`, optional): Number of trails after the incidence of
               a point. Defaults to 2.
-
-            If `time` is a :obj:`str`, then it must be a column name available
-            in the query that is of type numeric or datetime.
 
         color (dict or str, optional): Color style to apply to map. For
             example, this can be used to change the color of all geometries
-            in this layer, or creating a graduated color or choropleth map.
+            in this layer, or to create a graduated color or choropleth map.
 
             If `color` is a :obj:`str`, there are two options:
 
-            - A column name to style by. The default classification is
-              quantiles for quantitative data and category for qualitative
-              data.
+            - A column name to style by to create, for example, a choropleth
+              map if working with polygons. The default classification is
+              `quantiles` for quantitative data and `category` for
+              qualitative data.
             - A hex value or `web color name
               <https://www.w3.org/TR/css3-color/#svg-color>`__.
 
             If `color` is a :obj:`dict`, the following keys are options, with
             values described:
 
-            - column (str): Column to base coloring from.
-            - scheme (dict, optional): Dictionary definition of color scheme,
-              or a scheme such as `styling.sunset(7)` from the
-              styling module of cartoframes that exposes `CartoColors
+            - column (`str`): Column used for the basis of styling
+            - scheme (`dict`, optional): Scheme such as `styling.sunset(7)` from
+              the `styling module <#module-styling>`__ of cartoframes that
+              exposes `CartoColors
               <https://github.com/CartoDB/CartoColor/wiki/CARTOColor-Scheme-Names>`__.
               Defaults to `mint <#styling.mint>`__ scheme for quantitative
               data and `bold` for qualitative data. More control is given by
@@ -208,19 +210,28 @@ class QueryLayer(AbstractLayer):
               utility function.
 
         size (dict or int, optional): Size style to apply to point data.
+
+            If `size` is an :obj:`int`, all points are sized by this value.
+
+            If `size` is a :obj:`str`, this value is interpreted as a column,
+            and the points are sized by the value in this column. The
+            classification method defaults to `quantiles`, with a min size of
+            5, and a max size of 5. Use the :obj:`dict` input to override these
+            values.
+
             If `size` is a :obj:`dict`, the follow keys are options, with
             values described as:
 
-            - column (str): Column to base sizing of points on
+            - column (`str`): Column to base sizing of points on
             - bin_method (str, optional): Quantification method for dividing
               data range into bins. Must be one of the methods in
               :obj:`BinMethod` (excluding `category`).
-            - bins (int, optional): Number of bins to break data into. Defaults
+            - bins (`int`, optional): Number of bins to break data into.
+              Defaults to 5.
+            - max (`int`, optional): Maximum point width (in pixels). Defaults
+              to 25.
+            - min (`int`, optional): Minimum point width (in pixels). Defaults
               to 5.
-            - max (int, optional): Maximum point width (in pixels). Defaults to
-              25.
-            - min (int, optional): Minimum point width (in pixels). Defaults to
-              5.
 
         tooltip (tuple, optional): **Not yet implemented.**
         legend: **Not yet implemented.**
@@ -500,8 +511,9 @@ class QueryLayer(AbstractLayer):
 
 class Layer(QueryLayer):
     """A cartoframes Data Layer based on a specific table in user's CARTO
-    database. This layer class is useful for visualizing individual datasets
-    with `CartoContext.map() <#context.CartoContext.map>`__.
+    database. This layer class is used for visualizing individual datasets
+    with `CartoContext.map() <#context.CartoContext.map>`__'s ``layers``
+    keyword argument.
 
     Example:
         .. code:: python
@@ -514,7 +526,12 @@ class Layer(QueryLayer):
                                  color={'column': 'mr_fox_sightings',
                                         'scheme': styling.prism(10)})])
 
-    **Parameters:** See :obj:`QueryLayer` for a full list of arguments.
+    Args:
+        table_name (str): Name of table in CARTO account
+        Styling: See :obj:`QueryLayer` for a full list of all arguments
+          arguments for styling this map data layer.
+        source (pandas.DataFrame, optional): Not currently implemented
+        overwrite (bool, optional): Not currently implemented
     """
     def __init__(self, table_name, source=None, overwrite=False, time=None,
                  color=None, size=None, tooltip=None, legend=None):

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -176,10 +176,21 @@ class QueryLayer(AbstractLayer):
             - trails (int, optional): Number of trails after the incidence of
               a point. Defaults to 2.
 
-            If `time` is a :obj:`str`, then it must be a column name available in
-            the query that is of type numeric or datetime.
+            If `time` is a :obj:`str`, then it must be a column name available
+            in the query that is of type numeric or datetime.
 
-        color (dict or str, optional): Color style to apply to map.
+        color (dict or str, optional): Color style to apply to map. For
+            example, this can be used to change the color of all geometries
+            in this layer, or creating a graduated color or choropleth map.
+
+            If `color` is a :obj:`str`, there are two options:
+
+            - A column name to style by. The default classification is
+              quantiles for quantitative data and category for qualitative
+              data.
+            - A hex value or `web color name
+              <https://www.w3.org/TR/css3-color/#svg-color>`__.
+
             If `color` is a :obj:`dict`, the following keys are options, with
             values described:
 
@@ -188,16 +199,22 @@ class QueryLayer(AbstractLayer):
               or a scheme such as `styling.sunset(7)` from the
               styling module of cartoframes that exposes `CartoColors
               <https://github.com/CartoDB/CartoColor/wiki/CARTOColor-Scheme-Names>`__.
-              Defaults to mint scheme.
+              Defaults to `mint <#styling.mint>`__ scheme for quantitative
+              data and `bold` for qualitative data. More control is given by
+              using `styling.scheme <#styling.scheme>`__.
+
+              If you wish to define a custom scheme outside of CartoColors, it
+              is recommended to use the `styling.custom <#styling.custom>`__
+              utility function.
 
         size (dict or int, optional): Size style to apply to point data.
-            If `size` is a :obj:`dict`, the follow keys are options, with values
-            described as:
+            If `size` is a :obj:`dict`, the follow keys are options, with
+            values described as:
 
             - column (str): Column to base sizing of points on
             - bin_method (str, optional): Quantification method for dividing
-              data range into bins. Must be one of: ``quantiles``, ``equal``,
-              ``headtails``, or ``jenks``. Defaults to ``quantiles``.
+              data range into bins. Must be one of the methods in
+              :obj:`BinMethod` (excluding `category`).
             - bins (int, optional): Number of bins to break data into. Defaults
               to 5.
             - max (int, optional): Maximum point width (in pixels). Defaults to
@@ -320,7 +337,7 @@ class QueryLayer(AbstractLayer):
         else:
             self.color = self.color or DEFAULT_COLORS[layer_idx]
         # choose appropriate scheme if not already specified
-        if (self.scheme is None) and (self.color in self.style_cols):
+        if (not self.scheme) and (self.color in self.style_cols):
             if self.style_cols[self.color] in ('string', 'boolean', ):
                 self.scheme = antique(10)
             elif self.style_cols[self.color] in ('number', ):

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -184,10 +184,10 @@ class QueryLayer(AbstractLayer):
             values described:
 
             - column (str): Column to base coloring from.
-            - scheme (str, optinal): Color scheme from
-              `CartoColors
+            - scheme (dict, optional): Dictionary definition of color scheme from
+              styling module of cartoframes that exposes `CartoColors
               <https://github.com/CartoDB/CartoColor/wiki/CARTOColor-Scheme-Names>`__.
-              Defaults to `Mint`.
+              Defaults to mint scheme.
             - bin_method (str, optional): Quantification method for dividing
               data range into bins. Must be one of: ``quantiles``, ``equal``,
               ``headtails``, or ``jenks``. Defaults to ``quantiles``.

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -188,11 +188,6 @@ class QueryLayer(AbstractLayer):
               styling module of cartoframes that exposes `CartoColors
               <https://github.com/CartoDB/CartoColor/wiki/CARTOColor-Scheme-Names>`__.
               Defaults to mint scheme.
-            - bin_method (str, optional): Quantification method for dividing
-              data range into bins. Must be one of: ``quantiles``, ``equal``,
-              ``headtails``, or ``jenks``. Defaults to ``quantiles``.
-            - bins (int, optional): Number of bins to divide data amongst in
-              the `bin_method`. Defaults to 5.
 
         size (dict or int, optional): Size style to apply to point data.
             If `size` is a :obj:`dict`, the follow keys are options, with values

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -8,6 +8,15 @@ in its `GitHub repository <https://github.com/Carto-color/>`__.
 
 
 class BinMethod:
+    """Data classification methods used for the styling of data on maps.
+
+    Attributes:
+        quantiles (str): Quantiles classification for quantitative data
+        jenks (str): Jenks classification for quantitative data
+        headtails (str): Head/Tails classification for quantitative data
+        equal (str): Equal Interval classification for quantitative data
+        category (str): Category classification for qualitative data
+    """
     quantiles = 'quantiles'
     jenks = 'jenks'
     headtails = 'headtails'
@@ -31,7 +40,16 @@ def get_scheme_cartocss(column, scheme_info):
 
 
 def custom(colors, bins=None, bin_method=BinMethod.quantiles):
-    """Get custom scheme"""
+    """Create a custom scheme.
+
+    Args:
+        colors (list of str): List of hex values for styling data
+        bins (int, optional): Number of bins to style by. If not given, the
+          number of colors will be used.
+        bin_method (str, optional): Classification method. One of the values
+          in :obj:`BinMethod`. Defaults to `quantiles`, which only works with
+          quantitative data.
+    """
     return {
         'colors': colors,
         'bins': bins if bins is not None else len(colors),
@@ -39,7 +57,22 @@ def custom(colors, bins=None, bin_method=BinMethod.quantiles):
     }
 
 
-def _scheme(name, bins, bin_method):
+def scheme(name, bins, bin_method):
+    """Return a custom scheme based on CartoColors.
+
+    Args:
+        name (str): Name of a CartoColor.
+        bins (int): Number of bins for classifying data. CartoColors have 7
+          bins max for quantitative data, and 11 max for qualitative data.
+        bin_method (str): One of methods in :obj:`BinMethod`.
+
+    .. Warning::
+
+       Input types are particularly sensitive in this function, and little
+       feedback is given for errors. ``name`` and ``bin_method`` arguments
+       are case-sensitive.
+
+    """
     return {
         'name': name,
         'bins': bins,
@@ -51,190 +84,190 @@ def _scheme(name, bins, bin_method):
 def burg(bins, bin_method=BinMethod.quantiles):
     """CartoColor Burg quantitative scheme
     """
-    return _scheme('Burg', bins, bin_method)
+    return scheme('Burg', bins, bin_method)
 
 
 def burgYl(bins, bin_method=BinMethod.quantiles):
     """CartoColor BurgYl quantitative scheme
     """
-    return _scheme('BurgYl', bins, bin_method)
+    return scheme('BurgYl', bins, bin_method)
 
 
 def redOr(bins, bin_method=BinMethod.quantiles):
     """CartoColor RedOr quantitative scheme
     """
-    return _scheme('RedOr', bins, bin_method)
+    return scheme('RedOr', bins, bin_method)
 
 
 def orYel(bins, bin_method=BinMethod.quantiles):
     """CartoColor OrYel quantitative scheme
     """
-    return _scheme('OrYel', bins, bin_method)
+    return scheme('OrYel', bins, bin_method)
 
 
 def peach(bins, bin_method=BinMethod.quantiles):
     """CartoColor Peach quantitative scheme
     """
-    return _scheme('Peach', bins, bin_method)
+    return scheme('Peach', bins, bin_method)
 
 
 def pinkYl(bins, bin_method=BinMethod.quantiles):
     """CartoColor PinkYl quantitative scheme
     """
-    return _scheme('PinkYl', bins, bin_method)
+    return scheme('PinkYl', bins, bin_method)
 
 
 def mint(bins, bin_method=BinMethod.quantiles):
     """CartoColor Mint quantitative scheme
     """
-    return _scheme('Mint', bins, bin_method)
+    return scheme('Mint', bins, bin_method)
 
 
 def bluGrn(bins, bin_method=BinMethod.quantiles):
     """CartoColor BluGrn quantitative scheme
     """
-    return _scheme('BluGrn', bins, bin_method)
+    return scheme('BluGrn', bins, bin_method)
 
 
 def darkMint(bins, bin_method=BinMethod.quantiles):
     """CartoColor DarkMint quantitative scheme
     """
-    return _scheme('DarkMint', bins, bin_method)
+    return scheme('DarkMint', bins, bin_method)
 
 
 def emrld(bins, bin_method=BinMethod.quantiles):
     """CartoColor Emrld quantitative scheme
     """
-    return _scheme('Emrld', bins, bin_method)
+    return scheme('Emrld', bins, bin_method)
 
 
 def bluYl(bins, bin_method=BinMethod.quantiles):
     """CartoColor BluYl quantitative scheme
     """
-    return _scheme('BluYl', bins, bin_method)
+    return scheme('BluYl', bins, bin_method)
 
 
 def teal(bins, bin_method=BinMethod.quantiles):
     """CartoColor Teal quantitative scheme
     """
-    return _scheme('Teal', bins, bin_method)
+    return scheme('Teal', bins, bin_method)
 
 
 def tealGrn(bins, bin_method=BinMethod.quantiles):
     """CartoColor TealGrn quantitative scheme
     """
-    return _scheme('TealGrn', bins, bin_method)
+    return scheme('TealGrn', bins, bin_method)
 
 
 def purp(bins, bin_method=BinMethod.quantiles):
     """CartoColor Purp quantitative scheme
     """
-    return _scheme('Purp', bins, bin_method)
+    return scheme('Purp', bins, bin_method)
 
 
 def purpOr(bins, bin_method=BinMethod.quantiles):
     """CartoColor PurpOr quantitative scheme
     """
-    return _scheme('PurpOr', bins, bin_method)
+    return scheme('PurpOr', bins, bin_method)
 
 
 def sunset(bins, bin_method=BinMethod.quantiles):
     """CartoColor Sunset quantitative scheme
     """
-    return _scheme('Sunset', bins, bin_method)
+    return scheme('Sunset', bins, bin_method)
 
 
 def magenta(bins, bin_method=BinMethod.quantiles):
     """CartoColor Magenta quantitative scheme
     """
-    return _scheme('Magenta', bins, bin_method)
+    return scheme('Magenta', bins, bin_method)
 
 
 def sunsetDark(bins, bin_method=BinMethod.quantiles):
     """CartoColor SunsetDark quantitative scheme
     """
-    return _scheme('SunsetDark', bins, bin_method)
+    return scheme('SunsetDark', bins, bin_method)
 
 
 def brwnYl(bins, bin_method=BinMethod.quantiles):
     """CartoColor BrwnYl quantitative scheme
     """
-    return _scheme('BrwnYl', bins, bin_method)
+    return scheme('BrwnYl', bins, bin_method)
 
 
 def armyRose(bins, bin_method=BinMethod.quantiles):
     """CartoColor ArmyRose divergent quantitative scheme
     """
-    return _scheme('ArmyRose', bins, bin_method)
+    return scheme('ArmyRose', bins, bin_method)
 
 
 def fall(bins, bin_method=BinMethod.quantiles):
     """CartoColor Fall divergent quantitative scheme
     """
-    return _scheme('Fall', bins, bin_method)
+    return scheme('Fall', bins, bin_method)
 
 
 def geyser(bins, bin_method=BinMethod.quantiles):
     """CartoColor Geyser divergent quantitative scheme
     """
-    return _scheme('Geyser', bins, bin_method)
+    return scheme('Geyser', bins, bin_method)
 
 
 def temps(bins, bin_method=BinMethod.quantiles):
     """CartoColor Temps divergent quantitative scheme
     """
-    return _scheme('Temps', bins, bin_method)
+    return scheme('Temps', bins, bin_method)
 
 
 def tealRose(bins, bin_method=BinMethod.quantiles):
     """CartoColor TealRose divergent quantitative scheme
     """
-    return _scheme('TealRose', bins, bin_method)
+    return scheme('TealRose', bins, bin_method)
 
 
 def tropic(bins, bin_method=BinMethod.quantiles):
     """CartoColor Tropic divergent quantitative scheme
     """
-    return _scheme('Tropic', bins, bin_method)
+    return scheme('Tropic', bins, bin_method)
 
 
 def earth(bins, bin_method=BinMethod.quantiles):
     """CartoColor Earth divergent quantitative scheme
     """
-    return _scheme('Earth', bins, bin_method)
+    return scheme('Earth', bins, bin_method)
 
 
 def antique(bins, bin_method=BinMethod.category):
     """CartoColor Antique qualitative scheme
     """
-    return _scheme('Antique', bins, bin_method)
+    return scheme('Antique', bins, bin_method)
 
 
 def bold(bins, bin_method=BinMethod.category):
     """CartoColor Bold qualitative scheme
     """
-    return _scheme('Bold', bins, bin_method)
+    return scheme('Bold', bins, bin_method)
 
 
 def pastel(bins, bin_method=BinMethod.category):
     """CartoColor Pastel qualitative scheme
     """
-    return _scheme('Pastel', bins, bin_method)
+    return scheme('Pastel', bins, bin_method)
 
 
 def prism(bins, bin_method=BinMethod.category):
     """CartoColor Prism qualitative scheme
     """
-    return _scheme('Prism', bins, bin_method)
+    return scheme('Prism', bins, bin_method)
 
 
 def safe(bins, bin_method=BinMethod.category):
     """CartoColor Safe qualitative scheme
     """
-    return _scheme('Safe', bins, bin_method)
+    return scheme('Safe', bins, bin_method)
 
 
 def vivid(bins, bin_method=BinMethod.category):
     """CartoColor Vivid qualitative scheme
     """
-    return _scheme('Vivid', bins, bin_method)
+    return scheme('Vivid', bins, bin_method)

--- a/test/test_styling.py
+++ b/test/test_styling.py
@@ -113,6 +113,6 @@ class TestColorScheme(unittest.TestCase):
                 'ramp([acadia], (#FFF,#888,#000), equal(3), <=)')
 
     def test_scheme(self):
-        """styling._scheme"""
-        self.assertEqual(styling._scheme('acadia', 27, 'jenks'),
+        """styling.scheme"""
+        self.assertEqual(styling.scheme('acadia', 27, 'jenks'),
                          dict(name='acadia', bins=27, bin_method='jenks'))


### PR DESCRIPTION
When using 'color' argument in Layer Class as a dictionary, the `scheme` key does not take a string type value. It requires a dictionary of the styling scheme. Docstring is changed in this PR to reflect this.

Attempting to color by numeric column by quantiles using a string for `scheme` fails:
```Python
# numeric
cc.map(layers=[BaseMap(),
               Layer('all_month_3',
                     color = {'column':'mag','scheme':'Sunset','bin_method':'quantiles','bins':5})], 
       interactive=True)
```
But this syntax works
```Python
cc.map(layers=[BaseMap(),
               Layer('all_month_3',
                     color = {'column':'mag','scheme':{'bin_method': 'quantiles', 'bins': 5, 'name': 'Sunset'}})],
       interactive=True)
```
And this works as well:

```Python
from cartoframes.styling import sunset
cc.map(layers=[BaseMap(),
               Layer('all_month_3',
                     color = {'column':'mag','scheme':sunset(5)})],
       interactive=True)
```