### PR TITLE
release/v1.0b1 fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ latest version:
 
 .. code:: bash
 
-    $ pip install cartoframes
+    $ pip install (--pre) cartoframes
 
 `cartoframes` is continuously tested on Python versions 2.7, 3.5, and 3.6. It is recommended to use `cartoframes` in Jupyter Notebooks (`pip install jupyter`). See the example usage section below or notebooks in the `examples directory <https://github.com/CartoDB/cartoframes/tree/master/examples>`__ for using `cartoframes` in that environment.
 

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,11 @@ latest version:
 
     $ pip install (--pre) cartoframes
 
+or 
+.. code:: bash
+
+    $ pip install cartoframes==1.0b1
+
 `cartoframes` is continuously tested on Python versions 2.7, 3.5, and 3.6. It is recommended to use `cartoframes` in Jupyter Notebooks (`pip install jupyter`). See the example usage section below or notebooks in the `examples directory <https://github.com/CartoDB/cartoframes/tree/master/examples>`__ for using `cartoframes` in that environment.
 
 Virtual Environment
@@ -82,6 +87,11 @@ To setup `cartoframes` and `Jupyter` in a `virtual environment <http://python-gu
     (venv) $ pip install cartoframes jupyter
     (venv) $ jupyter notebook
 
+To install the 1.0b1 version, run instead:
+
+.. code:: bash
+    (venv) $ pip install cartoframes==1.0b1 jupyter
+
 Then create a new notebook and try the example code snippets below with tables that are in your CARTO account.
 
 Using `pipenv`
@@ -100,6 +110,13 @@ Alternatively, `pipenv <https://pipenv.readthedocs.io/en/latest/>`__ provides an
     $ pipenv install cartoframes jupyter
     $ pipenv run jupyter notebook
 
+To install the 1.0b1 version, run instead:
+
+.. code:: bash
+    $ pipenv --three
+    $ pipenv install cartoframes==1.0b1 jupyter
+    $ pipenv run jupyter notebook
+
 Native pip
 ----------
 
@@ -108,6 +125,12 @@ If you install packages at a system level, you can install `cartoframes` with:
 .. code:: bash
 
     $ pip install cartoframes
+
+or to install the 1.0b1 version:
+
+.. code:: bash
+
+    $ pip install cartoframes==1.0b1
 
 Example usage
 =============

--- a/docs/developer-center/examples/introduction.md
+++ b/docs/developer-center/examples/introduction.md
@@ -1,3 +1,3 @@
 ## CARTOframes Examples
 
-All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/master/examples)
+All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/develop/examples)

--- a/docs/developer-center/examples/introduction.md
+++ b/docs/developer-center/examples/introduction.md
@@ -5,6 +5,7 @@ All the CARTOframes practical examples and use cases are placed in our [GitHub r
 <div class="example-notebook">
     <iframe
         id="example-notebook-embeded"
+        class="example-notebook-embeded"
         src="/developers/cartoframes/examples/html/index.html"
         width="100%"
         height="100%"

--- a/docs/developer-center/examples/introduction.md
+++ b/docs/developer-center/examples/introduction.md
@@ -1,3 +1,13 @@
 ## CARTOframes Examples
 
 All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/develop/examples)
+
+<div class="example-notebook">
+    <iframe
+        id="example-notebook-embeded"
+        src="/developers/cartoframes/examples/html/index.html"
+        width="100%"
+        height="100%"
+        frameBorder="0">
+    </iframe>
+</div>

--- a/docs/developer-center/examples/notebooks.md
+++ b/docs/developer-center/examples/notebooks.md
@@ -5,6 +5,7 @@ All the CARTOframes practical examples and use cases are placed in our [GitHub r
 <div class="example-notebook">
     <iframe
         id="example-notebook-embeded"
+        class="example-notebook-embeded"
         src="/developers/cartoframes/examples/html/index.html"
         width="100%"
         height="100%"

--- a/docs/developer-center/examples/notebooks.md
+++ b/docs/developer-center/examples/notebooks.md
@@ -1,3 +1,3 @@
 ## Jupyter Notebooks
 
-All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/master/examples)
+All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/develop/examples)

