### PR TITLE
updates manifest to include assets for sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-# include the license and readme files
-include LICENSE README.rst
+# include the license, README, and asset files
+include LICENSE README.rst cartoframes/assets/*


### PR DESCRIPTION
Asset files (just cartoframes.html) were not included in `sdist` packages because the were not listed in the MANIFEST.in.