### PR TITLE
Moves cc.query table creation to the Import API

### DIFF
--- a/test/test_context.py
+++ b/test/test_context.py
@@ -401,7 +401,7 @@ class TestCartoContext(unittest.TestCase):
                             msg='Should have the columns requested')
 
         # should have exected schema
-        expected_dtypes = ('object', 'object', 'object', 'int64',
+        expected_dtypes = ('object', 'object', 'object', 'float64',
                            'datetime64[ns]', 'object', )
         self.assertTupleEqual(expected_dtypes,
                               tuple(str(d) for d in df.dtypes),


### PR DESCRIPTION
By moving to the Import API, this avoids the undesirable ghost table problem that has been afflicting SQL-generated tables.

## ToDo

- There is some strange behavior when performing the `cc.query('...', table_name='...')` operation twice. The expectation is that it will fail if the table already exists (`collision_strategy=skip`), but the original table seems to disappear from the dataset dashboard instead. It is accessible from the SQL panel. Further, the second table is not created but no error is thrown.
- In light of the bug ^^^, I'll add a quick test to see if the table exists and fail if it does with a proper overwrite error, and add an inline code TODO about replacing this once the bug has been fixed.

closes #282, closes #272 