### PR TITLE
adds param for cartoframes client

### DIFF
--- a/test/test_context.py
+++ b/test/test_context.py
@@ -48,6 +48,8 @@ class TestCartoContext(unittest.TestCase):
                                                 api_key=self.apikey)
             self.sql_client = SQLClient(self.auth_client)
 
+        # sets client to be ci
+        cartoframes.context.default_sql_args['client'] += '_dev_ci'
         # sets skip value
         WILL_SKIP = self.apikey is None or self.username is None
 

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -49,7 +49,7 @@ class TestCartoContext(unittest.TestCase):
             self.sql_client = SQLClient(self.auth_client)
 
         # sets client to be ci
-        cartoframes.context.default_sql_args['client'] += '_dev_ci'
+        cartoframes.context.DEFAULT_SQL_ARGS['client'] += '_dev_ci'
         # sets skip value
         WILL_SKIP = self.apikey is None or self.username is None
 


### PR DESCRIPTION
@stuartlynn, this adds the `client` param for the SQL API to signal that cartoframes is being used. I still need to verify in kibana that it's going through.

Method coverage:

- [x] `CartoContext`: every time instantiated
- [x] `cc.read`: once for every time used
- [x] `cc.query`: once for every time used
- [x] `cc.map`: n times for each n-layer map created (only on data layers, excludes basemaps)
- [x] `cc.write`: once for every time used
- [x] `cc.delete`: Not used as there is no SQL in this method

## TODOs

- [x] update the tests to modify the version to `<version>_dev_ci`

Ref #238 