--- a/docs/developer-center/examples/notebooks.md
+++ b/docs/developer-center/examples/notebooks.md
@@ -1,3 +1,13 @@
 ## Jupyter Notebooks
 
 All the CARTOframes practical examples and use cases are placed in our [GitHub repository](https://github.com/CartoDB/cartoframes/blob/develop/examples)
+
+<div class="example-notebook">
+    <iframe
+        id="example-notebook-embeded"
+        src="/developers/cartoframes/examples/html/index.html"
+        width="100%"
+        height="100%"
+        frameBorder="0">
+    </iframe>
+</div>

--- a/docs/developer-center/guides/00-Introduction.md
+++ b/docs/developer-center/guides/00-Introduction.md
@@ -6,13 +6,13 @@ If you're already familiar with Jupyter Notebooks, you can also take a look to o
 
 ### Content
 
-* [Quickstart]({{ site.url }}/developers/cartoframes/guides/quickstart/)
-* [Context]({{ site.url }}/developers/cartoframes/guides/context/)
-* [Basemaps And Viewport]({{ site.url }}/developers/cartoframes/guides/basemaps-and-viewport/)
-* [Sources]({{ site.url }}/developers/cartoframes/guides/sources/)
-* [Legends]({{ site.url }}/developers/cartoframes/guides/legends/)
-* [Popups]({{ site.url }}/developers/cartoframes/guides/popups/)
-* [Helper Methods Part 1]({{ site.url }}/developers/cartoframes/guides/helper-methods-part-1/)
-* [Helper Methods Part 2]({{ site.url }}/developers/cartoframes/guides/helper-methods-part-2/)
-* [Publishing]({{ site.url }}/developers/cartoframes/guides/publishing/)
+* [Quickstart]({{ site.url }}/developers/cartoframes/guides/Quickstart/)
+* [Context]({{ site.url }}/developers/cartoframes/guides/Context/)
+* [Basemaps And Viewport]({{ site.url }}/developers/cartoframes/guides/Basemaps-And-Viewport/)
+* [Sources]({{ site.url }}/developers/cartoframes/guides/Sources/)
+* [Legends]({{ site.url }}/developers/cartoframes/guides/Legends/)
+* [Popups]({{ site.url }}/developers/cartoframes/guides/Popups/)
+* [Helper Methods Part 1]({{ site.url }}/developers/cartoframes/guides/Helper-Methods-Part-1/)
+* [Helper Methods Part 2]({{ site.url }}/developers/cartoframes/guides/Helper-Methods-Part-2/)
+* [Publishing]({{ site.url }}/developers/cartoframes/guides/Publishing/)
 * [Spatial Analysis]({{ site.url }}/developers/cartoframes/guides/Spatial-Analysis/)

--- a/docs/developer-center/guides/00-Introduction.md
+++ b/docs/developer-center/guides/00-Introduction.md
@@ -2,7 +2,7 @@
 
 Use these guides to learn about integrating CARTOframes into your data science workflows. Working inside of a Jupyter notebook, the guides walk through initial set-up and installation, reading data from CARTO into your Python session, writing data to your CARTO account, and the basics of visualizing your data on a map. We also cover how to use a series of Helper Methods to create meaningful visualizations that can be published and shared.
 
-If you're already familiar with Jupyter Notebooks, you can also take a look to our [Notebook Examples](https://github.com/CartoDB/cartoframes/blob/master/examples) which can be also used as a starting point to learn CARTOframes.
+If you're already familiar with Jupyter Notebooks, you can also take a look to our [Notebook Examples](https://github.com/CartoDB/cartoframes/blob/develop/examples) which can be also used as a starting point to learn CARTOframes.
 
 ### Content
 

--- a/docs/developer-center/guides/01-Quickstart.md
+++ b/docs/developer-center/guides/01-Quickstart.md
@@ -14,10 +14,20 @@ You can install CARTOframes with `pip`. Simply type the following in the command
 $ pip install --pre cartoframes
 ```
 
+or 
+
+```bash
+$ pip install cartoframes==1.0b1
+```
+
 To install through a Jupyter notebook, you can run
 
 ```bash
 ! pip install --pre cartoframes
+```
+
+```bash
+!pip install cartoframes==1.0b1
 ```
 
 It is recommended to install cartoframes in a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). For example, you can run the following command to create a virtual env, activate it, and install cartoframes:
@@ -26,6 +36,14 @@ It is recommended to install cartoframes in a [virtual environment](http://docs.
 $ virtualenv cfenv
 $ source cfenv/bin/activate
 (cfenv) $ pip install --pre cartoframes
+```
+
+or
+
+```bash
+$ virtualenv cfenv
+$ source cfenv/bin/activate
+(cfenv) $ pip install cartoframes==1.0b1
 ```
 
 You'll notice the virtual environment name in your command line prompt, like above. Type `deactivate` to exit the virtualenv:

--- a/docs/developer-center/guides/01-Quickstart.md
+++ b/docs/developer-center/guides/01-Quickstart.md
@@ -11,13 +11,13 @@ This guide walks you through the process of installing and authenticating CARTOf
 You can install CARTOframes with `pip`. Simply type the following in the command line to do a system install:
 
 ```bash
-$ pip install cartoframes
+$ pip install --pre cartoframes
 ```
 
 To install through a Jupyter notebook, you can run
 
 ```bash
-!pip install cartoframes
+! pip install --pre cartoframes
 ```
 
 It is recommended to install cartoframes in a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). For example, you can run the following command to create a virtual env, activate it, and install cartoframes:
