### PR TITLE
updates DataFrame.drop syntax for api change

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -420,10 +420,11 @@ class CartoContext(object):
         tempfile = '{temp_dir}/{table_name}.csv'.format(temp_dir=temp_dir,
                                                         table_name=table_name)
         self._debug_print(tempfile=tempfile)
-        df.drop(geom_col, axis=1, errors='ignore').to_csv(path_or_buf=tempfile,
-                                                          na_rep='',
-                                                          header=pgcolnames,
-                                                          encoding='utf-8')
+        df.drop(labels=[geom_col], axis=1, errors='ignore').to_csv(
+                path_or_buf=tempfile,
+                na_rep='',
+                header=pgcolnames,
+                encoding='utf-8')
 
         with open(tempfile, 'rb') as f:
             params = {'type_guessing': False}


### PR DESCRIPTION
pandas 0.21.0 includes an update to `DataFrame.drop` that breaks. This PR updates the syntax so the drop operation works with versions <= 0.21.0