### PR TITLE
adds shared user to read operations for shared tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ wheels/
 .installed.cfg
 *.egg
 
+# Swap files
+.*.sw[nop]
+
 # project-specific
 CARTOCREDS.json
 SITEKEY.txt

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -153,7 +153,7 @@ class CartoContext(object):
         return paths[0] != 'public'
 
     def read(self, table_name, limit=None, index='cartodb_id',
-             decode_geom=False, user_table=None):
+             decode_geom=False, shared_user=None):
         """Read a table from CARTO into a pandas DataFrames.
 
         Args:
@@ -179,9 +179,9 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
-        query = 'SELECT * FROM "{user}"."{table_name}"'.format(
+        query = 'SELECT * FROM "{shared_user}"."{table_name}"'.format(
             table_name=table_name,
-            user=shared_user or self.creds.username())
+            shared_user=shared_user or self.creds.username())
         if limit is not None:
             if isinstance(limit, int) and (limit >= 0):
                 query += ' LIMIT {limit}'.format(limit=limit)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -179,9 +179,11 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
-        query = 'SELECT * FROM "{shared_user}"."{table_name}"'.format(
+        schema = 'public' if self._is_org else (
+            shared_user or self.creds.username())
+        query = 'SELECT * FROM "{schema}"."{table_name}"'.format(
             table_name=table_name,
-            shared_user=shared_user or self.creds.username())
+            schema=schema)
         if limit is not None:
             if isinstance(limit, int) and (limit >= 0):
                 query += ' LIMIT {limit}'.format(limit=limit)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -153,7 +153,7 @@ class CartoContext(object):
         return paths[0] != 'public'
 
     def read(self, table_name, limit=None, index='cartodb_id',
-             decode_geom=False):
+             decode_geom=False, user_table=None):
         """Read a table from CARTO into a pandas DataFrames.
 
         Args:
@@ -165,6 +165,8 @@ class CartoContext(object):
               `Shapely <https://github.com/Toblerity/Shapely>`__
               object that can be used, for example, in `GeoPandas
               <http://geopandas.org/>`__.
+            user_table (str, optional): If a table has been shared with you,
+              specify the user name (schema) who shared it.
 
         Returns:
             pandas.DataFrame: DataFrame representation of `table_name` from
@@ -177,7 +179,9 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
-        query = 'SELECT * FROM "{table_name}"'.format(table_name=table_name)
+        query = 'SELECT * FROM "{user}"."{table_name}"'.format(
+            table_name=table_name,
+            user=shared_user or self.creds.username())
         if limit is not None:
             if isinstance(limit, int) and (limit >= 0):
                 query += ' LIMIT {limit}'.format(limit=limit)

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -179,7 +179,7 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
-        schema = 'public' if self.is_org else (
+        schema = 'public' if not self.is_org else (
             shared_user or self.creds.username())
         query = 'SELECT * FROM "{schema}"."{table_name}"'.format(
             table_name=table_name,

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -165,7 +165,7 @@ class CartoContext(object):
               `Shapely <https://github.com/Toblerity/Shapely>`__
               object that can be used, for example, in `GeoPandas
               <http://geopandas.org/>`__.
-            user_table (str, optional): If a table has been shared with you,
+            shared_user (str, optional): If a table has been shared with you,
               specify the user name (schema) who shared it.
 
         Returns:
@@ -179,6 +179,7 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
+        # choose schema (default user - org or standalone - or shared)
         schema = 'public' if not self.is_org else (
             shared_user or self.creds.username())
         query = 'SELECT * FROM "{schema}"."{table_name}"'.format(

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -179,7 +179,7 @@ class CartoContext(object):
                 cc = cartoframes.CartoContext(BASEURL, APIKEY)
                 df = cc.read('acadia_biodiversity')
         """
-        schema = 'public' if self._is_org else (
+        schema = 'public' if self.is_org else (
             shared_user or self.creds.username())
         query = 'SELECT * FROM "{schema}"."{table_name}"'.format(
             table_name=table_name,


### PR DESCRIPTION
In Builder, when a user shares a table with you, you access it by referencing the username as a schema like so: `select * from "shared_user"."table_name"`. This didn't play well with the `CartoContext.read` operation because table names were quoted. This PR addresses that by adding a `shared_user` argument (None by default) where someone can access the shared table.

closes #394 