### PR TITLE
adds default grey styling to null-valued column values

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -1013,6 +1013,9 @@ class CartoContext(object):
                     query=layer.orig_query,
                     geoms=','.join(g['geom_type'] for g in resp['rows']),
                     common_geom=resp['rows'][0]['geom_type']))
+        elif len(resp['rows']) == 0:
+            raise ValueError('No geometry for layer. Check all layer tables '
+                             'and queries to ensure there are geometries.')
         return resp['rows'][0]['geom_type']
 
     def data_boundaries(self, df=None, table_name=None):

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -1306,8 +1306,8 @@ class CartoContext(object):
                 median_income = cc.data_discovery('transaction_events',
                                                   regex='.*median income.*',
                                                   time='2011 - 2015')
-                df = cc.data(median_income,
-                             'transaction_event')
+                df = cc.data('transaction_events',
+                             median_income)
 
             Pass in cherry-picked measures from the Data Observatory catalog.
             The rest of the metadata will be filled in, but it's important to

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -476,10 +476,11 @@ class QueryLayer(AbstractLayer):
                     'comp-op': 'source-over',
                 }
             })
-            css += cssify({
-                '#layer[{} = null]'.format(self.color or 'cartodb_id'): {
-                    'marker-fill': '#666'}
-                })
+            if self.color in self.style_cols:
+                css += cssify({
+                    '#layer[{} = null]'.format(self.color): {
+                        'marker-fill': '#666'}
+                    })
             for t in range(1, self.time['trails'] + 1):
                 # Trails decay as 1/2^n, and grow 30% at each step
                 trail_temp = cssify({
@@ -503,10 +504,11 @@ class QueryLayer(AbstractLayer):
                         'marker-line-color': line_color,
                         'marker-line-opacity': '1',
                     }})
-                css += cssify({
-                    '#layer[{} = null]'.format(self.color or 'cartodb_id'): {
-                        'marker-fill': '#ccc'}
-                    })
+                if self.color in self.style_cols:
+                    css += cssify({
+                        '#layer[{} = null]'.format(self.color): {
+                            'marker-fill': '#ccc'}
+                        })
                 return css
             elif self.geom_type == 'line':
                 css = cssify({
@@ -514,10 +516,11 @@ class QueryLayer(AbstractLayer):
                         'line-width': '1.5',
                         'line-color': color_style,
                     }})
-                css += cssify({
-                    '#layer[{} = null]'.format(self.color or 'cartodb_id'): {
-                        'line-color': '#ccc'}
-                    })
+                if self.color in self.style_cols:
+                    css += cssify({
+                        '#layer[{} = null]'.format(self.color): {
+                            'line-color': '#ccc'}
+                        })
                 return css
             elif self.geom_type == 'polygon':
                 css = cssify({
@@ -530,10 +533,11 @@ class QueryLayer(AbstractLayer):
                         'line-opacity': '0.25',
                         'line-comp-op': 'hard-light',
                     }})
-                css += cssify({
-                    '#layer[{} = null]'.format(self.color or 'cartodb_id'): {
-                        'polygon-fill': '#ccc'}
-                    })
+                if self.color in self.style_cols:
+                    css += cssify({
+                        '#layer[{} = null]'.format(self.color): {
+                            'polygon-fill': '#ccc'}
+                        })
                 return css
             else:
                 raise ValueError('Unsupported geometry type: {}'.format(

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -476,6 +476,10 @@ class QueryLayer(AbstractLayer):
                     'comp-op': 'source-over',
                 }
             })
