### PR TITLE
Fix tqdm lock issue

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -59,6 +59,9 @@ CACHE_DIR = user_cache_dir('cartoframes')
 # cartoframes version
 DEFAULT_SQL_ARGS = dict(do_post=False)
 
+# avoid _lock issue: https://github.com/tqdm/tqdm/issues/457
+tqdm(disable=True, total=0)  # initialise internal lock
+
 
 class CartoContext(object):
     """CartoContext class for authentication with CARTO and high-level

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     'pandas>=0.20.1',
     'webcolors>=1.7.0',
     'carto>=1.4.0',
-    'tqdm>=4.14.0,!=4.18.0',
+    'tqdm>=4.14.0',
     'appdirs>=1.4.3',
 ]
 


### PR DESCRIPTION
tqdm v 4.29.0 introduced an issue with the `_lock` attribute not being present, similar to the issue in 4.18.0. Here we add a config line for tqdm that solves the issue.