### PR TITLE
adds support for pre-defined bins

### DIFF
--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -242,6 +242,8 @@ class QueryLayer(AbstractLayer):
         # style columns as keys, data types as values
         self.style_cols = dict()
         self.geom_type = None
+        self.cartocss = None
+        self.torque_cartocss = None
 
         # TODO: move these if/else branches to individual methods
         # color, scheme = self._get_colorscheme()
@@ -407,11 +409,10 @@ class QueryLayer(AbstractLayer):
                 ]).format(col=self.color, query=self.orig_query)
                 agg_func = '\'CDB_Math_Mode(cf_value_{})\''.format(self.color)
                 self.scheme = {
-                        'bins': ','.join(str(i) for i in range(1, 11)),
-                        'name': (self.scheme.get('name') if self.scheme
-                                 else 'Bold'),
-                        'bin_method': '',
-                        }
+                    'bins': ','.join(str(i) for i in range(1, 11)),
+                    'name': (self.scheme.get('name') if self.scheme
+                             else 'Bold'),
+                    'bin_method': '', }
             elif (self.color in self.style_cols and
                   self.style_cols[self.color] in ('number', )):
                 self.query = ' '.join([
@@ -421,7 +422,7 @@ class QueryLayer(AbstractLayer):
                 agg_func = '\'avg({})\''.format(self.color)
             else:
                 agg_func = "'{method}(cartodb_id)'".format(
-                        method=method)
+                    method=method)
             self.torque_cartocss = cssify({
                 'Map': {
                     '-torque-frame-count': frames,
@@ -456,8 +457,8 @@ class QueryLayer(AbstractLayer):
 
         if self.scheme:
             color_style = get_scheme_cartocss(
-                    'value' if has_time else self.color,
-                    self.scheme)
+                'value' if has_time else self.color,
+                self.scheme)
         else:
             color_style = self.color
 
@@ -481,14 +482,14 @@ class QueryLayer(AbstractLayer):
                     '#layer[{} = null]'.format(self.color): {
                         'marker-fill': '#666'}
                     })
-            for t in range(1, self.time['trails'] + 1):
+            for trail_num in range(1, self.time['trails'] + 1):
                 # Trails decay as 1/2^n, and grow 30% at each step
                 trail_temp = cssify({
-                        '#layer[frame-offset={}]'.format(t): {
-                            'marker-width': size_style * (1.0 + t * 0.3),
-                            'marker-opacity': 0.9 / 2.0**t,
-                        }
-                    })
+                    '#layer[frame-offset={}]'.format(trail_num): {
+                        'marker-width': size_style * (1.0 + trail_num * 0.3),
+                        'marker-opacity': 0.9 / 2.0**trail_num,
+                    }
+                })
                 css += trail_temp
             return css
         else:

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -362,11 +362,10 @@ class QueryLayer(AbstractLayer):
             elif self.style_cols[self.color] in ('number', ):
                 self.scheme = mint(5)
             elif self.style_cols[self.color] in ('date', 'geometry', ):
-                raise ValueError('Cannot style column `{col}` of type '
-                                 '`{type}`. It must be numeric, text, or '
-                                 'boolean.'.format(
-                                     col=self.color,
-                                     type=self.style_cols[self.color]))
+                raise ValueError(
+                    'Cannot style column `{col}` of type `{type}`. It must be '
+                    'numeric, text, or boolean.'.format(
+                        col=self.color, type=self.style_cols[self.color]))
 
         if self.time:
             # validate time column information

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -16,12 +16,22 @@ class BinMethod:
         headtails (str): Head/Tails classification for quantitative data
         equal (str): Equal Interval classification for quantitative data
         category (str): Category classification for qualitative data