+            css += cssify({
+                '#layer[{} = null]'.format(self.color or 'cartodb_id'): {
+                    'marker-fill': '#666'}
+                })
             for t in range(1, self.time['trails'] + 1):
                 # Trails decay as 1/2^n, and grow 30% at each step
                 trail_temp = cssify({

--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -17,7 +17,7 @@ def cssify(css_dict):
             css += ' {field}: {field_value};'.format(field=field,
                                                      field_value=field_value)
         css += '} '
-    return css
+    return css.strip()
 
 
 def normalize_colnames(columns):

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -566,6 +566,16 @@ class TestCartoContext(unittest.TestCase):
             cc.map(layers=[Layer(self.test_read_table, time='cartodb_id'),
                            Layer(self.test_read_table, time='cartodb_id')])
 
+        # no geometry
+        with self.assertRaises(ValueError):
+            cc.map(layers=QueryLayer('''
+                SELECT
+                    null::geometry as the_geom,
+                    null::geometry as the_geom_webmercator,
+                    row_number() OVER () as cartodb_id
+                FROM generate_series(1, 10) as m(i)
+                '''))
+
     @unittest.skipIf(WILL_SKIP, 'no cartocredentials, skipping')
     def test_cartocontext_map_time(self):
         """CartoContext.map time options"""

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -362,6 +362,16 @@ class TestQueryLayer(unittest.TestCase):
         qlayer.geom_type = 'line'
         self.assertRegexpMatches(qlayer._get_cartocss(BaseMap()),
                                  '^\#layer.*line\-width.*$')
+        # test point, line, polygon
+        for g in ('point', 'line', 'polygon', ):
+            styles = {'point': 'marker\-fill',
+                      'line': 'line\-color',
+                      'polygon': 'polygon\-fill'}
+            qlayer = QueryLayer(self.query, color='colname')
+            qlayer.geom_type = g
+            self.assertRegexpMatches(qlayer._get_cartocss(BaseMap()),
+                                     '^\#layer.*{}.*\}}$'.format(styles[g]))
+
         # geometry type should be defined
         with self.assertRaises(ValueError,
                                msg='invalid geometry type'):

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -160,6 +160,7 @@ class TestQueryLayer(unittest.TestCase):
             qlayer = QueryLayer(self.query, color='datetime_column')
             qlayer.style_cols['datetime_column'] = 'date'
             qlayer._setup([BaseMap(), qlayer], 1)
+
         # Exception testing
         # color column cannot be a geometry column
         with self.assertRaises(ValueError,
@@ -355,3 +356,15 @@ class TestQueryLayer(unittest.TestCase):
             ('.*marker-width:\sramp\(\[cold_brew\],\srange\(10,20\),\s'
              'quantiles\(5\)\).*')
         )
+
+        # test line cartocss
+        qlayer = QueryLayer(self.query)
+        qlayer.geom_type = 'line'
+        self.assertRegexpMatches(qlayer._get_cartocss(BaseMap()),
+                                 '^\#layer.*line\-width.*$')
+        # geometry type should be defined
+        with self.assertRaises(ValueError,
+                               msg='invalid geometry type'):
+            ql = QueryLayer(self.query, color='red')
+            ql.geom_type = 'notvalid'
+            ql._get_cartocss(BaseMap())

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -145,6 +145,7 @@ class TestQueryLayer(unittest.TestCase):
 
         for idx, color in enumerate(str_colors):
             qlayer = QueryLayer(self.query, color=color)
+            qlayer.geom_type = 'point'
             if color == 'cookie_monster':
                 qlayer.style_cols[color] = 'number'
                 qlayer._setup([BaseMap(), qlayer], 1)
@@ -192,10 +193,12 @@ class TestQueryLayer(unittest.TestCase):
                              dict(name='Antique', bin_method='',
                                   bins=','.join(str(i) for i in range(1, 11))))
         # expect category maps query
+        with open('qlayerquery.txt', 'w') as f:
+            f.write(ql.query)
         self.assertRegexpMatches(ql.query,
-                                 '^SELECT orig\.\*, '
-                                 '__wrap.cf_value_colorcol.* '
-                                 'GROUP BY.*orig\.colorcol$')
+                                 '(?s)^SELECT\norig\.\*,\s__wrap\.'
+                                 'cf_value_colorcol\n.*GROUP\sBY.*orig\.'
+                                 'colorcol$')
         # cartocss should have cdb math mode
         self.assertRegexpMatches(ql.cartocss,
                                  '.*CDB_Math_Mode\(cf_value_colorcol\).*')
@@ -346,6 +349,7 @@ class TestQueryLayer(unittest.TestCase):
         """layer.QueryLayer._get_cartocss"""
         qlayer = QueryLayer(self.query, size=dict(column='cold_brew', min=10,
                                                   max=20))
+        qlayer.geom_type = 'point'
         self.assertRegexpMatches(
             qlayer._get_cartocss(BaseMap()),
             ('.*marker-width:\sramp\(\[cold_brew\],\srange\(10,20\),\s'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -85,7 +85,7 @@ class TestUtils(unittest.TestCase):
                           "marker-width: 6; marker-fill: yellow; "
                           "marker-fill-opacity: 1; marker-allow-overlap: "
                           "true; marker-line-width: 0.5; marker-line-color: "
-                          "black; marker-line-opacity: 1;} "),
+                          "black; marker-line-opacity: 1;}"),
                          msg="point style")
 
         # polygon style
@@ -96,7 +96,7 @@ class TestUtils(unittest.TestCase):
                           "#cc607d, #9e3963, #672044), quantiles); "
                           "polygon-opacity: 0.9; polygon-gamma: 0.5; "
                           "line-color: #FFF; line-width: 0.5; line-opacity: "
-                          "0.25; line-comp-op: hard-light;} "),
+                          "0.25; line-comp-op: hard-light;}"),
                          msg="polygon style")
 
         # complex style
@@ -113,7 +113,7 @@ class TestUtils(unittest.TestCase):
                           "polygon-fill: blue; polygon-opacity: 0.9; "
                           "polygon-gamma: 0.5; line-color: #FFF; line-width: "
                           "0.5; line-opacity: 0.25; "
-                          "line-comp-op: hard-light;} "),
+                          "line-comp-op: hard-light;}"),
                          msg="multi-layer styling")
 
     def test_norm_colname(self):


### PR DESCRIPTION
This PR adds default grey-styling to geometries that are null-valued if a user styles by a column.

Works in Animated maps and torque maps. Adds further checking of geometry types for fitness for mapping.

<img width="892" alt="screen shot 2017-12-07 at 12 53 15" src="https://user-images.githubusercontent.com/1041056/33730356-ba84a572-db4d-11e7-8577-8e12c86e96f3.png">

cc @makella @michellemho 

closes #276 