### PR TITLE
adds basic authentication-checking method

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -105,11 +105,23 @@ class CartoContext(object):
                                             session=session)
         self.sql_client = SQLClient(self.auth_client)
         self.creds.username(self.auth_client.username)
+        self._is_authenticated()
         self.is_org = self._is_org_user()
 
         self._map_templates = {}
         self._srcdoc = None
         self._verbose = verbose
+
+    def _is_authenticated(self):
+        """Checks if credentials allow for authenticated carto access"""
+        try:
+            self.sql_client.send(
+                    'select * from information_schema.tables limit 0')
+        except CartoException as err:
+            raise CartoException('Cannot authenticate user `{0}`. Check '
+                                 'credentials ({1}).'.format(
+                                     self.creds.username(),
+                                     err))
 
     def _is_org_user(self):
         """Report whether user is in a multiuser CARTO organization or not"""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -126,9 +126,9 @@ class TestCartoContext(unittest.TestCase):
         self.assertEqual(cc.creds.base_url(), self.baseurl.strip('/'))
         self.assertEqual(cc.creds.username(), self.username)
         self.assertTrue(not cc.is_org)
-        # TODO: how to test instances of a class?
-        # self.assertTrue(cc.auth_client.__dict__ == self.auth_client.__dict__)
-        # self.assertTrue(cc.sql_client.__dict__ == self.sql_client.__dict__)
+        with self.assertRaises(CartoException):
+            cartoframes.CartoContext(base_url=self.baseurl,
+                                     api_key='notavalidkey')
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_cartocontext_credentials(self):


### PR DESCRIPTION
This adds a basic method that errors if the user is not authenticated. It checks if cartoframes has access to the user's system tables (which require proper authentication).

@michellemho, could you ensure this works as expected?

closes #275 