### PR TITLE
fixes bug where legends disappear if more than one layer without legends

### DIFF
--- a/cartoframes/assets/vector.html
+++ b/cartoframes/assets/vector.html
@@ -121,8 +121,6 @@
               document.getElementById('legends').style.display = 'block';
               // Place list items in the content section of the title/legend box
               document.getElementById('legends').innerHTML += legend;
-          } else {
-              document.getElementById('legends').style.display = 'none';
           }
       });
  


### PR DESCRIPTION
If more than one layer was added, the legend check code went to the `else` block and hid the legend. The problem is that if a legend already exists, it is hidden for subsequent layers.