### PR TITLE
Docs: use `username` instead of `user` in Credentials

### DIFF
--- a/docs/developer-center/_internal/reference/07-CartoContext.md
+++ b/docs/developer-center/_internal/reference/07-CartoContext.md
@@ -20,7 +20,7 @@ There are two ways of authenticating against a CARTO account:
 
     ```python
     from cartoframes import Credentials
-    creds = Credentials(user='eschbacher', key='abcdefg')
+    creds = Credentials(username='eschbacher', key='abcdefg')
     cc = CartoContext(creds=creds)
     ```
 

--- a/docs/developer-center/guides/01-Quickstart.md
+++ b/docs/developer-center/guides/01-Quickstart.md
@@ -71,7 +71,7 @@ cc = CartoContext(
 
 ```python
 from cartoframes import Credentials, CartoContext
-creds = Credentials(user='<your_user_name>', key='<your_api_key>')
+creds = Credentials(username='<your_user_name>', key='<your_api_key>')
 cc = CartoContext(creds=creds)
 ```
 
@@ -79,7 +79,7 @@ You can also save your credentials to use later, independent of the Python sessi
 
 ```python
 from cartoframes import Credentials, CartoContext
-creds = Credentials(user='<your_user_name>', key='<your_api_key>')
+creds = Credentials(username='<your_user_name>', key='<your_api_key>')
 creds.save()  # save credentials for later use (not dependent on Python session)
 ```
 


### PR DESCRIPTION
Fix Credentials parameter name in docs: `username` instead of `user`