+        mapping (dict): The TurboCarto mappings
     """
     quantiles = 'quantiles'
     jenks = 'jenks'
     headtails = 'headtails'
     equal = 'equal'
     category = 'category'
+
+    # Mappings: https://github.com/CartoDB/turbo-carto/#mappings-default-values
+    mapping = {
+        quantiles: '>',
+        jenks: '>',
+        headtails: '<',
+        equal: '>',
+        category: '=',
+    }
 
 
 def get_scheme_cartocss(column, scheme_info):
@@ -35,13 +45,14 @@ def get_scheme_cartocss(column, scheme_info):
         bins = ','.join(str(i) for i in scheme_info['bins'])
     else:
         bins = scheme_info['bins']
+    comparison = ', {}'.format(BinMethod.mapping.get(bin_method, '>='))
     ramp = ('ramp([{column}], {color_scheme}, '
             '{bin_method}({bins}){comparison})').format(
                 column=column,
                 color_scheme=color_scheme,
                 bin_method=bin_method,
                 bins=bins,
-                comparison=('' if bin_method == 'category' else ', <='))
+                comparison=comparison)
     print(ramp)
     return ramp
 

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -5,7 +5,6 @@ in its `GitHub repository <https://github.com/Carto-color/>`__.
     :width: 700px
     :alt: CARTOColors
 """  # noqa
-import collections
 
 class BinMethod:
     """Data classification methods used for the styling of data on maps.
@@ -40,20 +39,19 @@ def get_scheme_cartocss(column, scheme_info):
         color_scheme = '({})'.format(','.join(scheme_info['colors']))
     else:
         color_scheme = 'cartocolor({})'.format(scheme_info['name'])
-    bin_method = scheme_info['bin_method']
     if not isinstance(scheme_info['bins'], int):
         bins = ','.join(str(i) for i in scheme_info['bins'])
     else:
         bins = scheme_info['bins']
+    bin_method = scheme_info['bin_method']
     comparison = ', {}'.format(BinMethod.mapping.get(bin_method, '>='))
-    ramp = ('ramp([{column}], {color_scheme}, '
+    return ('ramp([{column}], {color_scheme}, '
             '{bin_method}({bins}){comparison})').format(
                 column=column,
                 color_scheme=color_scheme,
                 bin_method=bin_method,
                 bins=bins,
                 comparison=comparison)
-    return ramp
 
 
 def custom(colors, bins=None, bin_method=BinMethod.quantiles):
@@ -79,8 +77,11 @@ def scheme(name, bins, bin_method):
 
     Args:
         name (str): Name of a CARTOColor.
-        bins (int): Number of bins for classifying data. CARTOColors have 7
-          bins max for quantitative data, and 11 max for qualitative data.
+        bins (int or iterable): If an `int`, the number of bins for classifying
+          data. CARTOColors have 7 bins max for quantitative data, and 11 max
+          for qualitative data. If `bins` is a `list`, it is the upper range
+          for classifying data. E.g., `bins` can be of the form ``(10, 20, 30,
+          40, 50)``.
         bin_method (str): One of methods in :obj:`BinMethod`.
 
     .. Warning::
@@ -93,8 +94,7 @@ def scheme(name, bins, bin_method):
     return {
         'name': name,
         'bins': bins,
-        'bin_method': (bin_method if not isinstance(bins, collections.Iterable)
-                       else ''),
+        'bin_method': (bin_method if isinstance(bins, int) else ''),
     }
 
 

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -53,7 +53,6 @@ def get_scheme_cartocss(column, scheme_info):
                 bin_method=bin_method,
                 bins=bins,
                 comparison=comparison)
-    print(ramp)
     return ramp
 
 

--- a/cartoframes/styling.py
+++ b/cartoframes/styling.py
@@ -5,7 +5,7 @@ in its `GitHub repository <https://github.com/Carto-color/>`__.
     :width: 700px
     :alt: CARTOColors
 """  # noqa
