### PR TITLE
Refactor decoding geometry support

### DIFF
--- a/cartoframes/auth/context.py
+++ b/cartoframes/auth/context.py
@@ -32,7 +32,7 @@ from ..analysis import Table
 from ..__version__ import __version__
 from ..columns import dtypes, date_columns_names, bool_columns_names
 from ..data import Dataset
-from ..data.utils import decode_geometry, recursive_read, get_columns
+from ..data.utils import decode_geometry, ENC_WKB_HEX, recursive_read, get_columns
 
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlencode
@@ -521,7 +521,7 @@ class Context(object):
         date_column_names = date_columns_names(query_columns)
         bool_column_names = bool_columns_names(query_columns)
 
-        converters = {'the_geom': lambda x: decode_geometry(x) if decode_geom else x}
+        converters = {'the_geom': lambda x: decode_geometry(x, ENC_WKB_HEX) if decode_geom else x}
         for bool_column_name in bool_column_names:
             converters[bool_column_name] = lambda x: _convert_bool(x)
 

--- a/cartoframes/auth/context.py
+++ b/cartoframes/auth/context.py
@@ -32,7 +32,7 @@ from ..analysis import Table
 from ..__version__ import __version__
 from ..columns import dtypes, date_columns_names, bool_columns_names
 from ..data import Dataset
-from ..data.utils import decode_geometry, ENC_WKB_HEX, recursive_read, get_columns
+from ..data.utils import decode_geometry, ENC_WKB_BHEX, recursive_read, get_columns
 
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlencode
@@ -521,7 +521,7 @@ class Context(object):
         date_column_names = date_columns_names(query_columns)
         bool_column_names = bool_columns_names(query_columns)
 
-        converters = {'the_geom': lambda x: decode_geometry(x, ENC_WKB_HEX) if decode_geom else x}
+        converters = {'the_geom': lambda x: decode_geometry(x, ENC_WKB_BHEX) if decode_geom else x}
         for bool_column_name in bool_column_names:
             converters[bool_column_name] = lambda x: _convert_bool(x)
 

--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -546,12 +546,8 @@ class Dataset(object):
             .format(schema=self._schema or self._get_schema(), table_name=self._table_name)
 
     def _copyfrom(self, with_lnglat=None):
-        enc_type = ''
         geom_col = _get_geom_col_name(self._df)
