### PR TITLE
pegs binder to develop (for now)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Try it Out
 * Latest (develop branch): |develop|
 
 .. |stable| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/cartodb/cartoframes/v1.0b1?filepath=examples
+    :target: https://mybinder.org/v2/gh/cartodb/cartoframes/v0.10.1?filepath=examples
 
 .. |develop| image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/cartodb/cartoframes/develop?filepath=examples

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,18 @@ CARTOframes
     :target: https://travis-ci.org/CartoDB/cartoframes
 .. image:: https://coveralls.io/repos/github/CartoDB/cartoframes/badge.svg?branch=master
     :target: https://coveralls.io/github/CartoDB/cartoframes?branch=master
-.. image:: https://mybinder.org/badge_logo.svg
+
+Try it Out
+==========
+
+* Stable (v0.10.1): |stable|
+* Latest (develop branch): |develop|
+
+.. |stable| image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/cartodb/cartoframes/v1.0b1?filepath=examples
+
+.. |develop| image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/cartodb/cartoframes.git/develop?filepath=examples
 
 A Python package for integrating `CARTO <https://carto.com/>`__ maps, analysis, and data services into data science workflows.
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@ CARTOframes
     :target: https://coveralls.io/github/CartoDB/cartoframes?branch=master
 
 Try it Out
-==========
 
 * Stable (v0.10.1): |stable|
 * Latest (develop branch): |develop|
@@ -17,7 +16,7 @@ Try it Out
     :target: https://mybinder.org/v2/gh/cartodb/cartoframes/v1.0b1?filepath=examples
 
 .. |develop| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/cartodb/cartoframes.git/develop?filepath=examples
+    :target: https://mybinder.org/v2/gh/cartodb/cartoframes/develop?filepath=examples
 
 A Python package for integrating `CARTO <https://carto.com/>`__ maps, analysis, and data services into data science workflows.
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,12 @@ CARTOframes
 .. image:: https://coveralls.io/repos/github/CartoDB/cartoframes/badge.svg?branch=master
     :target: https://coveralls.io/github/CartoDB/cartoframes?branch=master
 
+A Python package for integrating `CARTO <https://carto.com/>`__ maps, analysis, and data services into data science workflows.
+
+Python data analysis workflows often rely on the de facto standards `pandas <http://pandas.pydata.org/>`__ and `Jupyter notebooks <http://jupyter.org/>`__. Integrating CARTO into this workflow saves data scientists time and energy by not having to export datasets as files or retain multiple copies of the data. Instead, CARTOframes give the ability to communicate reproducible analysis while providing the ability to gain from CARTO's services like hosted, dynamic or static maps and `Data Observatory <https://carto.com/platform/location-data-streams/>`__ augmentation.
+
 Try it Out
+----------
 
 * Stable (v0.10.1): |stable|
 * Latest (develop branch): |develop|
@@ -17,10 +22,6 @@ Try it Out
 
 .. |develop| image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/cartodb/cartoframes/develop?filepath=examples
-
-A Python package for integrating `CARTO <https://carto.com/>`__ maps, analysis, and data services into data science workflows.
-
-Python data analysis workflows often rely on the de facto standards `pandas <http://pandas.pydata.org/>`__ and `Jupyter notebooks <http://jupyter.org/>`__. Integrating CARTO into this workflow saves data scientists time and energy by not having to export datasets as files or retain multiple copies of the data. Instead, CARTOframes give the ability to communicate reproducible analysis while providing the ability to gain from CARTO's services like hosted, dynamic or static maps and `Data Observatory <https://carto.com/platform/location-data-streams/>`__ augmentation.
 
 Features
 ========

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ A Python package for integrating `CARTO <https://carto.com/>`__ maps, analysis, 
 Python data analysis workflows often rely on the de facto standards `pandas <http://pandas.pydata.org/>`__ and `Jupyter notebooks <http://jupyter.org/>`__. Integrating CARTO into this workflow saves data scientists time and energy by not having to export datasets as files or retain multiple copies of the data. Instead, CARTOframes give the ability to communicate reproducible analysis while providing the ability to gain from CARTO's services like hosted, dynamic or static maps and `Data Observatory <https://carto.com/platform/location-data-streams/>`__ augmentation.
 
 Try it Out
-----------
+==========
 
 * Stable (v0.10.1): |stable|
 * Latest (develop branch): |develop|

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-cartoframes
+-e git+https://github.com/cartodb/cartoframes.git@develop#egg=cartoframes
 # Additional dependencies from examples
 matplotlib
 pandas


### PR DESCRIPTION
If a user clicks the try in mybinder link in the README, they are taken to v0.10.1 cartoframes (since that's what pip gives them -- pip knows not to get the pre-release v1.0b1). This is confusing.

What we probably should do is update the readme and have two links:
* Stable: points to mybinder that installs from v0.10.1 and installs that release from pip
~~* Latest beta: points to v1.0b1 and installs that release from pip~~
* Develop: points to develop branch and installs cartoframes from there

We can't change the v1.0b1 tag to update the binder/requirements.txt file, so we're not going to offer the beta install at this point.