### PR TITLE
install carto SDK from Github master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-carto>=1.3.1
+-e git+https://github.com/CartoDB/carto-python.git#egg=carto
 pyrestcli>=0.6.3
 pandas>=0.19.2
 webcolors==1.7


### PR DESCRIPTION
While in development let's install the SDK from Github and let's fix the version only when doing a release.