-        if geom_col is not None:
-            first_geom = _first_value(self._df[geom_col])
-            if first_geom:
-                enc_type = detect_encoding_type(first_geom)
+        enc_type = _detect_encoding_type(self._df, geom_col)
         columns = ','.join(norm for norm, orig in self._normalized_column_names)
         self._con.copy_client.copyfrom(
             """COPY {table_name}({columns},the_geom)
@@ -824,3 +820,11 @@ def _first_value(array):
     array = array.loc[~array.isnull()]  # Remove null values
     if len(array) > 0:
         return array.iloc[0]
+
+
+def _detect_encoding_type(df, geom_col):
+    if geom_col is not None:
+        first_geom = _first_value(df[geom_col])
+        if first_geom:
+            return detect_encoding_type(first_geom)
+    return ''

--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -813,11 +813,11 @@ def _get_geom_col_type(df):
             geom = decode_geometry(first_geom, enc_type)
             if geom is not None:
                 return geom.geom_type
+        else:
+            warn('Dataset with null geometries')
 
 
 def _first_value(array):
     array = array.loc[~array.isnull()]  # Remove null values
     if len(array) > 0:
         return array.iloc[0]
-    else:
-        warn('Dataset with null geometries')

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -143,17 +143,11 @@ def detect_encoding_type(input_geom):
     - ENC_WKT: 'POINT (1234 5789)'
     - ENC_EWKT: 'SRID=4326;POINT (1234 5789)'
     """
+    from shapely import wkb
     from shapely.geometry.base import BaseGeometry
 
     if isinstance(input_geom, BaseGeometry):
         return ENC_SHAPELY
-
-    if isinstance(input_geom, bytes):
-        try:
-            ba.unhexlify(input_geom)
-            return ENC_WKB_BHEX
-        except Exception:
-            return ENC_WKB
 
     if isinstance(input_geom, str):
         if re.match(r'^[0-9a-fA-F]+$', input_geom):
@@ -165,7 +159,18 @@ def detect_encoding_type(input_geom):
                 if geom != '':
                     return ENC_EWKT
             elif input_geom != '':
-                return ENC_WKT
+                try:
+                    wkb.loads(input_geom)
+                    return ENC_WKB
+                except Exception:
+                    return ENC_WKT
+
+    if isinstance(input_geom, bytes):
+        try:
+            ba.unhexlify(input_geom)
+            return ENC_WKB_BHEX
+        except Exception:
+            return ENC_WKB
 
 
 def _load_wkb(geom):

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -143,7 +143,6 @@ def detect_encoding_type(input_geom):
     - ENC_WKT: 'POINT (1234 5789)'
     - ENC_EWKT: 'SRID=4326;POINT (1234 5789)'
     """
-    from shapely import wkb, geos
     from shapely.geometry.base import BaseGeometry
 
     if isinstance(input_geom, BaseGeometry):
@@ -204,7 +203,7 @@ def _load_ewkt(egeom):
     ogeom = loads(geom)
     if srid:
         from shapely.geos import lgeos
-        lgeos.GEOSSetSRID(ogeom._geom, srid)
+        lgeos.GEOSSetSRID(ogeom._geom, int(srid))
     return ogeom
 
 

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -98,14 +98,6 @@ def _compute_geometry_from_geom(geom):
     return geom.apply(lambda g: decode_geometry(g, enc_type))
 
 
-def _first_value(array):
-    array = array.loc[~array.isnull()]  # Remove null values
-    if len(array) > 0:
-        return array.iloc[0]
-    else:
-        warn('Dataset with null geometries')
-
-
 def _compute_geometry_from_latlng(lat, lng):
     from shapely import geometry
     return [geometry.Point(xy) for xy in zip(lng, lat)]

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -170,7 +170,7 @@ def detect_encoding_type(input_geom):
         result = re.match(r'^SRID=\d+;(.*)$', input_geom)
         prefix = 'e' if result else ''
         geom = result.group(1) if result else input_geom
-    
+
         if re.match(r'^[0-9a-fA-F]+$', geom):
             return prefix + ENC_WKB_HEX_ASCII
         elif geom != '':

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -164,6 +164,7 @@ def detect_encoding_type(input_geom):
                 if geom != '':
                     return ENC_EWKT
             elif input_geom != '':
+                # This is required because in P27 bytes = str
                 try:
                     wkb.loads(input_geom)
                     return ENC_WKB

--- a/cartoframes/data/utils.py
+++ b/cartoframes/data/utils.py
@@ -43,7 +43,6 @@ ENC_SHAPELY = 'shapely'
 ENC_WKB = 'wkb'
 ENC_WKB_HEX = 'wkb-hex'
 ENC_WKB_HEX_ASCII = 'wkb-hex-ascii'
-ENC_EWKB_HEX_ASCII = 'ewkb-hex-ascii'
 ENC_WKT = 'wkt'
 ENC_EWKT = 'ewkt'
 
@@ -119,18 +118,14 @@ def _encode_decode_decorator(func):
 
 @_encode_decode_decorator
 def decode_geometry(geom, enc_type):
-    """Decode any geometry into a shapely geometry"""
-    from shapely import wkb
-    from shapely import wkt
-
+    """Decode any geometry into a shapely geometry."""
     func = {
         ENC_SHAPELY: lambda: geom,
-        ENC_WKB: lambda: wkb.loads(geom),
-        ENC_WKB_HEX: lambda: wkb.loads(ba.unhexlify(geom)),
-        ENC_WKB_HEX_ASCII: lambda: wkb.loads(geom, hex=True),
-        ENC_EWKB_HEX_ASCII: lambda: wkb.loads(_remove_srid(geom), hex=True),
-        ENC_WKT: lambda: wkt.loads(geom),
-        ENC_EWKT: lambda: wkt.loads(_remove_srid(geom))
+        ENC_WKB: lambda: _load_wkb(geom),
+        ENC_WKB_HEX: lambda: _load_wkb_hex(geom),
+        ENC_WKB_HEX_ASCII: lambda: _load_wkb_hex_ascii(geom),
+        ENC_WKT: lambda: _load_wkt(geom),
+        ENC_EWKT: lambda: _load_ewkt(geom)
     }.get(enc_type)
 
     return func() if func else geom
@@ -140,12 +135,15 @@ def detect_encoding_type(input_geom):
     """
     Detect geometry encoding type:
     - ENC_WKB: b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@'
+    - ENC_EWKB: b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@'
     - ENC_WKB_HEX: b'0101000000000000000048934000000000009db640'
+    - ENC_EWKB_HEX: b'0101000020E6100000000000000048934000000000009DB640'
     - ENC_WKB_HEX_ASCII: '0101000000000000000048934000000000009db640'
-    - ENC_EWKB_HEX_ASCII: 'SRID=4326;0101000000000000000048934000000000009db640'
+    - ENC_EWKB_HEX_ASCII: '0101000020E6100000000000000048934000000000009DB640'
     - ENC_WKT: 'POINT (1234 5789)'
     - ENC_EWKT: 'SRID=4326;POINT (1234 5789)'
     """
+    from shapely import wkb, geos
     from shapely.geometry.base import BaseGeometry
 
     if isinstance(input_geom, BaseGeometry):
@@ -159,19 +157,63 @@ def detect_encoding_type(input_geom):
             return ENC_WKB
 
     if isinstance(input_geom, str):
-        result = re.match(r'^SRID=\d+;(.*)$', input_geom)
-        prefix = 'e' if result else ''
-        geom = result.group(1) if result else input_geom
+        if re.match(r'^[0-9a-fA-F]+$', input_geom):
+            return ENC_WKB_HEX_ASCII
+        else:
+            result = re.match(r'^SRID=\d+;(.*)$', input_geom)
+            if result:
+                geom = result.group(1)
+                if geom != '':
+                    return ENC_EWKT
+            elif input_geom != '':
+                return ENC_WKT
 
-        if re.match(r'^[0-9a-fA-F]+$', geom):
-            return prefix + ENC_WKB_HEX_ASCII
-        elif geom != '':
-            return prefix + ENC_WKT
+
+def _load_wkb(geom):
+    """Load WKB or EWKB geometry."""
+    from shapely.wkb import loads
+    return loads(geom)
 
 
-def _remove_srid(text):
-    result = re.match(r'^SRID=\d+;(.*)$', text)
-    return result.group(1) if result else text
+def _load_wkb_hex(geom):
+    """Load WKB_HEX or EWKB_HEX geometry.
+    The geom must be converted to WKB/EWKB before loading.
+    """
+    from shapely.wkb import loads
+    return loads(ba.unhexlify(geom))
+
+
+def _load_wkb_hex_ascii(geom):
+    """Load WKB_HEX_ASCII or EWKB_HEX_ASCII geometry."""
+    from shapely.wkb import loads
+    return loads(geom, hex=True)
+
+
+def _load_wkt(geom):
+    """Load WKT geometry."""
+    from shapely.wkt import loads
+    return loads(geom)
+
+
+def _load_ewkt(egeom):
+    """Load EWKT geometry.
+    The SRID must be removed before loading and added after loading.
+    """
+    from shapely.wkt import loads
+    (srid, geom) = _extract_srid(egeom)
+    ogeom = loads(geom)
+    if srid:
+        from shapely.geos import lgeos
+        lgeos.GEOSSetSRID(ogeom._geom, srid)
+    return ogeom
+
+
+def _extract_srid(egeom):
+    result = re.match(r'^SRID=(\d+);(.*)$', egeom)
+    if result:
+        return (result.group(1), result.group(2))
+    else:
+        return (0, egeom)
 
 
 def recursive_read(context, query, retry_times=DEFAULT_RETRY_TIMES):

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -145,3 +145,38 @@ class TestDataUtils(unittest.TestCase):
     def test_detect_encoding_type_ewkt(self):
         enc_type = detect_encoding_type('SRID=4326;POINT (1234 5789)')
         self.assertEqual(enc_type, 'ewkt')
+
+    def test_decode_geometry_shapely(self):
+        geom = decode_geometry(Point(1234, 5789), 'shapely')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_wkb(self):
+        geom = decode_geometry(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_wkb_hex(self):
+        geom = decode_geometry(b'0101000000000000000048934000000000009db640', 'wkb-hex')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_wkb_hex_ascii(self):
+        geom = decode_geometry('0101000000000000000048934000000000009db640', 'wkb-hex-ascii')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_ewkb_hex_ascii(self):
+        geom = decode_geometry('SRID=4326;0101000000000000000048934000000000009db640', 'ewkb-hex-ascii')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_wkt(self):
+        geom = decode_geometry('POINT (1234 5789)', 'wkt')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))
+
+    def test_decode_geometry_ewkt(self):
+        geom = decode_geometry('SRID=4326;POINT (1234 5789)', 'ewkt')
+        expected_geom = Point(1234, 5789)
+        self.assertEqual(str(geom), str(expected_geom))

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -133,18 +133,18 @@ class TestDataUtils(unittest.TestCase):
         self.assertEqual(enc_type, 'wkb')
 
     def test_detect_encoding_type_wkb_hex(self):
-        enc_type = detect_encoding_type(b'0101000000000000000048934000000000009db640')
-        self.assertEqual(enc_type, 'wkb-hex')
-
-        enc_type = detect_encoding_type(b'0101000020E6100000000000000048934000000000009DB640')  # ext
-        self.assertEqual(enc_type, 'wkb-hex')
-
-    def test_detect_encoding_type_wkb_hex_ascii(self):
         enc_type = detect_encoding_type('0101000000000000000048934000000000009db640')
-        self.assertEqual(enc_type, 'wkb-hex-ascii')
+        self.assertEqual(enc_type, 'wkb-hex')
 
         enc_type = detect_encoding_type('0101000020E6100000000000000048934000000000009DB640')  # ext
-        self.assertEqual(enc_type, 'wkb-hex-ascii')
+        self.assertEqual(enc_type, 'wkb-hex')
+
+    def test_detect_encoding_type_wkb_bhex(self):
+        enc_type = detect_encoding_type(b'0101000000000000000048934000000000009db640')
+        self.assertEqual(enc_type, 'wkb-bhex')
+
+        enc_type = detect_encoding_type(b'0101000020E6100000000000000048934000000000009DB640')  # ext
+        self.assertEqual(enc_type, 'wkb-bhex')
 
     def test_detect_encoding_type_wkt(self):
         enc_type = detect_encoding_type('POINT (1234 5789)')
@@ -166,33 +166,39 @@ class TestDataUtils(unittest.TestCase):
             b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
+        self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
         geom = decode_geometry(
             b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')  # ext
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
+        self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkb_hex(self):
         expected_geom = Point(1234, 5789)
 
-        geom = decode_geometry(b'0101000000000000000048934000000000009db640', 'wkb-hex')
+        geom = decode_geometry('0101000000000000000048934000000000009DB640', 'wkb-hex')
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
+        self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
-        geom = decode_geometry(b'0101000020E6100000000000000048934000000000009DB640', 'wkb-hex')  # ext
+        geom = decode_geometry('0101000020E6100000000000000048934000000000009DB640', 'wkb-hex')  # ext
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
+        self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
-    def test_decode_geometry_wkb_hex_ascii(self):
+    def test_decode_geometry_wkb_bhex(self):
         expected_geom = Point(1234, 5789)
 
-        geom = decode_geometry('0101000000000000000048934000000000009db640', 'wkb-hex-ascii')
+        geom = decode_geometry(b'0101000000000000000048934000000000009DB640', 'wkb-bhex')
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
+        self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
-        geom = decode_geometry('0101000020E6100000000000000048934000000000009DB640', 'wkb-hex-ascii')  # ext
+        geom = decode_geometry(b'0101000020E6100000000000000048934000000000009DB640', 'wkb-bhex')  # ext
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
+        self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkt(self):
         expected_geom = Point(1234, 5789)
@@ -200,6 +206,7 @@ class TestDataUtils(unittest.TestCase):
         geom = decode_geometry('POINT (1234 5789)', 'wkt')
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
+        self.assertEqual(geom.wkt, 'POINT (1234 5789)')
 
     def test_decode_geometry_ewkt(self):
         expected_geom = Point(1234, 5789)
@@ -207,3 +214,4 @@ class TestDataUtils(unittest.TestCase):
         geom = decode_geometry('SRID=4326;POINT (1234 5789)', 'ewkt')  # ext
         self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
+        self.assertEqual(geom.wkt, 'POINT (1234 5789)')

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -1,5 +1,4 @@
 """Unit tests for cartoframes.data.utils"""
-import sys
 import unittest
 import pandas as pd
 

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -1,4 +1,5 @@
 """Unit tests for cartoframes.data.utils"""
+import sys
 import unittest
 import pandas as pd
 
@@ -139,6 +140,7 @@ class TestDataUtils(unittest.TestCase):
         enc_type = detect_encoding_type('0101000020E6100000000000000048934000000000009DB640')  # ext
         self.assertEqual(enc_type, 'wkb-hex')
 
+    @unittest.skipIf(sys.version_info < (3, 5), 'requires python3.5 or higher')
     def test_detect_encoding_type_wkb_bhex(self):
         enc_type = detect_encoding_type(b'0101000000000000000048934000000000009db640')
         self.assertEqual(enc_type, 'wkb-bhex')
@@ -160,58 +162,41 @@ class TestDataUtils(unittest.TestCase):
         self.assertEqual(str(geom), str(expected_geom))
 
     def test_decode_geometry_wkb(self):
-        expected_geom = Point(1234, 5789)
-
         geom = decode_geometry(
             b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
         geom = decode_geometry(
             b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')  # ext
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkb_hex(self):
-        expected_geom = Point(1234, 5789)
-
         geom = decode_geometry('0101000000000000000048934000000000009DB640', 'wkb-hex')
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
         geom = decode_geometry('0101000020E6100000000000000048934000000000009DB640', 'wkb-hex')  # ext
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
+    @unittest.skipIf(sys.version_info < (3, 5), 'requires python3.5 or higher')
     def test_decode_geometry_wkb_bhex(self):
-        expected_geom = Point(1234, 5789)
-
         geom = decode_geometry(b'0101000000000000000048934000000000009DB640', 'wkb-bhex')
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
         geom = decode_geometry(b'0101000020E6100000000000000048934000000000009DB640', 'wkb-bhex')  # ext
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkt(self):
-        expected_geom = Point(1234, 5789)
-
         geom = decode_geometry('POINT (1234 5789)', 'wkt')
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkt, 'POINT (1234 5789)')
 
     def test_decode_geometry_ewkt(self):
-        expected_geom = Point(1234, 5789)
-
         geom = decode_geometry('SRID=4326;POINT (1234 5789)', 'ewkt')  # ext
-        self.assertEqual(str(geom), str(expected_geom))
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkt, 'POINT (1234 5789)')

--- a/test/data/test_data_utils.py
+++ b/test/data/test_data_utils.py
@@ -9,7 +9,8 @@ from geopandas.geoseries import GeoSeries
 
 from cartoframes.data import Dataset
 from cartoframes.data.utils import compute_query, compute_geodataframe, \
-    decode_geometry, detect_encoding_type
+    decode_geometry, detect_encoding_type, ENC_SHAPELY, ENC_WKB, ENC_WKB_HEX, \
+    ENC_WKB_BHEX, ENC_WKT, ENC_EWKT
 
 from mocks.context_mock import ContextMock
 
@@ -122,81 +123,79 @@ class TestDataUtils(unittest.TestCase):
 
     def test_detect_encoding_type_shapely(self):
         enc_type = detect_encoding_type(Point(1234, 5789))
-        self.assertEqual(enc_type, 'shapely')
+        self.assertEqual(enc_type, ENC_SHAPELY)
 
     def test_detect_encoding_type_wkb(self):
         enc_type = detect_encoding_type(
             b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
-        self.assertEqual(enc_type, 'wkb')
+        self.assertEqual(enc_type, ENC_WKB)
 
         enc_type = detect_encoding_type(
             b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')  # ext
-        self.assertEqual(enc_type, 'wkb')
+        self.assertEqual(enc_type, ENC_WKB)
 
     def test_detect_encoding_type_wkb_hex(self):
         enc_type = detect_encoding_type('0101000000000000000048934000000000009db640')
-        self.assertEqual(enc_type, 'wkb-hex')
+        self.assertEqual(enc_type, ENC_WKB_HEX)
 
         enc_type = detect_encoding_type('0101000020E6100000000000000048934000000000009DB640')  # ext
-        self.assertEqual(enc_type, 'wkb-hex')
+        self.assertEqual(enc_type, ENC_WKB_HEX)
 
-    @unittest.skipIf(sys.version_info < (3, 5), 'requires python3.5 or higher')
     def test_detect_encoding_type_wkb_bhex(self):
         enc_type = detect_encoding_type(b'0101000000000000000048934000000000009db640')
-        self.assertEqual(enc_type, 'wkb-bhex')
+        self.assertEqual(enc_type, ENC_WKB_BHEX)
 
         enc_type = detect_encoding_type(b'0101000020E6100000000000000048934000000000009DB640')  # ext
-        self.assertEqual(enc_type, 'wkb-bhex')
+        self.assertEqual(enc_type, ENC_WKB_BHEX)
 
     def test_detect_encoding_type_wkt(self):
         enc_type = detect_encoding_type('POINT (1234 5789)')
-        self.assertEqual(enc_type, 'wkt')
+        self.assertEqual(enc_type, ENC_WKT)
 
     def test_detect_encoding_type_ewkt(self):
         enc_type = detect_encoding_type('SRID=4326;POINT (1234 5789)')  # ext
-        self.assertEqual(enc_type, 'ewkt')
+        self.assertEqual(enc_type, ENC_EWKT)
 
     def test_decode_geometry_shapely(self):
         expected_geom = Point(1234, 5789)
-        geom = decode_geometry(Point(1234, 5789), 'shapely')
+        geom = decode_geometry(Point(1234, 5789), ENC_SHAPELY)
         self.assertEqual(str(geom), str(expected_geom))
 
     def test_decode_geometry_wkb(self):
         geom = decode_geometry(
-            b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')
+            b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', ENC_WKB)
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
         geom = decode_geometry(
-            b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', 'wkb')  # ext
+            b'\x01\x01\x00\x00 \xe6\x10\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@', ENC_WKB)  # ext
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkb_hex(self):
-        geom = decode_geometry('0101000000000000000048934000000000009DB640', 'wkb-hex')
+        geom = decode_geometry('0101000000000000000048934000000000009DB640', ENC_WKB_HEX)
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
-        geom = decode_geometry('0101000020E6100000000000000048934000000000009DB640', 'wkb-hex')  # ext
+        geom = decode_geometry('0101000020E6100000000000000048934000000000009DB640', ENC_WKB_HEX)  # ext
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb_hex, '0101000000000000000048934000000000009DB640')
 
-    @unittest.skipIf(sys.version_info < (3, 5), 'requires python3.5 or higher')
     def test_decode_geometry_wkb_bhex(self):
-        geom = decode_geometry(b'0101000000000000000048934000000000009DB640', 'wkb-bhex')
+        geom = decode_geometry(b'0101000000000000000048934000000000009DB640', ENC_WKB_BHEX)
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
-        geom = decode_geometry(b'0101000020E6100000000000000048934000000000009DB640', 'wkb-bhex')  # ext
+        geom = decode_geometry(b'0101000020E6100000000000000048934000000000009DB640', ENC_WKB_BHEX)  # ext
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkb, b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00H\x93@\x00\x00\x00\x00\x00\x9d\xb6@')
 
     def test_decode_geometry_wkt(self):
-        geom = decode_geometry('POINT (1234 5789)', 'wkt')
+        geom = decode_geometry('POINT (1234 5789)', ENC_WKT)
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 0)
         self.assertEqual(geom.wkt, 'POINT (1234 5789)')
 
     def test_decode_geometry_ewkt(self):
-        geom = decode_geometry('SRID=4326;POINT (1234 5789)', 'ewkt')  # ext
+        geom = decode_geometry('SRID=4326;POINT (1234 5789)', ENC_EWKT)  # ext
         self.assertEqual(lgeos.GEOSGetSRID(geom._geom), 4326)
         self.assertEqual(geom.wkt, 'POINT (1234 5789)')

--- a/test/mocks/context_mock.py
+++ b/test/mocks/context_mock.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 class CredsMock():
     def __init__(self, key=None, username=None):
         self._key = key

--- a/test/mocks/context_mock.py
+++ b/test/mocks/context_mock.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 class CredsMock():
     def __init__(self, key=None, username=None):
         self._key = key

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -585,13 +585,13 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
     def test_rows(self):
         df = pd.DataFrame.from_dict({'test': [True, [1, 2]]})
         ds = Dataset.from_dataframe(df)
-        rows = ds._rows(ds.dataframe, ['test'], None, '')
+        rows = ds._rows(ds.dataframe, ['test'], None, '', '')
 
         self.assertEqual(list(rows), [b'True|\n', b'[1, 2]|\n'])
 
     def test_rows_null(self):
         df = pd.DataFrame.from_dict({'test': [None, [None, None]]})
         ds = Dataset.from_dataframe(df)
-        rows = ds._rows(ds.dataframe, ['test'], None, '')
+        rows = ds._rows(ds.dataframe, ['test'], None, '', '')
 
         self.assertEqual(list(rows), [b'|\n', b'|\n'])

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -12,7 +12,7 @@ from carto.exceptions import CartoException
 
 from cartoframes.auth import Context
 from cartoframes.data import Dataset
-from cartoframes.data.utils import decode_geometry, setting_value_exception
+from cartoframes.data.utils import setting_value_exception
 from cartoframes.columns import normalize_name
 from cartoframes.geojson import load_geojson
 from mocks.dataset_mock import DatasetMock
@@ -495,13 +495,6 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         dataset = Dataset.from_table(table_name='fake_table', context=FakeContext())
         self.assertEqual(dataset._schema, username)
-
-    def test_decode_geometry(self):
-        # Point (0, 0) without SRID
-        ewkb = '010100000000000000000000000000000000000000'
-        decoded_geom = decode_geometry(ewkb)
-        self.assertEqual(decoded_geom.wkt, 'POINT (0 0)')
-        self.assertIsNone(decode_geometry(None))
 
     # FIXME does not work in python 2.7 (COPY stucks and blocks the table, fix after
     # https://github.com/CartoDB/CartoDB-SQL-API/issues/579 is fixed)

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -1,5 +1,4 @@
 pytest
 geopandas
 matplotlib
-shapely
 coveralls

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 geopandas
 matplotlib
 coveralls
+mock

--- a/test/viz/helpers/test_color_bins_layer.py
+++ b/test/viz/helpers/test_color_bins_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/helpers/test_color_category_layer.py
+++ b/test/viz/helpers/test_color_category_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/helpers/test_size_bins_layer.py
+++ b/test/viz/helpers/test_size_bins_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/helpers/test_size_category_layer.py
+++ b/test/viz/helpers/test_size_category_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/helpers/test_size_continuous_layer.py
+++ b/test/viz/helpers/test_size_continuous_layer.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from cartoframes.viz import helpers, Source
 
 

--- a/test/viz/test_widget_list.py
+++ b/test/viz/test_widget_list.py
@@ -64,8 +64,8 @@ class TestWidgetList(unittest.TestCase):
         """WidgetList should be properly initialized"""
 
         widget_list = WidgetList([
-          Widget(widget_a),
-          Widget(widget_b)
+            Widget(widget_a),
+            Widget(widget_b)
         ])
 
         self.assertTrue(isinstance(widget_list.widgets[0], Widget))
@@ -74,8 +74,8 @@ class TestWidgetList(unittest.TestCase):
     def test_widget_list_variables(self):
         """Widget List should return a proper variables object"""
         widget_list = WidgetList([
-          Widget(widget_a),
-          Widget(widget_b)
+            Widget(widget_a),
+            Widget(widget_b)
         ])
 
         variables = widget_list.get_variables()
@@ -94,24 +94,24 @@ class TestWidgetList(unittest.TestCase):
         """Widget List should return a proper widgets info object"""
 
         widget_list = WidgetList([
-          Widget(widget_a),
-          Widget(widget_b)
+            Widget(widget_a),
+            Widget(widget_b)
         ])
 
         widgets_info = widget_list.get_widgets_info()
         self.assertEqual(widgets_info, [
-          {
-            'type': 'formula',
-            'name': 'vb6dbcf',
-            'value': 'viewportSum($amount)',
-            'title': '[TITLE]',
-            'description': '[description]',
-            'footer': '[footer]'
-          }, {
-            'type': 'default',
-            'name': 'v76441e',
-            'value': '"Custom Info"',
-            'title': '',
-            'description': '',
-            'footer': ''
-          }])
+            {
+                'type': 'formula',
+                'name': 'vb6dbcf',
+                'value': 'viewportSum($amount)',
+                'title': '[TITLE]',
+                'description': '[description]',
+                'footer': '[footer]'
+            }, {
+                'type': 'default',
+                'name': 'v76441e',
+                'value': '"Custom Info"',
+                'title': '',
+                'description': '',
+                'footer': ''
+            }])


### PR DESCRIPTION
Related to #773, #798

This PR adds a method to detect the geometry encoding type. With that information, the `decode_geometry` function has been refactored to use the enc_type instead. This improves the performance and also increases the support of all possible encoding types.