### PR TITLE
moves table generation query to payload instead of param

### DIFF
--- a/test/test_context.py
+++ b/test/test_context.py
@@ -426,7 +426,7 @@ class TestCartoContext(unittest.TestCase):
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_cartoframes_query(self):
-        """cartoframes.CartoContext.query"""
+        """context.CartoContext.query"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
         cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )


### PR DESCRIPTION
in `CartoContext.query`, you can create a new table on carto, but long queries like you'd have with data observatory augmentation were causing a 414 (too long URI). So the query should be moved to the body of the POST. That's what this handles.

closes #310, closes #335 