### PR TITLE
adds 404 page for documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ It is recommended to use `cartoframes` in Jupyter Notebooks (`pip install jupyte
 Virtual Environment
 -------------------
 
-To setup `cartoframes` and `Jupyter` in a `virtual environment <http://python-guide-pt-br.readthedocs.io/en/latest/dev/virtualenvs/#basic-usage>`__:
+To setup `cartoframes` and `Jupyter` in a `virtual environment <http://python-guide.readthedocs.io/en/latest/dev/virtualenvs/>`__:
 
 .. code:: bash
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>cartoframes documentation</title>
+    <link rel="stylesheet" href="_static/alabaster.css" type="text/css" />
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
+    <link rel="stylesheet" href="_static/custom.css" type="text/css" />
+    <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
+  </head>
+  <body>
+    <div class="document">
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+          <div class="body" role="main">
+            <div class="section" id="cartoframes-package">
+              <h1>CARTOframes documentation has moved!</h1>
+              <div class="section" id="submodules">
+                <p>Find current documentation here: <a href="https://cartoframes.readthedocs.io/">https://cartoframes.readthedocs.io/</a></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="sphinxsidebar" role="navigation" aria-label="main navigation"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the 404 page for the documentation. Once this merged into master and checked with gh-pages to work, all docs pages will be removed except for index, which will have the same content as this 404. This points to the new cartoframes docs: https://cartoframes.readthedocs.io/en/latest/


Ref #313 