### PR TITLE
do not include default index when writing DataFrame

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -11,7 +11,6 @@ from warnings import warn
 import requests
 import IPython
 import pandas as pd
-import numpy as np
 from tqdm import tqdm
 from appdirs import user_cache_dir
 
@@ -218,10 +217,11 @@ class CartoContext(object):
             table_name = norm_colname(table_name)
             warn('Table will be named `{}`'.format(table_name))
 
-        # Issue warning if the index is anything but the Pandas default range index
-        if (df.index != np.arange(len(df))).any():
-            warn('CARTO dataset will not include DataFrame index. To include the index, '
-                 'use Pandas method `reset_index` before '
+        # issue warning if the index is anything but the pandas default
+        #  range index
+        if not df.index.equals(pd.RangeIndex(0, df.shape[0], 1)):
+            warn('CARTO dataset will not include DataFrame index. To '
+                 'include the index, use Pandas method `reset_index` before '
                  'writing the DataFrame to CARTO. ')
 
         if df.shape[0] > MAX_IMPORT_ROWS:

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -144,7 +144,7 @@ class CartoContext(object):
     def write(self, df, table_name, temp_dir=CACHE_DIR,
               overwrite=False, lnglat=None, encode_geom=False, geom_col=None,
               **kwargs):
-        """Write a DataFrame to a CARTO table. DataFrame index is not included.
+        """Write a DataFrame to a CARTO table.
 
         Example:
             Write a pandas DataFrame to CARTO.
@@ -201,43 +201,48 @@ class CartoContext(object):
             :obj:`BatchJobStatus` or None: If `lnglat` flag is set and the
             DataFrame has more than 100,000 rows, a :obj:`BatchJobStatus`
             instance is returned. Otherwise, None.
+
+        .. note::
+            DataFrame indexes are changed to ordinary columns. CARTO creates
+            an index called `cartodb_id` for every table that runs from 1 to
+            the length of the DataFrame.
         """
+        # work on a copy to avoid changing the original
+        _df = df.copy()
         if not os.path.exists(temp_dir):
             self._debug_print(temp_dir='creating directory at ' + temp_dir)
             os.makedirs(temp_dir)
         if encode_geom:
-            _add_encoded_geom(df, geom_col)
+            _add_encoded_geom(_df, geom_col)
 
         if not overwrite:
             # error if table exists and user does not want to overwrite
             self._table_exists(table_name)
 
-        pgcolnames = normalize_colnames(df.columns)
+        # issue warning if the index is anything but the pandas default
+        #  range index
+        if not _df.index.equals(pd.RangeIndex(0, _df.shape[0], 1)):
+            _df.reset_index(inplace=True)
+
+        pgcolnames = normalize_colnames(_df.columns)
         if table_name != norm_colname(table_name):
             table_name = norm_colname(table_name)
             warn('Table will be named `{}`'.format(table_name))
 
-        # issue warning if the index is anything but the pandas default
-        #  range index
-        if not df.index.equals(pd.RangeIndex(0, df.shape[0], 1)):
-            warn('CARTO dataset will not include DataFrame index. To '
-                 'include the index, use Pandas method `reset_index` before '
-                 'writing the DataFrame to CARTO. ')
-
-        if df.shape[0] > MAX_IMPORT_ROWS:
+        if _df.shape[0] > MAX_IMPORT_ROWS:
             # NOTE: schema is set using different method than in _set_schema
             # send placeholder table
-            final_table_name = self._send_dataframe(df.iloc[0:0], table_name,
+            final_table_name = self._send_dataframe(_df.iloc[0:0], table_name,
                                                     temp_dir, geom_col,
                                                     pgcolnames, kwargs)
             # send dataframe in batches, combine into placeholder table
-            final_table_name = self._send_batches(df, table_name, temp_dir,
+            final_table_name = self._send_batches(_df, table_name, temp_dir,
                                                   geom_col, pgcolnames, kwargs)
         else:
-            final_table_name = self._send_dataframe(df, table_name, temp_dir,
+            final_table_name = self._send_dataframe(_df, table_name, temp_dir,
                                                     geom_col, pgcolnames,
                                                     kwargs)
-            self._set_schema(df, final_table_name, pgcolnames)
+            self._set_schema(_df, final_table_name, pgcolnames)
 
         # create geometry column from long/lats if requested
         if lnglat:
@@ -249,7 +254,7 @@ class CartoContext(object):
                     '''.format(table_name=final_table_name,
                                lng=norm_colname(lnglat[0]),
                                lat=norm_colname(lnglat[1]))
-            if df.shape[0] > MAX_ROWS_LNGLAT:
+            if _df.shape[0] > MAX_ROWS_LNGLAT:
                 batch_client = BatchSQLClient(self.auth_client)
                 status = batch_client.create([query, ])
                 tqdm.write(
@@ -423,7 +428,7 @@ class CartoContext(object):
         tempfile = '{temp_dir}/{table_name}.csv'.format(temp_dir=temp_dir,
                                                         table_name=table_name)
         self._debug_print(tempfile=tempfile)
-        df.drop(geom_col, axis=1, errors='ignore').to_csv(path_or_buf=tempfile,
+        df.drop(labels=[geom_col], axis=1, errors='ignore').to_csv(path_or_buf=tempfile,
                                                           na_rep='',
                                                           header=pgcolnames,
                                                           index=False,

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -29,7 +29,7 @@ class TestCartoContext(unittest.TestCase):
                 creds = json.loads(open('test/secret.json').read())
                 self.apikey = creds['APIKEY']
                 self.username = creds['USERNAME']
-            except:
+            except:  # noqa: E722
                 warnings.warn("Skipping CartoContext tests. To test it, "
                               "create a `secret.json` file in test/ by "
                               "renaming `secret.json.sample` to `secret.json` "
@@ -49,7 +49,7 @@ class TestCartoContext(unittest.TestCase):
             self.sql_client = SQLClient(self.auth_client)
 
         # sets skip value
-        WILL_SKIP = self.apikey is None or self.username is None
+        WILL_SKIP = self.apikey is None or self.username is None  # noqa: F841
 
         # table naming info
         has_mpl = 'mpl' if os.environ.get('MPLBACKEND') else 'nonmpl'
@@ -60,35 +60,34 @@ class TestCartoContext(unittest.TestCase):
         self.valid_columns = set(['affgeoid', 'aland', 'awater', 'created_at',
                                   'csafp', 'geoid', 'lsad', 'name', 'the_geom',
                                   'updated_at'])
+        table_args = dict(ver=pyver, mpl=has_mpl)
         # torque table
         self.test_point_table = 'tweets_obama'
 
         # for writing to carto
         self.test_write_table = 'cartoframes_test_table_{ver}_{mpl}'.format(
-            ver=pyver,
-            mpl=has_mpl)
+            **table_args)
         self.mixed_case_table = 'AbCdEfG_{0}_{1}'.format(pyver, has_mpl)
 
         # for batch writing to carto
         self.test_write_batch_table = (
             'cartoframes_test_batch_table_{ver}_{mpl}'.format(
-                ver=pyver,
-                mpl=has_mpl))
+                **table_args))
 
         self.test_write_lnglat_table = (
             'cartoframes_test_write_lnglat_table_{ver}_{mpl}'.format(
-                ver=pyver,
-                mpl=has_mpl))
+                **table_args))
 
+        self.write_named_index = (
+                'cartoframes_test_write_non_default_index_{ver}_{mpl}'.format(
+                    **table_args))
         # for queries
         self.test_query_table = ('cartoframes_test_query_'
                                  'table_{ver}_{mpl}'.format(
-                                    ver=pyver,
-                                    mpl=has_mpl))
+                                    **table_args))
         self.test_delete_table = ('cartoframes_test_delete_'
                                   'table_{ver}_{mpl}').format(
-                                      ver=pyver,
-                                      mpl=has_mpl)
+                                      **table_args)
 
     def tearDown(self):
         """restore to original state"""
@@ -96,7 +95,8 @@ class TestCartoContext(unittest.TestCase):
                   self.test_write_batch_table,
                   self.test_write_lnglat_table,
                   self.test_query_table,
-                  self.mixed_case_table.lower(), )
+                  self.mixed_case_table.lower(),
+                  self.write_named_index, )
         sql_drop = 'DROP TABLE IF EXISTS {};'
 
         if self.apikey and self.baseurl:
@@ -140,7 +140,6 @@ class TestCartoContext(unittest.TestCase):
         saved_creds.save()
         cc_saved = cartoframes.CartoContext()
         self.assertEqual(cc_saved.creds.key(), self.apikey)
-
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_cartocontext_isorguser(self):
@@ -266,7 +265,7 @@ class TestCartoContext(unittest.TestCase):
         self.assertDictEqual(cols['fields'], expected_schema)
 
         # test properly encoding
-        df = pd.DataFrame({'vals':[1,2],'strings':['a','ô']})
+        df = pd.DataFrame({'vals': [1, 2], 'strings': ['a', 'ô']})
         cc.write(df, self.test_write_table, overwrite=True)
 
         # check if table exists
@@ -276,6 +275,23 @@ class TestCartoContext(unittest.TestCase):
             LIMIT 0
             '''.format(table=self.test_write_table))
         self.assertIsNotNone(resp)
+
+    @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
+    def test_cartocontext_write_index(self):
+        """context.CartoContext.write with non-default index"""
+        cc = cartoframes.CartoContext(base_url=self.baseurl,
+                                      api_key=self.apikey)
+        df = pd.DataFrame({
+                    'vals': range(3),
+                    'ids': list('abc')
+                },
+                index=list('xyz'))
+        df.index.name = 'named_index'
+        cc.write(df, self.write_named_index)
+
+        df_index = cc.read(self.write_named_index)
+        self.assertSetEqual(set(('the_geom', 'vals', 'ids', 'named_index')),
+                            set(df_index.columns))
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_cartocontext_mixed_case(self):
@@ -828,7 +844,7 @@ class TestBatchJobStatus(unittest.TestCase):
                 creds = json.loads(open('test/secret.json').read())
                 self.apikey = creds['APIKEY']
                 self.username = creds['USERNAME']
-            except:
+            except:  # noqa: E722
                 warnings.warn('Skipping CartoContext tests. To test it, '
                               'create a `secret.json` file in test/ by '
                               'renaming `secret.json.sample` to `secret.json` '
@@ -848,7 +864,7 @@ class TestBatchJobStatus(unittest.TestCase):
             self.sql_client = SQLClient(self.auth_client)
 
         # sets skip value
-        WILL_SKIP = self.apikey is None or self.username is None
+        WILL_SKIP = self.apikey is None or self.username is None  # noqa: F841
         has_mpl = 'mpl' if os.environ.get('MPLBACKEND') else 'nonmpl'
         pyver = sys.version[0:3].replace('.', '_')
 


### PR DESCRIPTION
The default pandas DataFrame index is not included when writing a DataFrame to CARTO. This is achieved by setting the index keyword argument to `False` in Pandas to_csv() method in the _send_dataframe() function.

If the index(es) is (are) anything other than the Pandas default, the dataframe's indexes are changed to normal columns with `DataFrame.reset_index()`, and that is sent to CARTO.

closes #221 