### PR TITLE
Map Postgres schema to dataframe schema on read

### DIFF
--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -156,4 +156,4 @@ def pg2dtypes(pgtype):
         'timestamp without time zone': 'datetime64[ns]',
         'USER-DEFINED': 'object',
     }
-    return mapping.get(str(pgtype), 'object')
+    return mapping.get(str(pgtype), None)

--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -123,20 +123,31 @@ def normalize_name(column_name):
 
 
 def dtypes(columns, exclude_dates=False):
-    return {x.name: x.dtype for x in columns if not (exclude_dates is True and x.pgtype == 'date')}
+    return {x.name: x.dtype for x in columns if not (exclude_dates is True and x.dtype == 'datetime64[ns]')}
 
 
 def date_columns_names(columns):
-    return [x.name for x in columns if x.pgtype == 'date']
+    return [x.name for x in columns if x.dtype == 'datetime64[ns]']
 
 
 def pg2dtypes(pgtype):
     """Returns equivalent dtype for input `pgtype`."""
     mapping = {
-        'date': 'datetime64[ns]',
-        'number': 'float64',
-        'string': 'object',
+        'bigint': 'int64',
         'boolean': 'bool',
+        'date': 'datetime64[ns]',
+        'double precision': 'float64',
         'geometry': 'object',
+        'int': 'int64',
+        'integer': 'int64',
+        'number': 'float64',
+        'numeric': 'float64',
+        'real': 'float64',
+        'smallint': 'int32',
+        'string': 'object',
+        'timestamp': 'datetime64[ns]',
+        'timestamp with time zone': 'datetime64[ns]',
+        'timestamp without time zone': 'datetime64[ns]',
+        'USER-DEFINED': 'object',
     }
     return mapping.get(str(pgtype), 'object')

--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -156,4 +156,4 @@ def pg2dtypes(pgtype):
         'timestamp without time zone': 'datetime64[ns]',
         'USER-DEFINED': 'object',
     }
-    return mapping.get(str(pgtype), None)
+    return mapping.get(str(pgtype), 'object')

--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -7,7 +7,9 @@ from unidecode import unidecode
 
 
 class Column(object):
-    DATETIME_DTYPES = ['datetime64[ns]', 'datetime64[ns, UTC]']
+    DATETIME_DTYPES = ['datetime64[D]', 'datetime64[ns]', 'datetime64[ns, UTC]']
+    SUPPORTED_GEOM_COL_NAMES = ['geom', 'the_geom', 'geometry']
+    RESERVED_COLUMN_NAMES = SUPPORTED_GEOM_COL_NAMES + ['the_geom_webmercator', 'cartodb_id']
     MAX_LENGTH = 63
     MAX_COLLISION_LENGTH = MAX_LENGTH - 4
     RESERVED_WORDS = ('ALL', 'ANALYSE', 'ANALYZE', 'AND', 'ANY', 'ARRAY', 'AS', 'ASC', 'ASYMMETRIC', 'AUTHORIZATION',
@@ -123,9 +125,10 @@ def normalize_name(column_name):
     return normalize_names([column_name])[0]
 
 
-def dtypes(columns, exclude_dates=False):    
+def dtypes(columns, exclude_dates=False, exclude_the_geom=False):
     return {x.name: x.dtype if not x.name == 'cartodb_id' else 'int64'
-            for x in columns if not (exclude_dates is True and x.dtype in Column.DATETIME_DTYPES)}
+            for x in columns if not (exclude_dates is True and x.dtype in Column.DATETIME_DTYPES)
+            and not(exclude_the_geom is True and x.name in Column.SUPPORTED_GEOM_COL_NAMES)}
 
 
 def date_columns_names(columns):

--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -123,7 +123,8 @@ def normalize_name(column_name):
 
 
 def dtypes(columns, exclude_dates=False):
-    return {x.name: x.dtype for x in columns if not (exclude_dates is True and x.dtype == 'datetime64[ns]')}
+    return {x.name: x.dtype if not x.name == 'cartodb_id' else 'int64'
+            for x in columns if not (exclude_dates is True and x.dtype == 'datetime64[ns]')}
 
 
 def date_columns_names(columns):
