### PR TITLE
max and min marker-size range fix

### DIFF
--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -293,12 +293,13 @@ class QueryLayer(AbstractLayer):
             }
             # Assign default range and update if min/max given
             old_size['range'] = size['range']
-            if 'min' in old_size.keys():
+            if 'min' in old_size:
                 old_size['range'][0] = old_size['min']
-            if 'max' in old_size.keys():
+            if 'max' in old_size:
                 old_size['range'][1] = old_size['max']
             # Update all the keys in size if they exist in old_size
             size.update(old_size)
+            self.style_cols[size['column']] = None
 
         self.color = color
         self.scheme = scheme

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -182,7 +182,6 @@ class QueryLayer(AbstractLayer):
         color (dict or str, optional): Color style to apply to map.
             If `color` is a :obj:`dict`, the following keys are options, with
             values described:
-
             - column (str): Column to base coloring from.
             - scheme (str, optinal): Color scheme from
               `CartoColors
@@ -286,15 +285,19 @@ class QueryLayer(AbstractLayer):
                 raise ValueError("When time is specified, size can "
                                  "only be a fixed size")
             old_size = size
+            # Default size range, bins, and bin_method
             size = {
                 'range': [5, 25],
-                'bins': 10,
+                'bins': 5,
                 'bin_method': BinMethod.quantiles,
             }
+            # Input default range and update if min/max given
+            old_size['range'] = size['range']
+            if 'min' in old_size.keys():
+                old_size['range'][0] = old_size['min']
+            if 'max' in old_size.keys():
+                old_size['range'][1] = old_size['max']
             size.update(old_size)
-            # Since we're accessing min/max, convert range into a list
-            size['range'] = list(size['range'])
-            self.style_cols[size['column']] = None
 
         self.color = color
         self.scheme = scheme

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -291,12 +291,13 @@ class QueryLayer(AbstractLayer):
                 'bins': 5,
                 'bin_method': BinMethod.quantiles,
             }
-            # Input default range and update if min/max given
+            # Assign default range and update if min/max given
             old_size['range'] = size['range']
             if 'min' in old_size.keys():
                 old_size['range'][0] = old_size['min']
             if 'max' in old_size.keys():
                 old_size['range'][1] = old_size['max']
+            # Update all the keys in size if they exist in old_size
             size.update(old_size)
 
         self.color = color

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -292,11 +292,13 @@ class QueryLayer(AbstractLayer):
                 'bin_method': BinMethod.quantiles,
             }
             # Assign default range and update if min/max given
-            old_size['range'] = size['range']
+            old_size['range'] = old_size.get('range', size['range'])
             if 'min' in old_size:
                 old_size['range'][0] = old_size['min']
+                old_size.pop('min')
             if 'max' in old_size:
                 old_size['range'][1] = old_size['max']
+                old_size.pop('max')
             # Update all the keys in size if they exist in old_size
             size.update(old_size)
             self.style_cols[size['column']] = None

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -289,20 +289,39 @@ class TestQueryLayer(unittest.TestCase):
     def test_querylayer_size_defaults(self):
         """layer.QueryLayer gets defaults for options not passed"""
         qlayer = QueryLayer(self.query, size='cold_brew')
-        size_col_ans = {'column': 'cold_brew',
-                        'range': [5, 25],
-                        'bins': 10,
-                        'bin_method': 'quantiles'}
-        self.assertEqual(qlayer.size, size_col_ans,
-                         msg='size column should receive defaults')
+        size_col_ans = {
+            'column': 'cold_brew',
+            'range': [5, 25],
+            'bins': 5,
+            'bin_method': 'quantiles'
+        }
+        self.assertDictEqual(qlayer.size, size_col_ans,
+                             msg='size column should receive defaults')
 
-        qlayer = QueryLayer(self.query, size={'column': 'cold_brew',
-                                              'range': [4, 15],
-                                              'bin_method': 'equal'})
-        ans = {'column': 'cold_brew',
-               'range': [4, 15],
-               'bins': 10,
-               'bin_method': 'equal'}
-        self.assertEqual(qlayer.size, ans,
-                         msg=('size dict should receive defaults if not '
-                              'provided'))
+        qlayer = QueryLayer(self.query,
+                            size={
+                                'column': 'cold_brew',
+                                'range': [4, 15],
+                                'bin_method': 'equal'
+                            })
+        ans = {
+            'column': 'cold_brew',
+            'range': [4, 15],
+            'bins': 5,
+            'bin_method': 'equal'
+        }
+        self.assertDictEqual(qlayer.size, ans,
+                             msg=('size dict should receive defaults if not '
+                                  'provided'))
+        qlayer = QueryLayer(self.query, size={
+                                            'column': 'cold_brew',
+                                            'min': 10,
+                                            'max': 20
+                                        })
+        ans = {
+            'column': 'cold_brew',
+            'range': [10, 20],
+            'bins': 5,
+            'bin_method': 'quantiles'
+        }
+        self.assertDictEqual(qlayer.size, ans)


### PR DESCRIPTION
This PR allows the size parameters "max" and "min" to be set. Before, the defaults would override user input. Now, user inputs override defaults.