-
+import collections
 
 class BinMethod:
     """Data classification methods used for the styling of data on maps.
@@ -31,14 +31,19 @@ def get_scheme_cartocss(column, scheme_info):
     else:
         color_scheme = 'cartocolor({})'.format(scheme_info['name'])
     bin_method = scheme_info['bin_method']
-    return ('ramp([{column}], {color_scheme}, '
+    if not isinstance(scheme_info['bins'], int):
+        bins = ','.join(str(i) for i in scheme_info['bins'])
+    else:
+        bins = scheme_info['bins']
+    ramp = ('ramp([{column}], {color_scheme}, '
             '{bin_method}({bins}){comparison})').format(
                 column=column,
                 color_scheme=color_scheme,
                 bin_method=bin_method,
-                bins=scheme_info['bins'],
-                comparison=('' if bin_method == 'category' else ', <=')
-            )
+                bins=bins,
+                comparison=('' if bin_method == 'category' else ', <='))
+    print(ramp)
+    return ramp
 
 
 def custom(colors, bins=None, bin_method=BinMethod.quantiles):
@@ -78,7 +83,8 @@ def scheme(name, bins, bin_method):
     return {
         'name': name,
         'bins': bins,
-        'bin_method': bin_method,
+        'bin_method': (bin_method if not isinstance(bins, collections.Iterable)
+                       else ''),
     }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Map Styling Functions
 ---------------------
 .. automodule:: styling
     :members:
+    :member-order: bysource
 
 BatchJobStatus
 --------------

--- a/test/test_styling.py
+++ b/test/test_styling.py
@@ -84,6 +84,7 @@ class TestColorScheme(unittest.TestCase):
         self.assertEqual(self.temps['bin_method'], 'quantiles')
 
     def test_styling_values(self):
+        """styling.BinMethod, etc."""
         # Raise AttributeError if invalid name is entered
         with self.assertRaises(AttributeError):
             styling.apple(bins=4, BinMethod=BinMethod.quantiles)
@@ -100,23 +101,23 @@ class TestColorScheme(unittest.TestCase):
         """styling.get_scheme_cartocss"""
         # test on category
         self.assertEqual(get_scheme_cartocss('acadia', self.vivid),
-                         'ramp([acadia], cartocolor(Vivid), category(4))')
+                         'ramp([acadia], cartocolor(Vivid), category(4), =)')
         # test on quantative
         self.assertEqual(get_scheme_cartocss('acadia', self.purp),
-                         'ramp([acadia], cartocolor(Purp), quantiles(4), <=)')
+                         'ramp([acadia], cartocolor(Purp), quantiles(4), >)')
         # test on custom
         self.assertEqual(
             get_scheme_cartocss('acadia',
                                 styling.custom(('#FFF', '#888', '#000'),
                                                bins=3,
                                                bin_method='equal')),
-            'ramp([acadia], (#FFF,#888,#000), equal(3), <=)')
+            'ramp([acadia], (#FFF,#888,#000), equal(3), >)')
 
         # test with non-int quantification
         self.assertEqual(
             get_scheme_cartocss('acadia',
                                 styling.sunset([1, 2, 3])),
-            'ramp([acadia], cartocolor(Sunset), (1,2,3), <=)')
+            'ramp([acadia], cartocolor(Sunset), (1,2,3), >=)')
 
     def test_scheme(self):
         """styling.scheme"""

--- a/test/test_styling.py
+++ b/test/test_styling.py
@@ -106,11 +106,17 @@ class TestColorScheme(unittest.TestCase):
                          'ramp([acadia], cartocolor(Purp), quantiles(4), <=)')
         # test on custom
         self.assertEqual(
-                get_scheme_cartocss('acadia',
-                                    styling.custom(('#FFF', '#888', '#000'),
-                                                   bins=3,
-                                                   bin_method='equal')),
-                'ramp([acadia], (#FFF,#888,#000), equal(3), <=)')
+            get_scheme_cartocss('acadia',
+                                styling.custom(('#FFF', '#888', '#000'),
+                                               bins=3,
+                                               bin_method='equal')),
+            'ramp([acadia], (#FFF,#888,#000), equal(3), <=)')
+
+        # test with non-int quantification
+        self.assertEqual(
+            get_scheme_cartocss('acadia',
+                                styling.sunset([1, 2, 3])),
+            'ramp([acadia], cartocolor(Sunset), (1,2,3), <=)')
 
     def test_scheme(self):
         """styling.scheme"""


### PR DESCRIPTION
In addition to offloading bins to CARTO, users can pre-define bins like so:

```python
cc.map(Layer('table', color={'column': 'numercol',
                             'scheme': styling.sunset([1, 2, 3, 4])}))
```