@@ -133,17 +134,17 @@ def date_columns_names(columns):
 def pg2dtypes(pgtype):
     """Returns equivalent dtype for input `pgtype`."""
     mapping = {
-        'bigint': 'int64',
+        'bigint': 'float64',
         'boolean': 'bool',
         'date': 'datetime64[ns]',
         'double precision': 'float64',
         'geometry': 'object',
         'int': 'int64',
-        'integer': 'int64',
+        'integer': 'float64',
         'number': 'float64',
         'numeric': 'float64',
         'real': 'float64',
-        'smallint': 'int32',
+        'smallint': 'float64',
         'string': 'object',
         'timestamp': 'datetime64[ns]',
         'timestamp with time zone': 'datetime64[ns]',

--- a/cartoframes/columns.py
+++ b/cartoframes/columns.py
@@ -7,6 +7,7 @@ from unidecode import unidecode
 
 
 class Column(object):
+    DATETIME_DTYPES = ['datetime64[ns]', 'datetime64[ns, UTC]']
     MAX_LENGTH = 63
     MAX_COLLISION_LENGTH = MAX_LENGTH - 4
     RESERVED_WORDS = ('ALL', 'ANALYSE', 'ANALYZE', 'AND', 'ANY', 'ARRAY', 'AS', 'ASC', 'ASYMMETRIC', 'AUTHORIZATION',
@@ -122,13 +123,13 @@ def normalize_name(column_name):
     return normalize_names([column_name])[0]
 
 
-def dtypes(columns, exclude_dates=False):
+def dtypes(columns, exclude_dates=False):    
     return {x.name: x.dtype if not x.name == 'cartodb_id' else 'int64'
-            for x in columns if not (exclude_dates is True and x.dtype == 'datetime64[ns]')}
+            for x in columns if not (exclude_dates is True and x.dtype in Column.DATETIME_DTYPES)}
 
 
 def date_columns_names(columns):
-    return [x.name for x in columns if x.dtype == 'datetime64[ns]']
+    return [x.name for x in columns if x.dtype in Column.DATETIME_DTYPES]
 
 
 def pg2dtypes(pgtype):
@@ -136,7 +137,7 @@ def pg2dtypes(pgtype):
     mapping = {
         'bigint': 'float64',
         'boolean': 'bool',
-        'date': 'datetime64[ns]',
+        'date': 'datetime64[D]',
         'double precision': 'float64',
         'geometry': 'object',
         'int': 'int64',
@@ -147,6 +148,7 @@ def pg2dtypes(pgtype):
         'smallint': 'float64',
         'string': 'object',
         'timestamp': 'datetime64[ns]',
+        'timestampz': 'datetime64[ns]',
         'timestamp with time zone': 'datetime64[ns]',
         'timestamp without time zone': 'datetime64[ns]',
         'USER-DEFINED': 'object',

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -452,7 +452,7 @@ class CartoContext(object):
         result = recursive_read(self, copy_query)
 
         query_columns = get_columns(self, query)
-        df_types = dtypes(query_columns, exclude_dates=True, exclude_the_geom=decode_geom)
+        df_types = dtypes(query_columns, exclude_dates=True, exclude_the_geom=True)
         date_column_names = date_columns_names(query_columns)
 
         df = pd.read_csv(result, dtype=df_types,

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -207,7 +207,8 @@ class CartoContext(object):
         return res['rows'][0]['unnest'] != 'public'
 
     def read(self, table_name, limit=None, decode_geom=False, shared_user=None, retry_times=3):
-        """Read a table from CARTO into a pandas DataFrames.
+        """Read a table from CARTO into a pandas DataFrames. Column types are inferred from database types, to
+          avoid problems with integer columns with NA or null values, they are automatically retrieved as float64
 
         Args:
             table_name (str): Name of table in user's CARTO account.
@@ -410,17 +411,17 @@ class CartoContext(object):
 
               .. code:: python
 
-                {'bigint': 'int64',
+                {'bigint': 'float64',
                  'boolean': 'bool',
                  'date': 'datetime64[ns]',
                  'double precision': 'float64',
                  'geometry': 'object',
                  'int': 'int64',
-                 'integer': 'int64',
+                 'integer': 'float64',
                  'number': 'float64',
                  'numeric': 'float64',
                  'real': 'float64',
-                 'smallint': 'int32',
+                 'smallint': 'float64',
                  'string': 'object',
                  'timestamp': 'datetime64[ns]',
                  'timestamp with time zone': 'datetime64[ns]',
@@ -578,17 +579,17 @@ class CartoContext(object):
 
               .. code:: python
 
-                {'bigint': 'int64',
+                {'bigint': 'float64',
                  'boolean': 'bool',
                  'date': 'datetime64[ns]',
                  'double precision': 'float64',
                  'geometry': 'object',
                  'int': 'int64',
-                 'integer': 'int64',
+                 'integer': 'float64',
                  'number': 'float64',
                  'numeric': 'float64',
                  'real': 'float64',
-                 'smallint': 'int32',
+                 'smallint': 'float64',
                  'string': 'object',
                  'timestamp': 'datetime64[ns]',
                  'timestamp with time zone': 'datetime64[ns]',

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -289,6 +289,9 @@ class CartoContext(object):
                 cc.map(layers=Layer('life_expectancy',
                                     color='both_sexes_life_expectancy'))
 
+        .. warning:: datetime64[ns] column will lose precision sending a dataframe to CARTO
+                     because postgresql has millisecond resolution while pandas does nanoseconds
+
         Args:
             df (pandas.DataFrame): DataFrame to write to ``table_name`` in user
                 CARTO account
@@ -413,7 +416,7 @@ class CartoContext(object):
 
                 {'bigint': 'float64',
                  'boolean': 'bool',
-                 'date': 'datetime64[ns]',
+                 'date': 'datetime64[D]',
                  'double precision': 'float64',
                  'geometry': 'object',
                  'int': 'int64',
@@ -424,6 +427,7 @@ class CartoContext(object):
                  'smallint': 'float64',
                  'string': 'object',
                  'timestamp': 'datetime64[ns]',
+                 'timestampz': 'datetime64[ns]',
                  'timestamp with time zone': 'datetime64[ns]',
                  'timestamp without time zone': 'datetime64[ns]',
                  'USER-DEFINED': 'object',}
@@ -481,7 +485,7 @@ class CartoContext(object):
                          parse_dates=date_column_names,
                          true_values=['t'],
                          false_values=['f'],
-                         index_col='cartodb_id' if 'cartodb_id' in df_types.keys() else False,
+                         index_col='cartodb_id' if 'cartodb_id' in df_types else False,
                          converters={'the_geom': lambda x: _decode_geom(x) if decode_geom else x})
 
         if decode_geom:
@@ -581,7 +585,7 @@ class CartoContext(object):
 
                 {'bigint': 'float64',
                  'boolean': 'bool',
-                 'date': 'datetime64[ns]',
+                 'date': 'datetime64[D]',
                  'double precision': 'float64',
                  'geometry': 'object',
                  'int': 'int64',
@@ -592,6 +596,7 @@ class CartoContext(object):
                  'smallint': 'float64',
                  'string': 'object',
                  'timestamp': 'datetime64[ns]',
+                 'timestampz': 'datetime64[ns]',
                  'timestamp with time zone': 'datetime64[ns]',
                  'timestamp without time zone': 'datetime64[ns]',
                  'USER-DEFINED': 'object',}

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -1580,7 +1580,6 @@ class CartoContext(object):
                 names[suggested] = suggested
 
         # drop description columns to lighten the query
-        # FIXME https://github.com/CartoDB/cartoframes/issues/593
         meta_columns = _meta.columns.values
         drop_columns = []
         for meta_column in meta_columns:

--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -404,6 +404,28 @@ class CartoContext(object):
               `Shapely <https://github.com/Toblerity/Shapely>`__
               object that can be used, for example, in `GeoPandas
               <http://geopandas.org/>`__.
+            query_columns (list, optional): A list of `cartoframes.column.Column` to infer data types. You should
+              create `Column` instances this way: Column('column_name', pgtype='the_database_type') where
+              `the_database_type` is mapped using this dictionary:
+
+              .. code:: python
+
+                {'bigint': 'int64',
+                 'boolean': 'bool',
+                 'date': 'datetime64[ns]',
+                 'double precision': 'float64',
+                 'geometry': 'object',
+                 'int': 'int64',
+                 'integer': 'int64',
+                 'number': 'float64',
+                 'numeric': 'float64',
+                 'real': 'float64',
+                 'smallint': 'int32',
+                 'string': 'object',
+                 'timestamp': 'datetime64[ns]',
+                 'timestamp with time zone': 'datetime64[ns]',
+                 'timestamp without time zone': 'datetime64[ns]',
+                 'USER-DEFINED': 'object',}
 
         Returns:
             pandas.DataFrame: DataFrame representation of query supplied.
@@ -550,6 +572,28 @@ class CartoContext(object):
               By default `is_select=None` that means that the method will return a dataframe if
               the `query` starts with a `select` clause, otherwise it will just execute the query
               and return `None`
+            query_columns (list, optional): A list of `cartoframes.column.Column` to infer data types. You should
+              create `Column` instances this way: Column('column_name', pgtype='the_database_type') where
+              `the_database_type` is mapped using this dictionary:
+
+              .. code:: python
+
+                {'bigint': 'int64',
+                 'boolean': 'bool',
+                 'date': 'datetime64[ns]',
+                 'double precision': 'float64',
+                 'geometry': 'object',
+                 'int': 'int64',
+                 'integer': 'int64',
+                 'number': 'float64',
+                 'numeric': 'float64',
+                 'real': 'float64',
+                 'smallint': 'int32',
+                 'string': 'object',
+                 'timestamp': 'datetime64[ns]',
+                 'timestamp with time zone': 'datetime64[ns]',
+                 'timestamp without time zone': 'datetime64[ns]',
+                 'USER-DEFINED': 'object',}
 
         Returns:
             pandas.DataFrame: When `is_select=True` and the query is actually a SELECT query

--- a/test/test_columns.py
+++ b/test/test_columns.py
@@ -71,7 +71,7 @@ class TestColumns(unittest.TestCase):
 
     def test_pg2dtypes(self):
         results = {
-            'date': 'datetime64[ns]',
+            'date': 'datetime64[D]',
             'number': 'float64',
             'string': 'object',
             'boolean': 'bool',

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -246,7 +246,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         read_df.drop('the_geom', axis=1, inplace=True)
         self.assertSetEqual(set(df.columns), set(read_df.columns))
         self.assertTupleEqual(
-            tuple(str(d) for d in df.dtypes),
+            tuple('float64' if str(d) == 'int64' else 'float64' for d in df.dtypes),
             tuple(str(d) for d in read_df.dtypes),
             msg='Should have same schema/types'
         )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -246,7 +246,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         read_df.drop('the_geom', axis=1, inplace=True)
         self.assertSetEqual(set(df.columns), set(read_df.columns))
         self.assertTupleEqual(
-            tuple('float64' if str(d) == 'int64' else 'float64' for d in df.dtypes),
+            tuple('float64' if str(d) == 'int64' else str(d) for d in df.dtypes),
             tuple(str(d) for d in read_df.dtypes),
             msg='Should have same schema/types'
         )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -15,6 +15,7 @@ import json
 import random
 import warnings
 import requests
+from datetime import datetime
 
 from carto.exceptions import CartoException
 from carto.auth import APIKeyAuthClient
@@ -24,7 +25,7 @@ import IPython
 
 import cartoframes
 from cartoframes.datasets import Dataset
-from cartoframes.columns import normalize_name
+from cartoframes.columns import Column, normalize_name
 from cartoframes.utils import dict_items
 
 from utils import _UserUrlLoader
@@ -227,6 +228,31 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         self.assertEqual(len(df), 0)
         self.assertIsInstance(df, pd.DataFrame)
 
+    def test_cartocontext_read_with_same_schema(self):
+        cc = cartoframes.CartoContext(base_url=self.baseurl,
+                                      api_key=self.apikey)
+        df = pd.DataFrame({'fips': ['01'],
+                           'cfips': ['0001'],
+                           'intval': [1],
+                           'floatval': [1.0],
+                           'boolval': [True],
+                           'textval': ['text'],
+                           'dateval': datetime.now()
+                           })
+        df['boolval'] = df['boolval'].astype(bool)
+        cc.write(df, self.test_write_table, overwrite=True)
+        read_df = cc.read(self.test_write_table)
+
+        read_df.drop('the_geom', axis=1, inplace=True)
+        self.assertSetEqual(set(df.columns), set(read_df.columns))
+        self.assertTupleEqual(
+            tuple(str(d) for d in df.dtypes),
+            tuple(str(d) for d in read_df.dtypes),
+            msg='Should have same schema/types'
+        )
+        self.assertEqual(read_df.index.name, 'cartodb_id')
+        self.assertEqual(read_df.index.dtype, 'int64')
+
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_cartocontext_write(self):
         """context.CartoContext.write normal usage"""
@@ -387,12 +413,17 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         """context.CartoContext.query"""
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
-        cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )
+        columns = (Column('link', pgtype='string'),
+                   Column('body', pgtype='string'),
+                   Column('displayname', pgtype='string'),
+                   Column('friendscount', pgtype='number'),
+                   Column('postedtime', pgtype='date'), )
+        cols = [col.name for col in columns]
         df = cc.query('''
             SELECT {cols}, '02-06-1429'::date as invalid_df_date
             FROM tweets_obama
             LIMIT 100
-            '''.format(cols=','.join(cols)))
+            '''.format(cols=','.join(cols)), query_columns=columns)
 
         # ensure columns are in expected order
         df = df[list(cols) + ['invalid_df_date', ]]
@@ -477,12 +508,17 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         cc = cartoframes.CartoContext(base_url=self.baseurl,
                                       api_key=self.apikey)
 
-        cols = ('link', 'body', 'displayname', 'friendscount', 'postedtime', )
+        columns = (Column('link', pgtype='string'),
+                   Column('body', pgtype='string'),
+                   Column('displayname', pgtype='string'),
+                   Column('friendscount', pgtype='number'),
+                   Column('postedtime', pgtype='date'), )
+        cols = [col.name for col in columns]
         df = cc.fetch('''
             SELECT {cols}, '02-06-1429'::date as invalid_df_date
             FROM tweets_obama
             LIMIT 100
-            '''.format(cols=','.join(cols)))
+            '''.format(cols=','.join(cols)), query_columns=columns)
 
         # ensure columns are in expected order
         df = df[list(cols) + ['invalid_df_date', ]]
@@ -539,7 +575,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
             )
             SELECT ST_X(the_geom) as xval, ST_Y(the_geom) as yval
             FROM cte
-        ''')
+        ''', query_columns=(Column('xval', pgtype='number'), Column('yval', pgtype='number')))
 
         # same type of object
         self.assertIsInstance(df, pd.DataFrame,
@@ -570,7 +606,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         df = cc.fetch('''
             SELECT CDB_LatLng(0.1, 0) as the_geom, i
             FROM generate_series(1, 110) as m(i)
-        ''', decode_geom=True)
+        ''', decode_geom=True, query_columns=(Column('the_geom'), Column('i', pgtype='number')))
 
         # same type of object
         self.assertIsInstance(df, pd.DataFrame,
@@ -1055,17 +1091,14 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         data = cc.data(self.test_data_table, meta)
         anscols = set(meta['suggested_name'])
         origcols = set(cc.read(self.test_data_table, limit=1, decode_geom=True).columns)
-        self.assertSetEqual(anscols, set(data.columns) - origcols - {'the_geom'})
+        self.assertSetEqual(anscols, set(data.columns) - origcols - {'the_geom', 'cartodb_id'})
 
         meta = [{'numer_id': 'us.census.acs.B19013001',
                  'geom_id': 'us.census.tiger.block_group',
                  'numer_timespan': '2011 - 2015'}, ]
         data = cc.data(self.test_data_table, meta)
         self.assertSetEqual(set(('median_income_2011_2015', )),
-                            set(data.columns) - origcols - {'the_geom'})
-
-        # with self.assertRaises(NotImplementedError):
-        #     cc.data(self.test_data_table, meta, how='geom_ref')
+                            set(data.columns) - origcols - {'the_geom', 'cartodb_id'})
 
         with self.assertRaises(ValueError, msg='no measures'):
             meta = cc.data_discovery('United States', keywords='not a measure')
@@ -1088,16 +1121,21 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         data = cc.data(self.test_data_table, meta)
         anscols = set(meta['suggested_name'])
         origcols = set(cc.read(self.test_data_table, limit=1, decode_geom=True).columns)
-        self.assertSetEqual(anscols, set(data.columns) - origcols - {'the_geom'})
+        self.assertSetEqual(anscols, set(data.columns) - origcols - {'the_geom', 'cartodb_id'})
 
         meta = [{'numer_id': 'us.census.acs.B19013001',
                  'geom_id': 'us.census.tiger.block_group',
                  'numer_timespan': '2011 - 2015'}, ]
         data = cc.data(self.test_data_table, meta, persist_as=self.test_write_table)
         self.assertSetEqual(set(('median_income_2011_2015', )),
-                            set(data.columns) - origcols - {'the_geom'})
+                            set(data.columns) - origcols - {'the_geom', 'cartodb_id'})
+        self.assertEqual(data.index.name, 'cartodb_id')
+        self.assertEqual(data.index.dtype, 'int64')
 
         df = cc.read(self.test_write_table, decode_geom=False)
+
+        self.assertEqual(df.index.name, 'cartodb_id')
+        self.assertEqual(data.index.dtype, 'int64')
 
         # same number of rows
         self.assertEqual(len(df), len(data),

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -423,7 +423,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
             SELECT {cols}, '02-06-1429'::date as invalid_df_date
             FROM tweets_obama
             LIMIT 100
-            '''.format(cols=','.join(cols)), query_columns=columns)
+            '''.format(cols=','.join(cols)))
 
         # ensure columns are in expected order
         df = df[list(cols) + ['invalid_df_date', ]]
@@ -518,7 +518,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
             SELECT {cols}, '02-06-1429'::date as invalid_df_date
             FROM tweets_obama
             LIMIT 100
-            '''.format(cols=','.join(cols)), query_columns=columns)
+            '''.format(cols=','.join(cols)))
 
         # ensure columns are in expected order
         df = df[list(cols) + ['invalid_df_date', ]]
@@ -575,7 +575,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
             )
             SELECT ST_X(the_geom) as xval, ST_Y(the_geom) as yval
             FROM cte
-        ''', query_columns=(Column('xval', pgtype='number'), Column('yval', pgtype='number')))
+        ''')
 
         # same type of object
         self.assertIsInstance(df, pd.DataFrame,
@@ -606,7 +606,7 @@ class TestCartoContext(unittest.TestCase, _UserUrlLoader):
         df = cc.fetch('''
             SELECT CDB_LatLng(0.1, 0) as the_geom, i
             FROM generate_series(1, 110) as m(i)
-        ''', decode_geom=True, query_columns=(Column('the_geom'), Column('i', pgtype='number')))
+        ''', decode_geom=True)
 
         # same type of object
         self.assertIsInstance(df, pd.DataFrame,


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartoframes/issues/605
Closes #623

- When doing tests and thanks to [this comment](https://github.com/CartoDB/cartoframes/issues/605#issuecomment-484166025) I realized there's a ValueError on `pandas.read_csv` if a column is set as `int` but have nulls, NAs. I've decided to force conversion of `ints` to `floats`. 

- Alternatives to this approach could be:
  - First try to `read_csv` with `int` types, and when there's a `ValueError` then retry the `read_csv` with floats. I don't like very much this approach because in the worst case you end up reading the streaming twice.
  - Use `converters` for int columns and try to be smarter.
  - Check if there are nulls in the int columns by querying the database.
  - Any other?

I don't like any of those options... that's why I opted to just map int as float.