### PR TITLE
adds option for including/excluding quantiles

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -1232,8 +1232,8 @@ class CartoContext(object):
             `time` filters is important for getting a manageable metadata
             set. Besides there being a large number of measures in the DO, a
             metadata response has acceptable combinations of measures with
-            demonimators (normalization and density), the same measure from
-            other years, and quantiles measurements.
+            demonimators (normalization and density), and the same measure from
+            other years.
 
             For example, setting the region to be United States counties with
             no filter values set will result in many thousands of measures.
@@ -1302,45 +1302,35 @@ class CartoContext(object):
 
         Raises:
             ValueError: If `region` is a :obj:`list` and does not consist of
-              four elements, or if `region` is neither an acceptable region
-              nor a table in user account.
+              four elements, or if `region` is not an acceptable region
+            CartoException: If `region` is not a table in user account
         """
-        if (isinstance(region, collections.Iterable)
-                and not isinstance(region, str)):
-            # TODO: should this also check to see if each item is a number?
-            if len(region) != 4:
-                raise ValueError('`region` should be a list of the geographic '
-                                 'bounds of a region in the following order: '
-                                 'western longitude, southern latitude, '
-                                 'eastern longitude, and northern latitude. '
-                                 'For example, Switerland fits in '
-                                 '``[5.9559111595,45.8179931641,10.4920501709,'
-                                 '47.808380127]``.')
-            boundary = ('SELECT ST_MakeEnvelope({0}, {1}, {2}, {3}, 4326) AS '
-                        'env, 500::int AS cnt'.format(*region))
-        elif isinstance(region, str):
+        if isinstance(region, str):
             try:
-                # see if it's a DO region
+                # see if it's a DO region, nest in {}
                 countrytag = '\'{{{0}}}\''.format(
                     get_countrytag(region))
                 boundary = ('SELECT ST_MakeEnvelope(-180.0, -85.0, 180.0, '
                             '85.0, 4326) AS env, 500::int AS cnt')
-            except ValueError as regiontag_err:
-                try:
-                    # TODO: make this work for general queries
-                    # see if it's a table
-                    self.sql_client.send('''
-                        EXPLAIN SELECT * FROM {0} LIMIT 0
-                    '''.format(region).strip())
-                    boundary = ('SELECT ST_SetSRID(ST_Extent(the_geom), '
-                                '4326) AS env, count(*)::int AS cnt '
-                                'FROM {table_name}').format(
-                                    table_name=region)
-                except CartoException:
-                    raise ValueError('`{0}` is neither a table in user '
-                                     'account nor an available Data '
-                                     'Observatory region. {1}'.format(
-                                         region, regiontag_err))
+            except ValueError:
+                # TODO: make this work for general queries
+                # see if it's a table
+                self.sql_client.send(
+                    'EXPLAIN SELECT * FROM {}'.format(region))
+                boundary = (
+                    'SELECT ST_SetSRID(ST_Extent(the_geom), 4326) AS env, '
+                    'count(*)::int AS cnt FROM {table_name}').format(
+                        table_name=region)
+        elif isinstance(region, collections.Iterable):
+            if len(region) != 4:
+                raise ValueError(
+                    '`region` should be a list of the geographic bounds of a '
+                    'region in the following order: western longitude, '
+                    'southern latitude, eastern longitude, and northern '
+                    'latitude. For example, Switerland fits in '
+                    '``[5.9559111595,45.8179931641,10.4920501709,47.808380127]``.')
+            boundary = ('SELECT ST_MakeEnvelope({0}, {1}, {2}, {3}, 4326) AS '
+                        'env, 500::int AS cnt'.format(*region))
 
         if locals().get('countrytag') is None:
             countrytag = 'null'
@@ -1349,32 +1339,27 @@ class CartoContext(object):
             if isinstance(keywords, str):
                 keywords = [keywords, ]
             kwsearch = ' OR '.join(
-                ('numer_description ilike \'%{kw}%\' OR '
-                 'numer_name ilike \'%{kw}%\'').format(kw=kw)
+                ('numer_description ILIKE \'%{kw}%\' OR '
+                 'numer_name ILIKE \'%{kw}%\'').format(kw=kw)
                 for kw in keywords)
             kwsearch = '({})'.format(kwsearch)
 
         if regex:
-            regexsearch = ('(numer_description ~* {regex} OR '
-                           'numer_name ~* {regex})').format(
-                               regex=utils.pgquote(regex))
+            regexsearch = ('(numer_description ~* {regex} OR numer_name '
+                           '~* {regex})').format(regex=utils.pgquote(regex))
 
         if keywords or regex:
             subjectfilters = '{kw} {op} {regex}'.format(
                 kw=kwsearch if keywords else '',
                 op='OR' if (keywords and regex) else '',
-                regex=regexsearch if regex else '')
+                regex=regexsearch if regex else '').strip()
         else:
             subjectfilters = ''
 
-        if isinstance(time, str):
+        if isinstance(time, str) or time is None:
             time = [time, ]
-        elif time is None:
-            time = [None, ]
-        if isinstance(boundaries, str):
+        if isinstance(boundaries, str) or boundaries is None:
             boundaries = [boundaries, ]
-        elif boundaries is None:
-            boundaries = [None, ]
 
         if all(time) and all(boundaries):
             bt_filters = 'valid_geom AND valid_timespan'
@@ -1384,17 +1369,15 @@ class CartoContext(object):
             bt_filters = ''
 
         if bt_filters and subjectfilters:
-            filters = 'WHERE ({s}) AND ({bt})'.format(s=subjectfilters,
-                                                      bt=bt_filters)
+            filters = 'WHERE ({s}) AND ({bt})'.format(
+                s=subjectfilters, bt=bt_filters)
         elif bt_filters or subjectfilters:
             filters = 'WHERE {f}'.format(f=subjectfilters or bt_filters)
         else:
             filters = ''
 
-        if not include_quantiles:
-            quantiles = 'WHERE numer_aggregate <> \'quantile\''
-        else:
-            quantiles = ''
+        quantiles = ('WHERE numer_aggregate <> \'quantile\''
+                     if not include_quantiles else '')
 
         numer_query = utils.minify_sql((
             'SELECT',
@@ -1406,12 +1389,12 @@ class CartoContext(object):
             '    OBS_GetAvailableNumerators(',
             '        (SELECT env FROM envelope),',
             '        {countrytag},',
-            '        null,',
+            '        null,',  # denom_id
             '        {geom_id},',
-            '        {timespan}',
-            '    )',
-            '{filters}', ))
+            '        {timespan})',
+            '{filters}', )).strip()
 
+        # query all numerators for all `time`, `boundaries`, and raw/derived
         numers = '\nUNION\n'.join(
             numer_query.format(
                 timespan=utils.pgquote(t),
@@ -1459,7 +1442,7 @@ class CartoContext(object):
             '{quantiles}', )).format(
                 boundary=boundary,
                 numers=numers,
-                quantiles=quantiles)
+                quantiles=quantiles).strip()
         self._debug_print(query=query)
         resp = self.sql_client.send(query)
         return pd.DataFrame(resp['rows'])

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -975,7 +975,7 @@ class TestCartoContext(unittest.TestCase):
                     nid,
                     '^au\.data\.B01_Indig_[A-Za-z_]+Torres_St[A-Za-z_]+[FMP]$')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(CartoException):
             cc.data_discovery('non_existent_table_abcdefg')
 
         dd = cc.data_discovery('United States',

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -983,6 +983,24 @@ class TestCartoContext(unittest.TestCase):
                                time=('2006', '2010', ))
         self.assertTrue(dd.shape[0] >= 1)
 
+        poverty = cc.data_discovery(
+            'United States',
+            boundaries='us.census.tiger.census_tract',
+            keywords=['poverty status', ],
+            time='2011 - 2015',
+            include_quantiles=False)
+        df_quantiles = poverty[poverty.numer_aggregate == 'quantile']
+        self.assertEqual(df_quantiles.shape[0], 0)
+
+        poverty = cc.data_discovery(
+            'United States',
+            boundaries='us.census.tiger.census_tract',
+            keywords=['poverty status', ],
+            time='2011 - 2015',
+            include_quantiles=True)
+        df_quantiles = poverty[poverty.numer_aggregate == 'quantile']
+        self.assertTrue(df_quantiles.shape[0] > 0)
+
     def test_data(self):
         """context.CartoContext.data"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,


### PR DESCRIPTION
Quantiles are not always a quantity that someone wants to include in the metadata output.

Some of the reasons for excluding them by default:
* It makes it more difficult to find the metadata data that's desired since including them can at most double the number of measures returned
* Many users are probably not find this measure useful or understand what it's purpose is
* These measures do not participate in the spatial interpolation that happens with arbitrary polygons which are augmented
* By having a special flag for quantiles, users can easily include them and be educated about their existence and purpose

closes #342 

cc @hannahblue