### PR TITLE
Add dependencies file so that all examples run on binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,7 @@
+cartoframes
+# Additional dependencies from examples
+matplotlib
+pandas
+geopandas
+dask
+


### PR DESCRIPTION
## Changelog

- Motivation: 2 of the example binders wouldn't work as-is because the Docker image that was built for them was missing a few python dependencies
- Fix: I added a `binder/requirements.txt` to separate `binder` example dependencies from the `requirements.txt` associated with installation of the `cartoframes` module. I tested 

Link to test: https://mybinder.org/v2/gh/hydrosquall/cartoframes/feature/add-binder-dependencies?filepath=examples

Hopefully this fix makes it easier for more people to try `cartoframes` without having to install anything locally. Separately, it looks like the failing Travis build is unrelated to this change, so I'm happy to rebase this branch at any point.

cc @andy-esch or any other project maintainers 