### PR TITLE
Workaround to fix jinja revindex

### DIFF
--- a/cartoframes/assets/templates/viz/legends.html.j2
+++ b/cartoframes/assets/templates/viz/legends.html.j2
@@ -15,7 +15,7 @@
         heading="{{layer.legend.title}}"
         description="{{layer.legend.description}}"
       >
-        {{ createLegend(layer.legend, 'layer%d_legend' % loop.revindex0) }}
+        {{ createLegend(layer.legend, 'layer%d_legend' % loop.index0) }}
         {% if layer.legend.footer %}
           <span slot="footer">{{layer.legend.footer}}</span>
         {% endif %}

--- a/cartoframes/assets/templates/viz/map.js.j2
+++ b/cartoframes/assets/templates/viz/map.js.j2
@@ -98,7 +98,7 @@ function onReady() {
     }
 
     if (layer.legend) {
-      createLegend(mapLayer, layer.legend, index);
+      createLegend(mapLayer, layer.legend, layers.length - index - 1);
     }
 
     function setPopupsClick(tempPopup, interactivity, attrs) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 -e git+https://github.com/CartoDB/carto-python.git#egg=carto
--e git+https://github.com/aayushuppal/jinja@loop_fix#egg=jinja2
 .


### PR DESCRIPTION
Workaround for `loop.revindex0` in jinja.

This could be reverted when https://github.com/pallets/jinja/pull/993 is in upstream.