### PR TITLE
Adds customizable line styling for carto.js/raster maps

### DIFF
--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -315,8 +315,11 @@ class QueryLayer(AbstractLayer):
 
         self.query = query
         self.orig_query = query
+
         # style_cols and geom_type are updated right before layer is `_setup`
+        # because of this, any geometry related styling happens in `_setup`
         # style columns as keys, data types as values
+        # e.g., dict(my_col='numeric', other_col='text')
         self.style_cols = dict()
         self.geom_type = None
         self.cartocss = None
@@ -326,10 +329,13 @@ class QueryLayer(AbstractLayer):
         self.color, self.scheme = self._parse_color(color)
         self.time = self._parse_time(time)
         self.size = self._parse_size(size, time is not None)
-
         self.opacity = opacity if opacity is not None else 0.9
+
+        # future enhanements
         self.tooltip = tooltip
         self.legend = legend
+
+        # validation step
         self._validate_columns()
 
     def _parse_color(self, color):
@@ -359,7 +365,7 @@ class QueryLayer(AbstractLayer):
         return color, scheme
 
     def _parse_time(self, time):
-        """Setup the default time styling"""
+        """Parse time inputs"""
         if time is None:
             return None
 
@@ -389,7 +395,7 @@ class QueryLayer(AbstractLayer):
         return time
 
     def _parse_size(self, size, has_time=False):
-        """"""
+        """Parse size inputs"""
         if has_time:
             size = size or 4
         else:

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -323,30 +323,12 @@ class QueryLayer(AbstractLayer):
         self.torque_cartocss = None
 
         # TODO: move these if/else branches to individual methods
-        # color, scheme = self._get_colorscheme()
         # time = self._get_timescheme()
         # size = self._get_sizescheme()
         # If column was specified, force a scheme
         # It could be that there is a column named 'blue' for example
-        if isinstance(color, dict):
-            if 'column' not in color:
-                raise ValueError("Color must include a 'column' value")
-            # get scheme if exists. if not, one will be chosen later if needed
-            scheme = color.get('scheme')
-            color = color['column']
-            self.style_cols[color] = None
-        elif (color and
-              color[0] != '#' and
-              color not in webcolors.CSS3_NAMES_TO_HEX):
-            # color specified that is not a web color or hex value so its
-            #  assumed to be a column name
-            color = color
-            self.style_cols[color] = None
-            scheme = None
-        else:
-            # assume it's a color (hex, rgb(...),  or webcolor name)
-            color = color
-            scheme = None
+
+        self.color, self.scheme = self._set_color(color)
 
         if time:
             if isinstance(time, dict):
@@ -405,14 +387,37 @@ class QueryLayer(AbstractLayer):
             size.update(old_size)
             self.style_cols[size['column']] = None
 
-        self.color = color
         self.opacity = opacity if opacity is not None else 0.9
-        self.scheme = scheme
         self.size = size
         self.time = time
         self.tooltip = tooltip
         self.legend = legend
         self._validate_columns()
+
+    def _set_color(self, color):
+        """Setup the color scheme"""
+        if isinstance(color, dict):
+            if 'column' not in color:
+                raise ValueError("Color must include a 'column' value")
+            # get scheme if exists. if not, one will be chosen later if needed
+            scheme = color.get('scheme')
+            color = color['column']
+            self.style_cols[color] = None
+        elif (color and
+              color[0] != '#' and
+              color not in webcolors.CSS3_NAMES_TO_HEX):
+            # color specified that is not a web color or hex value so its
+            #  assumed to be a column name
+            color = color
+            self.style_cols[color] = None
+            scheme = None
+        else:
+            # assume it's a color (hex, rgb(...),  or webcolor name)
+            color = color
+            scheme = None
+
+        return color, scheme
+
 
     def _validate_columns(self):
         """Validate the options in the styles"""

