### PR TITLE
moves df query schema to rely on types instead of string versions

### DIFF
--- a/test/test_context.py
+++ b/test/test_context.py
@@ -479,14 +479,12 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
                             msg='Should have the columns requested')
 
         # should have exected schema
-        expected_dtypes = (str, str, str, float,
-                           datetime, str, )
-        for col, dtype in zip(df.columns, expected_dtypes):
-            self.assertTrue(
-                    isinstance(getattr(df, col).iloc[0], dtype),
-                    msg='Should have expected type: {0} ({1})'.format(
-                        col, str(dtype))
-                )
+        expected_dtypes = ('object', 'object', 'object', 'float64',
+                           'datetime64[ns, UTC]', 'object', )
+        self.assertTrue(
+                (str(d) for d in df.dtypes),
+                msg='Should have same schema/types'
+            )
 
         # empty response
         df_empty = cc.query('''

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -481,7 +481,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         expected_dtypes = ('object', 'object', 'object', 'float64',
                            'datetime64[ns, UTC]', 'object', )
         self.assertTupleEqual(
-            (str(d) for d in df.dtypes),
+            tuple(str(d) for d in df.dtypes),
             expected_dtypes,
             msg='Should have same schema/types'
         )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -482,8 +482,11 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         expected_dtypes = (str, str, str, float,
                            datetime, str, )
         for col, dtype in zip(df.columns, expected_dtypes):
-            self.assertTrue(isinstance(getattr(df, col).iloc[0], dtype),
-                            msg='Should have expected schema')
+            self.assertTrue(
+                    isinstance(getattr(df, col).iloc[0], dtype),
+                    msg='Should have expected type: {0} ({1})'.format(
+                        col, str(dtype))
+                )
 
         # empty response
         df_empty = cc.query('''

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -451,6 +451,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
     def test_cartoframes_query(self):
         """context.CartoContext.query"""
+        from datetime import datetime
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
         cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )
@@ -461,7 +462,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
             '''.format(cols=','.join(cols)))
 
         # ensure columns are in expected order
-        df = df[list(cols) + ['invalid_df_date']]
+        df = df[list(cols) + ['invalid_df_date', ]]
 
         # same number of rows
         self.assertEqual(len(df), 100,
@@ -478,11 +479,11 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
                             msg='Should have the columns requested')
 
         # should have exected schema
-        expected_dtypes = ('object', 'object', 'object', 'float64',
-                           'datetime64[ns]', 'object', )
-        self.assertTupleEqual(expected_dtypes,
-                              tuple(str(d) for d in df.dtypes),
-                              msg='Should have expected schema')
+        expected_dtypes = (str, str, str, float,
+                           datetime, str, )
+        for col, dtype in zip(df.columns, expected_dtypes):
+            self.assertTrue(isinstance(getattr(df, col).iloc[0], dtype),
+                            msg='Should have expected schema')
 
         # empty response
         df_empty = cc.query('''

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -22,6 +22,7 @@ from utils import _UserUrlLoader
 WILL_SKIP = False
 warnings.filterwarnings("ignore")
 
+
 class TestCartoContext(unittest.TestCase, _UserUrlLoader):
     """Tests for cartoframes.CartoContext"""
     def setUp(self):
@@ -70,7 +71,6 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         self.valid_columns = set(['affgeoid', 'aland', 'awater', 'created_at',
                                   'csafp', 'geoid', 'lsad', 'name', 'the_geom',
                                   'updated_at'])
-        table_args = dict(ver=pyver, mpl=has_mpl, gpd=has_gpd)
         # torque table
         self.test_point_table = 'tweets_obama'
 
@@ -449,9 +449,8 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         self.assertIsNone(cc.sync(pd.DataFrame(), 'acadia'))
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping')
-    def test_cartoframes_query(self):
+    def test_cartocontext_query(self):
         """context.CartoContext.query"""
-        from datetime import datetime
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
         cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )
@@ -481,10 +480,11 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         # should have exected schema
         expected_dtypes = ('object', 'object', 'object', 'float64',
                            'datetime64[ns, UTC]', 'object', )
-        self.assertTrue(
-                (str(d) for d in df.dtypes),
-                msg='Should have same schema/types'
-            )
+        self.assertTupleEqual(
+            (str(d) for d in df.dtypes),
+            expected_dtypes,
+            msg='Should have same schema/types'
+        )
 
         # empty response
         df_empty = cc.query('''


### PR DESCRIPTION
pandas latest includes timezones in the `datetime64[ns]` type and our tests rely flimsily on the string rep of the dtypes.