### PR TITLE
Contrib add vector interactivity (click and hover events)

### DIFF
--- a/cartoframes/assets/vector.html
+++ b/cartoframes/assets/vector.html
@@ -68,27 +68,38 @@
                   closeButton: false,
                   closeOnClick: false
                 });
-        if (elem['interactivity'] == 'click') {
-          setPopupsClick(tempPopup, interactivity);
-        } else if (elem['interactivity'] == 'hover') {
-          setPopupsHover(tempPopup, interactivity);
+        if (elem.interactivity.event == 'click') {
+          setPopupsClick(tempPopup, interactivity, elem.interactivity.header);
+        } else if (elem.interactivity.event == 'hover') {
+          setPopupsHover(tempPopup, interactivity, elem.interactivity.header);
         }
       }
     });
-    function setPopupsClick(tempPopup, intera) {
-      intera.off('featureHover', (event) => {updatePopup(tempPopup, event)});
-      intera.on('featureClick', (event) => {updatePopup(tempPopup, event)});
+    function setPopupsClick(tempPopup, intera, popupHeader) {
+      intera.off('featureHover', (event) => {
+          updatePopup(tempPopup, event, popupHeader)
+      });
+      intera.on('featureClick', (event) => {
+          updatePopup(tempPopup, event, popupHeader, popupHeader)
+      });
     }
-    function setPopupsHover(tempPopup, intera) {
-      intera.off('featureClick', (event) => {updatePopup(tempPopup, event)});
-      intera.on('featureHover', (event) => {updatePopup(tempPopup, event)});
+    function setPopupsHover(tempPopup, intera, popupHeader) {
+      intera.off('featureClick', (event) => {
+          updatePopup(tempPopup, event, popupHeader)
+      });
+      intera.on('featureHover', (event) => {
+          updatePopup(tempPopup, event, popupHeader)
+      });
     }
-    function updatePopup(layer_popup, event) {
+    function updatePopup(layer_popup, event, popupHeader) {
       if (event.features.length > 0) {
         const vars = event.features[0].variables;
-        let popupHTML = '';
+        let popupHTML = popupHeader ? `<h1>${popupHeader}</h1>` : ``;
         Object.keys(vars).forEach((varName) => {
-            popupHTML += `<h3 class="h3">${varName}</h3><p class="description open-sans">${vars[varName].value}</p>`;
+            popupHTML += `
+                <h3 class="h3">${varName}</h3>
+                <p class="description open-sans">${vars[varName].value}</p>
+            `;
         });
         layer_popup.setLngLat([event.coordinates.lng, event.coordinates.lat])
              .setHTML(`<div>${popupHTML}</div>`);

--- a/cartoframes/assets/vector.html
+++ b/cartoframes/assets/vector.html
@@ -45,12 +45,6 @@
     });
     var sources = @@SOURCES@@;
 
-    // Define pop-up
-    const popup = new mapboxgl.Popup({
-              closeButton: false,
-              closeOnClick: false
-            });
-
     map.fitBounds(@@BOUNDS@@, {animate: false});
 
     sources.forEach((elem, idx) => {
@@ -70,20 +64,41 @@
       temp.addTo(map, last_source);
       if (elem.interactivity) {
         let interactivity = new carto.Interactivity(temp);
-        interactivity.on('featureClick', featureEvent => {
-            const coords = featureEvent.coordinates;
-            const feature = featureEvent.features[0];
-            if (!feature) { return; }
-            let popupHTML = '';
-            Object.keys(feature.variables).forEach((varName) => {
-                popupHTML += `<h3 class="h3">${varName}</h3><p class="description open-sans">${feature.variables[varName].value}</p>`;
-            });
-            popup.setLngLat([coords.lng, coords.lat])
-                 .setHTML(popupHTML)
-                 .addTo(map);
-        });
+        let tempPopup = new mapboxgl.Popup({
+                  closeButton: false,
+                  closeOnClick: false
+                });
+        if (elem['interactivity'] == 'click') {
+          setPopupsClick(tempPopup, interactivity);
+        } else if (elem['interactivity'] == 'hover') {
+          setPopupsHover(tempPopup, interactivity);
+        }
       }
     });
+    function setPopupsClick(tempPopup, intera) {
+      intera.off('featureHover', (event) => {updatePopup(tempPopup, event)});
+      intera.on('featureClick', (event) => {updatePopup(tempPopup, event)});
+    }
+    function setPopupsHover(tempPopup, intera) {
+      intera.off('featureClick', (event) => {updatePopup(tempPopup, event)});
+      intera.on('featureHover', (event) => {updatePopup(tempPopup, event)});
+    }
+    function updatePopup(layer_popup, event) {
+      if (event.features.length > 0) {
+        const vars = event.features[0].variables;
+        let popupHTML = '';
+        Object.keys(vars).forEach((varName) => {
+            popupHTML += `<h3 class="h3">${varName}</h3><p class="description open-sans">${vars[varName].value}</p>`;
+        });
+        layer_popup.setLngLat([event.coordinates.lng, event.coordinates.lat])
+             .setHTML(`<div>${popupHTML}</div>`);
+        if (!layer_popup.isOpen()) {
+          layer_popup.addTo(map);
+        }
+      } else {
+        layer_popup.remove();
+      }
+    }
   </script>
 </body>
 </html>

--- a/cartoframes/assets/vector.html
+++ b/cartoframes/assets/vector.html
@@ -61,6 +61,22 @@
       );
       var last_source = idx === 0 ? 'watername_ocean' : 'layer' + (idx - 1);
       temp.addTo(map, last_source);
+      if (elem.interactivity) {
+        let interactivity = new carto.Interactivity(temp);
+        interactivity.on('featureClick', featureEvent => {
+            const coords = featureEvent.coordinates;
+            const feature = featureEvent.features[0];
+            if (!feature) { return; }
+            let popupHTML = '';
+            Object.keys(feature.variables).forEach((varName) => {
+              popupHTML += '<h2>' + varName + '</h2><p>' + feature.variables[varName].value + '</p>';
+            });
+            new mapboxgl.Popup()
+                .setLngLat([coords.lng, coords.lat])
+                .setHTML(popupHTML)
+                .addTo(map);
+        });
+      }
     });
   </script>
 </body>

