### PR TITLE
Unify style api

### DIFF
--- a/cartoframes/carto_vl/__init__.py
+++ b/cartoframes/carto_vl/__init__.py
@@ -5,8 +5,8 @@ from .utils import defaults
 from .utils.html import HTMLMap
 from .maps.map import Map
 from .layer.layer import Layer
+from .styles.style import Style
 from .sources import Sources as source
-from .styles import Style
 
 
 __all__ = [

--- a/cartoframes/carto_vl/__init__.py
+++ b/cartoframes/carto_vl/__init__.py
@@ -6,6 +6,7 @@ from .utils.html import HTMLMap
 from .maps.map import Map
 from .layer.layer import Layer
 from .sources import Sources as source
+from .styles import Style
 
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
   "Dataset",
   "SQL",
   "GeoJSON",
-  "source"
+  "source",
+  "Style"
 ]

--- a/cartoframes/carto_vl/layer/layer.py
+++ b/cartoframes/carto_vl/layer/layer.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from ..utils import defaults
+from ..style import Style
 
 
 class Layer(object):
@@ -53,56 +53,11 @@ class Layer(object):
         self.is_basemap = False
         self.source = source  # TO DO check instance of Source
         self.bounds = source.bounds
-        self.style = _parse_style_properties(style)
+        self.style = style if isinstance(style, Style) else Style(style)
         self.variables = _parse_variables(variables)
         self.interactivity = _parse_interactivity(interactivity)
         self.legend = legend
         self.viz = _set_viz(self.variables, self.style)
-
-
-def _convstr(obj):
-    """convert all types to strings or None"""
-    return str(obj) if obj is not None else None
-
-
-def _to_camel_case(text):
-    """convert properties to camelCase"""
-    components = text.split('-')
-    return components[0] + ''.join(x.title() for x in components[1:])
-
-
-def _parse_style_properties(style):
-    """Adds style properties to the styling"""
-    if style is None:
-        return ''
-    elif isinstance(style, dict):
-        return _parse_style_properties_dict(style)
-    elif isinstance(style, (tuple, list)):
-        return _parse_style_properties_list(style)
-    elif isinstance(style, str):
-        return style
-    else:
-        raise ValueError('`style` must be a dictionary, a list or a string')
-
-
-def _parse_style_properties_dict(style):
-    return '\n'.join(
-        '{name}: {value}'.format(
-          name=_to_camel_case(style_prop),
-          value=_convstr(style.get(style_prop))
-        )
-        for style_prop in style
-        if style_prop in defaults._STYLE_PROPERTIES
-        and style.get(style_prop) is not None
-        )
-
-
-def _parse_style_properties_list(style):
-    return '\n'.join(
-      '{name}: {value}'.format(
-          name=_to_camel_case(style_prop[0]),
-          value=_convstr(style_prop[1])
-      ) for style_prop in style if style_prop[0] in defaults._STYLE_PROPERTIES)
 
 
 def _parse_variables(variables):

--- a/cartoframes/carto_vl/layer/layer.py
+++ b/cartoframes/carto_vl/layer/layer.py
@@ -53,11 +53,20 @@ class Layer(object):
         self.is_basemap = False
         self.source = source  # TO DO check instance of Source
         self.bounds = source.bounds
-        self.style = style if isinstance(style, Style) else Style(style)
+        self.style = _set_style(style)
         self.variables = _parse_variables(variables)
         self.interactivity = _parse_interactivity(interactivity)
         self.legend = legend
         self.viz = _get_viz(self.variables, self.style)
+
+
+def _set_style(style):
+    if style is None:
+        return ''
+    elif isinstance(style, Style):
+        return style
+    else:
+        return Style(style)
 
 
 def _parse_variables(variables):
@@ -114,5 +123,7 @@ def _get_viz(variables, style):
         return '\n'.join([variables, style.viz])
     elif variables:
         return variables
-    else:
+    elif style and style.viz:
         return style.viz
