### PR TITLE
turbocarto and cartocss response text fix

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -839,19 +839,21 @@ class CartoContext(object):
 
             if time_layer:
                 # get turbo-carto processed cartocss
-                params.update(dict(callback='cartoframes'))
-                resp = requests.get(
-                        os.path.join(self.creds.base_url(),
-                                     'api/v1/map/named', map_name, 'jsonp'),
-                        params=params,
+                resp = self._auth_send(
+                        'api/v1/map/named/{}'.format(map_name),
+                        'POST',
+                        data=params['config'],
                         headers={'Content-Type': 'application/json'})
 
                 # check if errors in cartocss (already turbo-carto processed)
-                if "errors" not in resp.text:
-                    # replace previous cartocss with turbo-carto processed version
-                    layer.cartocss = json.loads(
-                            resp.text.split('&& cartoframes(')[1]
-                                .strip(');'))['metadata']['layers'][1]['meta']['cartocss']
+                if 'errors' not in resp:
+                    # replace previous cartocss with turbo-carto processed
+                    #  version
+                    layer.cartocss = (resp['metadata']
+                                          ['layers']
+                                          [1]
+                                          ['meta']
+                                          ['cartocss'])
                 config.update({
                     'order': 1,
                     'options': {

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -201,7 +201,7 @@ class CartoContext(object):
             :obj:`BatchJobStatus` or None: If `lnglat` flag is set and the
             DataFrame has more than 100,000 rows, a :obj:`BatchJobStatus`
             instance is returned. Otherwise, None.
-        """
+        """  # noqa
         if not os.path.exists(temp_dir):
             self._debug_print(temp_dir='creating directory at ' + temp_dir)
             os.makedirs(temp_dir)
@@ -739,7 +739,7 @@ class CartoContext(object):
                     LIMIT 0
                 '''.format(cols=','.join(layer.style_cols),
                            comma=',' if layer.style_cols else '',
-                           query=layer.query))
+                           query=layer.orig_query))
                 self._debug_print(layer_fields=resp)
                 for k, v in dict_items(resp['fields']):
                     layer.style_cols[k] = v['type']
@@ -927,11 +927,11 @@ class CartoContext(object):
             WHERE the_geom IS NOT NULL
             GROUP BY 1
             ORDER BY 2 DESC
-        '''.format(query=layer.query))
+        '''.format(query=layer.orig_query))
         if len(resp['rows']) > 1:
             warn('There are multiple geometry types in {query}: '
                  '{geoms}. Styling by `{common_geom}`, the most common'.format(
-                    query=layer.query,
+                    query=layer.orig_query,
                     geoms=','.join(g['geom_type'] for g in resp['rows']),
                     common_geom=resp['rows'][0]['geom_type']))
         return resp['rows'][0]['geom_type']
@@ -1113,7 +1113,7 @@ class CartoContext(object):
         extent_query = ('SELECT ST_EXTENT(the_geom) AS the_geom '
                         'FROM ({query}) AS t{idx}\n')
         union_query = 'UNION ALL\n'.join(
-            [extent_query.format(query=layer.query, idx=idx)
+            [extent_query.format(query=layer.orig_query, idx=idx)
              for idx, layer in enumerate(layers)
              if not layer.is_basemap])
 

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -846,10 +846,12 @@ class CartoContext(object):
                         params=params,
                         headers={'Content-Type': 'application/json'})
 
-                # replace previous cartocss with turbo-carto processed version
-                layer.cartocss = json.loads(
-                        resp.text.split('&& cartoframes(')[1]
-                            .strip(');'))['metadata']['layers'][1]['meta']['cartocss']
+                # check if errors in cartocss (already turbo-carto processed)
+                if "errors" not in resp.text:
+                    # replace previous cartocss with turbo-carto processed version
+                    layer.cartocss = json.loads(
+                            resp.text.split('&& cartoframes(')[1]
+                                .strip(');'))['metadata']['layers'][1]['meta']['cartocss']
                 config.update({
                     'order': 1,
                     'options': {

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -176,8 +176,8 @@ class QueryLayer(AbstractLayer):
             - trails (int, optional): Number of trails after the incidence of
               a point. Defaults to 2.
 
-            If `time` is a :obj:`str`, then it must be a column name available in
-            the query that is of type numeric or datetime.
+            If `time` is a :obj:`str`, then it must be a column name available
+            in the query that is of type numeric or datetime.
 
         color (dict or str, optional): Color style to apply to map.
             If `color` is a :obj:`dict`, the following keys are options, with
@@ -195,8 +195,8 @@ class QueryLayer(AbstractLayer):
               the `bin_method`. Defaults to 5.
 
         size (dict or int, optional): Size style to apply to point data.
-            If `size` is a :obj:`dict`, the follow keys are options, with values
-            described as:
+            If `size` is a :obj:`dict`, the follow keys are options, with
+            values described as:
 
             - column (str): Column to base sizing of points on
             - bin_method (str, optional): Quantification method for dividing
@@ -211,11 +211,12 @@ class QueryLayer(AbstractLayer):
 
         tooltip (tuple, optional): **Not yet implemented.**
         legend: **Not yet implemented.**
-    """
+    """  # noqa
     def __init__(self, query, time=None, color=None, size=None,
                  tooltip=None, legend=None):
 
         self.query = query
+        self.orig_query = query
         # style_cols and geom_type are updated right before layer is `_setup`
         # style columns as keys, data types as values
         self.style_cols = dict()
@@ -341,7 +342,8 @@ class QueryLayer(AbstractLayer):
             if self.geom_type != 'point':
                 raise ValueError('Cannot do time-based maps with data in '
                                  '`{query}` since this table does not contain '
-                                 'point geometries'.format(query=self.query))
+                                 'point geometries'.format(
+                                     query=self.orig_query))
             elif self.style_cols[self.time['column']] not in (
                     'number', 'date', ):
                 raise ValueError('Cannot create an animated map from column '
@@ -373,7 +375,7 @@ class QueryLayer(AbstractLayer):
                     '    ) AS _wrap',
                     ') AS __wrap',
                     'WHERE __wrap.{col} = orig.{col}',
-                ]]).format(col=self.color, query=self.query)
+                ]]).format(col=self.color, query=self.orig_query)
                 agg_func = '\'CDB_Math_Mode(cf_value_{})\''.format(self.color)
                 self.scheme = {
                         'bins': ','.join(str(i) for i in range(1, 11)),
@@ -386,7 +388,7 @@ class QueryLayer(AbstractLayer):
                 self.query = ' '.join([
                     'SELECT *, {col} as value',
                     'FROM ({query}) as _wrap'
-                ]).format(col=self.color, query=self.query)
+                ]).format(col=self.color, query=self.orig_query)
                 agg_func = '\'avg({})\''.format(self.color)
             else:
                 agg_func = "'{method}(cartodb_id)'".format(

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -325,3 +325,13 @@ class TestQueryLayer(unittest.TestCase):
             'bin_method': 'quantiles'
         }
         self.assertDictEqual(qlayer.size, ans)
+
+    def test_querylayer_get_cartocss(self):
+        """layer.QueryLayer._get_cartocss"""
+        qlayer = QueryLayer(self.query, size=dict(column='cold_brew', min=10,
+                                                  max=20))
+        self.assertRegex(
+            qlayer._get_cartocss(BaseMap()),
+            ('.*marker-width:\sramp\\(\\[cold_brew\\],\srange\\(10,20\\),\s'
+             'quantiles\\(5\\)\\).*')
+        )

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -330,8 +330,8 @@ class TestQueryLayer(unittest.TestCase):
         """layer.QueryLayer._get_cartocss"""
         qlayer = QueryLayer(self.query, size=dict(column='cold_brew', min=10,
                                                   max=20))
-        self.assertRegex(
+        self.assertRegexpMatches(
             qlayer._get_cartocss(BaseMap()),
-            ('.*marker-width:\sramp\\(\\[cold_brew\\],\srange\\(10,20\\),\s'
-             'quantiles\\(5\\)\\).*')
+            ('.*marker-width:\sramp\(\[cold_brew\],\srange\(10,20\),\s'
+             'quantiles\(5\)\).*')
         )

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -1,12 +1,28 @@
 """Unit tests for cartoframes.layers"""
 import unittest
-from cartoframes.layer import BaseMap, QueryLayer, AbstractLayer
+from cartoframes.layer import BaseMap, QueryLayer, AbstractLayer, Layer
 from cartoframes import styling
+import pandas as pd
 
 
 class TestAbstractLayer(unittest.TestCase):
     def test_class(self):
         self.assertIsNone(AbstractLayer().__init__())
+
+
+class TestLayer(unittest.TestCase):
+    def setUp(self):
+        self.coffee_temps = pd.DataFrame({
+            'a': range(4),
+            'b': list('abcd')
+        })
+
+    def test_layer_setup_dataframe(self):
+        """layer.Layer._setup()"""
+        layer = Layer('cortado', source=self.coffee_temps)
+
+        with self.assertRaises(NotImplementedError):
+            layer._setup([BaseMap(), layer], 1)
 
 
 class TestBaseMap(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the problem of requesting Turbocarto processed CartoCSS. When re-running a torque map; the request returns a response that contains errors. This PR fix checks for the term "error" in the response. If there no errors, the layer CartoCSS be replaced by the response text.

https://github.com/CartoDB/cartoframes/blob/c70b94ee7e0dea6e4e973d246b2a1b8904ed57fc/cartoframes/context.py#L843-L852

closes #249 