### PR TITLE
Allow list val in _rows method

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,7 +9,7 @@ Release 2019-06-xx
 Updates
 
 - Fix schema not always properly set in write operations (#734)
-
+- Fix error in Dataset.upload related with array data (#754)
 
 Changelog
 =========

--- a/cartoframes/dataset.py
+++ b/cartoframes/dataset.py
@@ -197,7 +197,7 @@ class Dataset(object):
                 if with_lnglat and col in Column.SUPPORTED_GEOM_COL_NAMES:
                     continue
                 val = row[col]
-                if pd.isnull(val) or val is None:
+                if self._is_null(val):
                     val = ''
                 if with_lnglat:
                     if col == with_lnglat[0]:
@@ -218,6 +218,13 @@ class Dataset(object):
 
             csv_row += '\n'
             yield csv_row.encode()
+
+    def _is_null(self, val):
+        vnull = pd.isnull(val)
+        if isinstance(vnull, bool):
+            return vnull
+        else:
+            return vnull.all()
 
     def _drop_table_query(self, if_exists=True):
         return '''DROP TABLE {if_exists} {table_name}'''.format(

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -6,6 +6,7 @@ import os
 import sys
 import json
 import warnings
+import pandas as pd
 
 from carto.exceptions import CartoException
 
@@ -511,3 +512,21 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
                 '''.format(table=table_name))
         except CartoException as e:
             self.assertTrue('relation "{}" does not exist'.format(table_name) in str(e))
+
+
+class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
+    """Unit tests for cartoframes.Dataset"""
+
+    def test_rows(self):
+        df = pd.DataFrame.from_dict({'test': [True, [1, 2]]})
+        ds = Dataset.from_dataframe(df)
+        rows = ds._rows(ds.df, ['test'], None, '')
+
+        self.assertEqual(list(rows), [b'True|\n', b'[1, 2]|\n'])
+
+    def test_rows_null(self):
+        df = pd.DataFrame.from_dict({'test': [None, [None, None]]})
+        ds = Dataset.from_dataframe(df)
+        rows = ds._rows(ds.df, ['test'], None, '')
+
+        self.assertEqual(list(rows), [b'|\n', b'|\n'])


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartoframes/issues/754