+    else:
+        return ''

--- a/cartoframes/carto_vl/layer/layer.py
+++ b/cartoframes/carto_vl/layer/layer.py
@@ -34,9 +34,9 @@ class Layer(object):
             vl.Map([
                 vl.Layer(
                     source=vl.source.SQL('SELECT * FROM populated_places WHERE adm0name = \'Spain\''),
-                    style={
+                    style=vl.Style({
                         'color': 'red'
-                    }
+                    })
                 )],
                 context=context
             )

--- a/cartoframes/carto_vl/layer/layer.py
+++ b/cartoframes/carto_vl/layer/layer.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from ..style import Style
+from ..styles.style import Style
 
 
 class Layer(object):
@@ -57,7 +57,7 @@ class Layer(object):
         self.variables = _parse_variables(variables)
         self.interactivity = _parse_interactivity(interactivity)
         self.legend = legend
-        self.viz = _set_viz(self.variables, self.style)
+        self.viz = _get_viz(self.variables, self.style)
 
 
 def _parse_variables(variables):
@@ -109,10 +109,10 @@ def _parse_interactivity(interactivity):
         raise ValueError('`interactivity` must be a dictionary')
 
 
-def _set_viz(variables, style):
+def _get_viz(variables, style):
     if variables and style:
-        return '\n'.join([variables, style])
+        return '\n'.join([variables, style.viz])
     elif variables:
         return variables
     else:
-        return style
+        return style.viz

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -3,20 +3,20 @@ from ..utils import defaults
 
 class Style(object):
     def __init__(self, style=None):
-        self.style = self._init_style(style)
+        self.viz = self._init_style(style)
 
     def _init_style(self, style):
         """Adds style properties to the styling"""
         if style is None:
             return ''
         elif isinstance(style, dict):
-            return self. _parse_style_properties_dict(style)
+            return self._parse_style_properties_dict(style)
         elif isinstance(style, str):
             return style
         else:
             raise ValueError('`style` must be a dictionary or a viz string')
 