--- a/cartoframes/assets/vector.html
+++ b/cartoframes/assets/vector.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Multi layer | CARTO</title>
+  <title>CARTO VL + CARTOframes</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
   <!-- Include CARTO VL JS -->
-  <script src="https://cartodb.github.io/carto-vl/dist/carto-vl.min.js"></script>
+  <script src="https://cartodb.github.io/carto-vl/dist/carto-vl.js"></script>
   <!-- Include Mapbox GL JS -->
-  <script src="https://cartodb-libs.global.ssl.fastly.net/mapbox-gl/v0.44.1-carto1/mapbox-gl.js"></script>
+  <script src="https://cartodb-libs.global.ssl.fastly.net/mapbox-gl/v0.45.0-carto1/mapbox-gl.js"></script>
   <!-- Include Mapbox GL CSS -->
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css" rel="stylesheet" />
+  <link href="https://cartodb-libs.global.ssl.fastly.net/mapbox-gl/v0.45.0-carto1/mapbox-gl.css" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="https://cartodb.github.io/carto-vl/examples/style.css">
   <style>
     body {
       margin: 0;
@@ -44,6 +45,12 @@
     });
     var sources = @@SOURCES@@;
 
+    // Define pop-up
+    const popup = new mapboxgl.Popup({
+              closeButton: false,
+              closeOnClick: false
+            });
+
     map.fitBounds(@@BOUNDS@@, {animate: false});
 
     sources.forEach((elem, idx) => {
@@ -69,12 +76,11 @@
             if (!feature) { return; }
             let popupHTML = '';
             Object.keys(feature.variables).forEach((varName) => {
-              popupHTML += '<h2>' + varName + '</h2><p>' + feature.variables[varName].value + '</p>';
+                popupHTML += `<h3 class="h3">${varName}</h3><p class="description open-sans">${feature.variables[varName].value}</p>`;
             });
-            new mapboxgl.Popup()
-                .setLngLat([coords.lng, coords.lat])
-                .setHTML(popupHTML)
-                .addTo(map);
+            popup.setLngLat([coords.lng, coords.lat])
+                 .setHTML(popupHTML)
+                 .addTo(map);
         });
       }
     });

--- a/cartoframes/contrib/vector.py
+++ b/cartoframes/contrib/vector.py
@@ -70,6 +70,7 @@ class QueryLayer(object):
         self.is_basemap = False
         self.styling = ''
         self.interactivity = None
+        self.header = None
 
         self._compose_style()
 
@@ -101,6 +102,7 @@ class QueryLayer(object):
             interactive_cols = '@{0}: ${0}'.format(interactivity)
         elif isinstance(interactivity, dict):
             self.interactivity = interactivity.get('event', 'click')
+            self.header = interactivity.get('header')
             interactive_cols = '\n'.join(
                 '@{0}: ${0}'.format(col) for col in interactivity['cols']
             )
@@ -201,11 +203,16 @@ def vmap(layers, context):
     jslayers = []
     for idx, layer in enumerate(layers):
         is_local = isinstance(layer, LocalLayer)