@@ -25,7 +25,7 @@ It is recommended to install cartoframes in a [virtual environment](http://docs.
 ```bash
 $ virtualenv cfenv
 $ source cfenv/bin/activate
-(cfenv) $ pip install cartoframes
+(cfenv) $ pip install --pre cartoframes
 ```
 
 You'll notice the virtual environment name in your command line prompt, like above. Type `deactivate` to exit the virtualenv:

--- a/docs/developer-center/guides/01-Quickstart.md
+++ b/docs/developer-center/guides/01-Quickstart.md
@@ -2,7 +2,7 @@
 
 ### About this Guide
 
-This guide walks you through the process of installing and authenticating CARTOframes to create an interactive visualization with a shareable link. The full notebook example can be found in the [01_basic_usage](https://github.com/CartoDB/cartoframes/blob/master/examples/01_quickstart/01_basic_usage.ipynb) notebook.
+This guide walks you through the process of installing and authenticating CARTOframes to create an interactive visualization with a shareable link. The full notebook example can be found in the [01_basic_usage](https://github.com/CartoDB/cartoframes/blob/develop/examples/01_quickstart/01_basic_usage.ipynb) notebook.
 
 ![Final visualization](../../img/guides/quickstart/quickstart-final.gif)
 

--- a/docs/developer-center/guides/04-Sources.md
+++ b/docs/developer-center/guides/04-Sources.md
@@ -1,6 +1,6 @@
 ## Sources
 
-In CARTOframes, the `Sources` are the origin of the data. In this guide, we cover the different types of sources that can be used with CARTOframes. You can also check the [Context Setup](https://github.com/CartoDB/cartoframes/blob/master/examples/01_quickstart/02_context_setup.ipynb) Notebook.
+In CARTOframes, the `Sources` are the origin of the data. In this guide, we cover the different types of sources that can be used with CARTOframes. You can also check the [Context Setup](https://github.com/CartoDB/cartoframes/blob/develop/examples/01_quickstart/02_context_setup.ipynb) Notebook.
 
 The basic syntax to set the `Source` of a visualization is:
 

--- a/docs/developer-center/guides/07-Helper-Methods-Part-1.md
+++ b/docs/developer-center/guides/07-Helper-Methods-Part-1.md
@@ -7,7 +7,7 @@ These predefined layer-level style helpers provide the following defaults:
 - an appropriate legend
 - hover interactivity on the mapped attribute
 
-[Helper Methods - Part 1](https://github.com/CartoDB/cartoframes/blob/master/examples/04_helper_methods/01_helper_methods_part_1.ipynb) Notebook.
+[Helper Methods - Part 1](https://github.com/CartoDB/cartoframes/blob/develop/examples/04_helper_methods/01_helper_methods_part_1.ipynb) Notebook.
 
 Each component of these helpers (Map, Style, Legend, Popup) have parameters that you can be accessed to customize your visualization which will be covered in [Helper Methods - Part 2]({{ site.url }}/developers/cartoframes/guides/helper-methods-part-2/)
 

--- a/docs/developer-center/guides/08-Helper-Methods-Part-2.md
+++ b/docs/developer-center/guides/08-Helper-Methods-Part-2.md
@@ -9,7 +9,7 @@ These predefined layer-level style helpers provide the following defaults:
 
 Each component of these helpers have parameters that you can accesse to customize pieces of your visualization.
 
-[Helper Methods - Part 1](https://github.com/CartoDB/cartoframes/blob/master/examples/04_helper_methods/01_helper_methods_part_1.ipynb) Notebook.
+[Helper Methods - Part 1](https://github.com/CartoDB/cartoframes/blob/develop/examples/04_helper_methods/01_helper_methods_part_1.ipynb) Notebook.
 
 In this guide, you will see how to modify the default visualization parameters of helper methods. For a more in-depth look at each helper method, visit [Helper Methods - Part 1]({{ site.url }}/developers/cartoframes/guides/helper-methods-part-1/)
 


### PR DESCRIPTION
* Fix links in Quickstart guide
* Fix links to GitHub using `develop` branch
* Add `--pre` to `pip install cartoframes` to install the beta version
* Add an iframe in the examples displaying a notebook example (a generated `html` from a notebook)