-    def _parse_style_properties_dict(style):
+    def _parse_style_properties_dict(self, style):
         return '\n'.join(
             '{name}: {value}'.format(
                 name=_to_camel_case(style_prop),

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -6,7 +6,7 @@ class Style(object):
     """CARTO VL Style
 
     Args:
-        style (dict, string): The style for a layer. It can be a dictionary or a viz string.
+        style (dict, string): The style for the layer. It can be a dictionary or a viz string.
             If a dict or a string are assigned to the Layer's style, it is casted to a Style.
 
     Attributes:
@@ -45,9 +45,9 @@ class Style(object):
               vl.Map([
                   vl.Layer(
                       source=vl.source.Dataset('populated_places'),
-                      style=vl.Style(\"\"\"
+                      style=vl.Style('''
                         color: red
-                      \"\"\")
+                      ''')
                   )],
                   context=context
               )
@@ -68,17 +68,23 @@ class Style(object):
             raise ValueError('`style` must be a dictionary or a viz string')
 
     def _parse_style_properties_dict(self, style):
-        return '\n'.join(
-            '{name}: {value}'.format(
-                name=style_prop,
-                value=_convstr(style.get(style_prop))
-            )
-            for style_prop in style
-            if style_prop in defaults._STYLE_PROPERTIES
-            and style.get(style_prop) is not None
-        )
+        style_properties = []
+
+        for prop in style:
+            if prop in defaults._STYLE_PROPERTIES and style.get(prop) is not None:
+                style_properties.append(
+                    '{name}: {value}'.format(
+                        name=prop,
+                        value=_convstr(style.get(prop))
+                    )
+                )
+            else:
+                raise ValueError('Style property "' + prop + '" is not valid. Valid style properties are: ' +
+                                 ', '.join(defaults._STYLE_PROPERTIES))
+
+        return '\n'.join(style_properties)
 
 
 def _convstr(obj):
-    """convert all types to strings or None"""
+    """Converts all types to strings or None"""
     return str(obj) if obj is not None else None

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -2,19 +2,66 @@ from ..utils import defaults
 
 
 class Style(object):
+    """CARTO VL Style
+
+    Args:
+        style (dict, string): The style for a layer. It can be a dictionary or a viz string.
+            If a dict or a string are assigned to the Layer's style, it is casted to a Style.
+
+    Attributes:
+        viz: The viz style
+
+    Example:
+
+        .. code::
+            from cartoframes import carto_vl as vl
+            from cartoframes import CartoContext
+
+            context = CartoContext(
+                base_url='https://cartovl.carto.com/',
+                api_key='default_public'
+            )
+
+            vl.Map([
+                vl.Layer(
+                    source=vl.source.Dataset('populated_places'),
+                    style=vl.Style({
+                        'color': 'red'
+                    })
+                )],
+                context=context
+            )
+
+        .. code::
+              from cartoframes import carto_vl as vl
+              from cartoframes import CartoContext
+
+              context = CartoContext(
+                  base_url='https://cartovl.carto.com/',
+                  api_key='default_public'
+              )
+
+              vl.Map([
+                  vl.Layer(
+                      source=vl.source.Dataset('populated_places'),
+                      style=vl.Style(\"\"\"
+                        color: red
+                      \"\"\")
+                  )],
+                  context=context
+              )
+    """
+
     def __init__(self, style=None):
         self.viz = self._init_style(style)
 
     def _init_style(self, style):
-        """Adds style properties to the styling"""
-        if style is None:
-            return ''
-        elif isinstance(style, dict):
-            return self._parse_style_properties_dict(style)
-        elif isinstance(style, str):
-            return style
-        else:
-            raise ValueError('`style` must be a dictionary or a viz string')
+        """
+        Parameters
+        ----------
+        style : str, dict
+            
+        """
 
     def _parse_style_properties_dict(self, style):
         return '\n'.join(

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -56,17 +56,20 @@ class Style(object):
         self.viz = self._init_style(style)
 
     def _init_style(self, style):
-        """
-        Parameters
-        ----------
-        style : str, dict
-            
-        """
+        """Adds style properties to the viz"""
+        if style is None:
+            return ''
+        elif isinstance(style, dict):
+            return self._parse_style_properties_dict(style)
+        elif isinstance(style, str):
+            return style
+        else:
+            raise ValueError('`style` must be a dictionary or a viz string')
 
     def _parse_style_properties_dict(self, style):
         return '\n'.join(
             '{name}: {value}'.format(
-                name=_to_camel_case(style_prop),
+                name=style_prop,
                 value=_convstr(style.get(style_prop))
             )
             for style_prop in style
@@ -78,9 +81,3 @@ class Style(object):
 def _convstr(obj):
     """convert all types to strings or None"""
     return str(obj) if obj is not None else None
-
-
-def _to_camel_case(text):
-    """convert properties to camelCase"""
-    components = text.split('-')
-    return components[0] + ''.join(x.title() for x in components[1:])

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -1,0 +1,39 @@
+from ..utils import defaults
+
+
+class Style(object):
+    def __init__(self, style=None):
+        self.style = self._init_style(style)
+
+    def _init_style(self, style):
+        """Adds style properties to the styling"""
+        if style is None:
+            return ''
+        elif isinstance(style, dict):
+            return self. _parse_style_properties_dict(style)
+        elif isinstance(style, str):
+            return style
+        else:
+            raise ValueError('`style` must be a dictionary or a viz string')
+
+    def _parse_style_properties_dict(style):
+        return '\n'.join(
+            '{name}: {value}'.format(
+                name=_to_camel_case(style_prop),
+                value=_convstr(style.get(style_prop))
+            )
+            for style_prop in style
+            if style_prop in defaults._STYLE_PROPERTIES
+            and style.get(style_prop) is not None
+        )
+
+
+def _convstr(obj):
+    """convert all types to strings or None"""
+    return str(obj) if obj is not None else None
+
+
+def _to_camel_case(text):
+    """convert properties to camelCase"""
+    components = text.split('-')
+    return components[0] + ''.join(x.title() for x in components[1:])

--- a/cartoframes/carto_vl/styles/style.py
+++ b/cartoframes/carto_vl/styles/style.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from ..utils import defaults
 
 

--- a/cartoframes/carto_vl/utils/defaults.py
+++ b/cartoframes/carto_vl/utils/defaults.py
@@ -34,4 +34,5 @@ _STYLE_PROPERTIES = (
     'order',
     'symbol',
     'symbolPlacement',
+    'resolution'
 )

--- a/cartoframes/carto_vl/utils/defaults.py
+++ b/cartoframes/carto_vl/utils/defaults.py
@@ -28,10 +28,10 @@ _STYLE_PROPERTIES = (
     'color',
     'width',
     'filter',
-    'stroke-width',
-    'stroke-color',
+    'strokeWidth',
+    'strokeColor',
     'transform',
     'order',
     'symbol',
-    'symbol-placement',
+    'symbolPlacement',
 )

--- a/cartoframes/carto_vl/utils/html.py
+++ b/cartoframes/carto_vl/utils/html.py
@@ -5,6 +5,7 @@ from cartoframes import utils
 from warnings import warn
 from jinja2 import Environment, PackageLoader
 
+
 class HTMLMap(object):
     def __init__(self):
         self.width = None

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,17 @@ import io
 from codecs import open
 from setuptools import setup, find_packages
 
+
+def walk_subpkg(name):
+    data_files = []
+    package_dir = 'cartoframes'
+    for parent, dirs, files in os.walk(os.path.join(package_dir, name)):
+        # Remove package_dir from the path.
+        sub_dir = os.sep.join(parent.split(os.sep)[1:])
+        for f in files:
+            data_files.append(os.path.join(sub_dir, f))
+    return data_files
+
 REQUIRES = [
     'pandas>=0.20.1',
     'webcolors>=1.7.0',
@@ -30,7 +41,8 @@ PACKAGE_DATA = {
     ],
     'cartoframes': [
         'assets/*',
-    ],
+        'assets/*.j2'
+    ] + walk_subpkg('assets'),
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/test/carto_vl/test_layers.py
+++ b/test/carto_vl/test_layers.py
@@ -20,6 +20,17 @@ class TestLayers(unittest.TestCase):
 
 
 class TestLayersStyle(unittest.TestCase):
+    def test_style_instance(self):
+        """should create a Style instance by default"""
+        carto_layer = carto_vl.Layer(
+            carto_vl.source.Dataset('layer_source'),
+            style={
+                'color': 'blue'
+            }
+        )
+
+        self.assertTrue(isinstance(carto_layer.style, carto_vl.Style))
+
     def test_style_dict(self):
         """should set the style when it is a dict"""
         carto_layer = carto_vl.Layer(
@@ -42,10 +53,10 @@ class TestLayersStyle(unittest.TestCase):
         carto_layer = carto_vl.Layer(
             carto_vl.source.Dataset('layer_source'),
             style="""
-                color: 'blue'
+                color: blue
                 width: 10
-                strokeColor': 'black'
-                strokeWidth': 1
+                strokeColor: black
+                strokeWidth: 1
             """
         )
 

--- a/test/carto_vl/test_layers.py
+++ b/test/carto_vl/test_layers.py
@@ -27,9 +27,26 @@ class TestLayersStyle(unittest.TestCase):
             style={
                 'color': 'blue',
                 'width': 10,
-                'stroke-color': 'black',
-                'stroke-width': 1
+                'strokeColor': 'black',
+                'strokeWidth': 1
             }
+        )
+
+        self.assertTrue('color: blue' in carto_layer.viz)
+        self.assertTrue('width: 10' in carto_layer.viz)
+        self.assertTrue('strokeColor: black' in carto_layer.viz)
+        self.assertTrue('strokeWidth: 1' in carto_layer.viz)
+
+    def test_style_str(self):
+        """should set the style when it is a dict"""
+        carto_layer = carto_vl.Layer(
+            carto_vl.source.Dataset('layer_source'),
+            style="""
+                color: 'blue'
+                width: 10
+                strokeColor': 'black'
+                strokeWidth': 1
+            """
         )
 
         self.assertTrue('color: blue' in carto_layer.viz)
@@ -44,33 +61,6 @@ class TestLayersStyle(unittest.TestCase):
             style={
                 'invalid': 1
             }
-        )
-        self.assertFalse('invalid: 1' in carto_layer.viz)
-
-    def test_style_list(self):
-        """should set the style when it is a dict"""
-        carto_layer = carto_vl.Layer(
-            carto_vl.sources.Dataset('layer_source'),
-            style=[
-                ['color', 'blue'],
-                ['width', 10],
-                ['stroke-color', 'black'],
-                ['stroke-width', 1]
-            ]
-        )
-
-        self.assertTrue('color: blue' in carto_layer.viz)
-        self.assertTrue('width: 10' in carto_layer.viz)
-        self.assertTrue('strokeColor: black' in carto_layer.viz)
-        self.assertTrue('strokeWidth: 1' in carto_layer.viz)
-
-    def test_style_list_valid_properties(self):
-        """should set only the valid properties"""
-        carto_layer = carto_vl.Layer(
-            carto_vl.sources.Dataset('layer_source'),
-            style=[
-                ['invalid', 1]
-            ]
         )
         self.assertFalse('invalid: 1' in carto_layer.viz)
 

--- a/test/carto_vl/test_styles.py
+++ b/test/carto_vl/test_styles.py
@@ -1,0 +1,13 @@
+import unittest
+from cartoframes import carto_vl
+
+
+class TestStyles(unittest.TestCase):
+    def test_is_style_defined(self):
+        self.assertNotEqual(carto_vl.Style, None)
+
+    def test_initialization(self):
+        """should initialize style attributes"""
+        style = carto_vl.Style('color: red')
+
+        self.assertEqual(style.viz, 'color: red')

--- a/test/carto_vl/test_styles.py
+++ b/test/carto_vl/test_styles.py
@@ -6,8 +6,20 @@ class TestStyles(unittest.TestCase):
     def test_is_style_defined(self):
         self.assertNotEqual(carto_vl.Style, None)
 
-    def test_initialization(self):
-        """should initialize style attributes"""
+    def test_style_string(self):
+        """should initialize style attributes from a string"""
         style = carto_vl.Style('color: red')
 
         self.assertEqual(style.viz, 'color: red')
+
+    def test_style_dictionary(self):
+        """should initialize style attributes from a dict"""
+        style = carto_vl.Style({'color': 'red'})
+
+        self.assertEqual(style.viz, 'color: red')
+
+    def test_wrong_attribute(self):
+        """should raise an error if style property is not valid"""
+
+        with self.assertRaises(ValueError):
+            carto_vl.Style({'wrong': 'red'})


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/cartoframes/issues/619
Blocked by: https://github.com/CartoDB/cartoframes/pull/626 (it has to be merged after this one because it depends on the new Layer API)

- [x] Use always a dict / viz string
- [x] Use always camelCase
- [x] Use a Style class --> in order to provide style helpers in the future
- [x] Add specs

* Simple layer setup

```python
 Layer( Dataset('world_population_2015'), Style({ 'color': 'turquoise'}))
```

* Map setup using a style dict

```python
Map([
   Layer(
        Dataset('world_population_2015'),
        Style({
             'color': 'turquoise',
             'strokeColor': 'white'
        })
    )],
    context=context
)
```

* Map setup using a style string

```python
Map([
   Layer(
        Dataset('world_population_2015'),
        Style("""
            color: turquoise
            strokeColor: white
        """)
    )],
    context=context
)
```