### PR TITLE
draws larger values on top

### DIFF
--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -295,7 +295,14 @@ class QueryLayer(AbstractLayer):
             # Since we're accessing min/max, convert range into a list
             size['range'] = list(size['range'])
             self.style_cols[size['column']] = None
-
+        if self.style_cols:
+            self.query = '''
+                SELECT * FROM ({query}) AS _orderwrap
+                ORDER BY {orders}
+                '''.format(
+                        query=self.query,
+                        orders=', '.join('{} ASC'.format(col)
+                                         for col in self.style_cols))
         self.color = color
         self.scheme = scheme
         self.size = size

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -177,9 +177,11 @@ class TestQueryLayer(unittest.TestCase):
                                   bins=','.join(str(i) for i in range(1, 11))))
         # expect category maps query
         self.assertRegexpMatches(ql.query,
-                                 '^SELECT orig\.\*, '
-                                 '__wrap.cf_value_colorcol.* '
-                                 'GROUP BY.*orig\.colorcol$')
+                                 ('^SELECT orig\.\*, '
+                                  '__wrap.cf_value_colorcol.* '))
+        # has order by style
+        self.assertRegexpMatches(ql.query,
+                                 '.*_orderwrap.*')
         # cartocss should have cdb math mode
         self.assertRegexpMatches(ql.cartocss,
                                  '.*CDB_Math_Mode\(cf_value_colorcol\).*')
@@ -200,8 +202,9 @@ class TestQueryLayer(unittest.TestCase):
                              styling.mint(5))
         # expect category maps query
         self.assertRegexpMatches(ql.query.strip(),
-                                 '^SELECT \*, colorcol as value '
-                                 '.*_wrap$')
+                                 '^SELECT\s\*,\scolorcol\sas\svalue.*')
+        self.assertRegexpMatches(ql.query,
+                                 '.*_orderwrap.*')
         # cartocss should have cdb math mode
         self.assertRegexpMatches(ql.cartocss,
                                  '.*avg\(colorcol\).*')


### PR DESCRIPTION
With this PR, larger values are drawn on top so they are more apparent if there is a large density of geometries. Compare the following.

Old behavior:
<img width="327" alt="screen shot 2017-10-24 at 14 09 54" src="https://user-images.githubusercontent.com/1041056/31963507-e7ae7060-b8ce-11e7-84df-324ae9d39e0a.png">

New behavior:
<img width="394" alt="screen shot 2017-10-24 at 14 08 34" src="https://user-images.githubusercontent.com/1041056/31963508-e7b841ee-b8ce-11e7-88ff-94bdde52b5a8.png">

This happens behind the scenes. The essential piece is this one:
https://github.com/CartoDB/cartoframes/pull/255/files#diff-68017a12a1b48d57202b94af67fafe4eR305

Current limitations:

* no user control over this behavior
* no control over which attribute is ordered first if, e.g., there is a color and size styling. There is currently no preference and results are likely to be non-deterministic (i.e., one user might get a map ordered by size first and color second, while another will have the opposite result).

closes #135 

cc @makella 