+        intera = (
+            dict(event=layer.interactivity, header=layer.header)
+            if layer.interactivity is not None
+            else None
+        )
         jslayers.append({
             'is_local': is_local,
             'styling': layer.styling,
             'source': layer.geojson_str if is_local else layer.query,
-            'interactivity': layer.interactivity
+            'interactivity': intera
         })
     html = '<iframe srcdoc="{content}" width=800 height=400></iframe>'.format(
         content=utils.safe_quotes(

--- a/cartoframes/contrib/vector.py
+++ b/cartoframes/contrib/vector.py
@@ -71,7 +71,7 @@ class QueryLayer(object):
         self.styling = '\n'.join(
             '{prop}: {style}'.format(prop=s, style=getattr(self, s))
             for s in valid_styles
-            if hasattr(self, s)
+            if getattr(self, s) is not None
         )
 
 def _get_html_doc(sources, bounds, creds=None, local_sources=None, basemap=None):

--- a/cartoframes/contrib/vector.py
+++ b/cartoframes/contrib/vector.py
@@ -69,7 +69,7 @@ class QueryLayer(object):
         self.orig_query = query
         self.is_basemap = False
         self.styling = ''
-        self.interactivity = interactivity is not None
+        self.interactivity = None
 
         self._compose_style()
 
@@ -90,17 +90,21 @@ class QueryLayer(object):
     def _set_interactivity(self, interactivity):
         """Adds interactivity syntax to the styling"""
         if isinstance(interactivity, list) or isinstance(interactivity, tuple):
+            self.interactivity = 'click'
             interactive_cols = '\n'.join(
                 '@{0}: ${0}'.format(col) for col in interactivity
             )
         elif isinstance(interactivity, str):
+            self.interactivity = 'click'
             interactive_cols = '@{0}: ${0}'.format(interactivity)
         elif isinstance(interactivity, dict):
+            self.interactivity = interactivity.get('event', 'click')
             interactive_cols = '\n'.join(
                 '@{0}: ${0}'.format(col) for col in interactivity['cols']
             )
         else:
-            return
+            raise ValueError('`interactivity` must be a str, a list of str, '
+                             'or a dict a `cols` key')
 
         self.styling = '\n'.join([interactive_cols, self.styling])
 

--- a/cartoframes/contrib/vector.py
+++ b/cartoframes/contrib/vector.py
@@ -89,7 +89,9 @@ class QueryLayer(object):
 
     def _set_interactivity(self, interactivity):
         """Adds interactivity syntax to the styling"""
-        if isinstance(interactivity, list) or isinstance(interactivity, tuple):
+        if interactivity is None:
+            return
+        elif isinstance(interactivity, list) or isinstance(interactivity, tuple):
             self.interactivity = 'click'
             interactive_cols = '\n'.join(
                 '@{0}: ${0}'.format(col) for col in interactivity

--- a/cartoframes/contrib/vector.py
+++ b/cartoframes/contrib/vector.py
@@ -41,6 +41,15 @@ class QueryLayer(object):
           Default is white.
         strokeWidth (float or str, optional): Defines the width of the stroke in
           pixels. Default is 1.
+        interactivity (str, list, or dict, optional): This option add
+          interactivity (click or hover) to a layer. Three types of inputs are
+          possible:
+
+          dict: If a :obj:`dict`, this must have the key `cols` with its value
+            a list of columns. Optionall add `event` to choose ``hover`` or
+            ``click``.
+          list: A list of valid column names in the data used for this layer
+          str: A column name in the data used in this layer
     """
     def __init__(self, query, color=None, size=None, time=None,
                  strokeColor=None, strokeWidth=None, interactivity=None):

--- a/test/test_contrib_vector.py
+++ b/test/test_contrib_vector.py
@@ -137,4 +137,25 @@ class TestContribVector(unittest.TestCase, _UserUrlLoader):
             ]
             self.assertIsInstance(vector.vmap(layers, cc), HTML)
 
+    def test_vector_interactivity(self):
+        """contrib.vector"""
+        cc = cartoframes.CartoContext(base_url=self.baseurl,
+                                      api_key=self.apikey)
+        layers = [
+            vector.Layer(self.points, interactivity='body'),
+            vector.QueryLayer(
+                'SELECT * FROM {}'.format(self.polys),
+                interactivity=['name', 'state_name', ]),
+            vector.QueryLayer(
+                'SELECT * FROM {}'.format(self.polys),
+                interactivity={
+                    'cols': ['name', 'state_name', ],
+                    'header': '<h1 class="h1">NAT</h1>',
+                    'event': 'click'
+                })
+        ]
+        self.assertIsInstance(vector.vmap(layers, cc), HTML)
 
+        # invalid entry for interactivity
+        self.assertRaises(ValueError):
+            vector.vmap([vector.Layer(self.points, interactivity=10), ])

--- a/test/test_contrib_vector.py
+++ b/test/test_contrib_vector.py
@@ -157,5 +157,5 @@ class TestContribVector(unittest.TestCase, _UserUrlLoader):
         self.assertIsInstance(vector.vmap(layers, cc), HTML)
 
         # invalid entry for interactivity
-        self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             vector.vmap([vector.Layer(self.points, interactivity=10), ])


### PR DESCRIPTION
This adds popups for all types of layers.

Example:
```python
from cartoframes.contrib import vector
from cartoframes import CartoContext
cc = CartoContext()

layers = [
    vector.Layer(
        'brooklyn_poverty',
         interactivity=[
             'poverty_per_pop', 'total_population', 'walked_to_work_2011_2015'
         ]
    )
]
vector.vmap(layers, context=cc)
```

![vectormaps](https://user-images.githubusercontent.com/1041056/40728525-4953732c-63f8-11e8-9fcb-79679adc44a3.gif)

## ToDo

- [x] click events
- [x] hover events
- [x] adds optional header field
- [ ] conforms to carto style guidelines (waiting to hear from @ivanmalagon)