--- a/cartoframes/layer.py
+++ b/cartoframes/layer.py
@@ -439,6 +439,8 @@ class QueryLayer(AbstractLayer):
                                  col=','.join(col_overlap)))
 
     def _setup(self, layers, layer_idx):
+        """Setups layers once geometry types and data types are known
+        """
         basemap = layers[0]
 
         # if color not specified, choose a default
@@ -450,15 +452,7 @@ class QueryLayer(AbstractLayer):
             self.color = self.color or DEFAULT_COLORS[layer_idx]
         # choose appropriate scheme if not already specified
         if (not self.scheme) and (self.color in self.style_cols):
-            if self.style_cols[self.color] in ('string', 'boolean', ):
-                self.scheme = antique(10)
-            elif self.style_cols[self.color] in ('number', ):
-                self.scheme = mint(5)
-            elif self.style_cols[self.color] in ('date', 'geometry', ):
-                raise ValueError(
-                    'Cannot style column `{col}` of type `{type}`. It must be '
-                    'numeric, text, or boolean.'.format(
-                        col=self.color, type=self.style_cols[self.color]))
+            self._choose_scheme()
 
         if self.time:
             # validate time column information
@@ -532,6 +526,18 @@ class QueryLayer(AbstractLayer):
         else:
             # use turbo-carto for non-animated maps
             self.cartocss = self._get_cartocss(basemap)
+
+    def _choose_scheme(self):
+        """Choose color scheme"""
+        if self.style_cols[self.color] in ('string', 'boolean', ):
+            self.scheme = antique(10)
+        elif self.style_cols[self.color] in ('number', ):
+            self.scheme = mint(5)
+        elif self.style_cols[self.color] in ('date', 'geometry', ):
+            raise ValueError(
+                'Cannot style column `{col}` of type `{type}`. It must be '
+                'numeric, text, or boolean.'.format(
+                    col=self.color, type=self.style_cols[self.color]))
 
     def _get_cartocss(self, basemap, has_time=False):
         """Generate cartocss for class properties"""

--- a/test/test_layer.py
+++ b/test/test_layer.py
@@ -49,6 +49,13 @@ class TestBaseMap(unittest.TestCase):
         self.voyager_only_labels = BaseMap(source='voyager',
                                            only_labels=True)
 
+    def test_basemap_repr(self):
+        """layer.Basemap.__repr__"""
+        self.assertEqual(
+            self.dark_only_labels.__repr__(),
+            'BaseMap(source=dark, labels=back, only_labels=True)'
+        )
+
     def test_basemap_invalid(self):
         """layer.Basemap exceptions on invalid source"""
         # Raise ValueError if invalid label is entered
@@ -309,6 +316,7 @@ class TestQueryLayer(unittest.TestCase):
     def test_querylayer_size_defaults(self):
         """layer.QueryLayer gets defaults for options not passed"""
         qlayer = QueryLayer(self.query, size='cold_brew')
+        qlayer.geom_type = 'point'
         size_col_ans = {
             'column': 'cold_brew',
             'range': [5, 25],


### PR DESCRIPTION
This PR
- Adds styling customization options to line-based data layers in raster maps (carto.js and static maps)
- Refactors the layers code to have more separable methods

Example:

![image](https://user-images.githubusercontent.com/1041056/48557613-37efff00-e8b5-11e8-95eb-f879cbcfdf95.png)

Using:

```python
from cartoframes import styling
linelayer = QueryLayer(
    '''with cte as (
        SELECT
            ST_Segmentize(ST_MakeLine(the_geom, cdb_latlng(38, -122))::geography, 1000)::geometry as the_geom, mag
            FROM all_month_3 order by time limit 10)
    SELECT the_geom, 1, st_transform(the_geom, 3857) as the_geom_webmercator, mag, 10 * (row_number() OVER ()) as size_col
    from cte
    ''',
    size={'column': 'size_col', 'range': [2, 6]},
    color={'column': 'mag', 'scheme': styling.sunset(7)}
)
cc.map(linelayer, interactive=False)
```