### PR TITLE
adds html repr to layer

### DIFF
--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -126,7 +126,7 @@ class Layer(object):
         self.widgets_info = self.widgets.get_widgets_info()
 
     def _repr_html_(self):
-        from .map import Map 
+        from .map import Map
         return Map(self)._repr_html_()
 
 

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -18,28 +18,28 @@ except ImportError:
 
 class Layer(object):
     """Layer to display data on a map. This class can be used as one or more
-    layers on :py:class:`Map <cartoframes.viz.Map>` or on its own in a Jupyter
+    layers in :py:class:`Map <cartoframes.viz.Map>` or on its own in a Jupyter
     notebook to get a preview of a Layer.
 
     Args:
-        source (Union[str, :py:class:`Dataset <cartoframes.data.Dataset>`, pandas.DataFrame]):
+        source (str, :py:class:`Dataset <cartoframes.data.Dataset>`, or pandas.DataFrame):
           The source data.
-        style (Union[str, dict, :py:class:`Style <cartoframes.viz.Style>`], optional):
+        style (str, dict, or :py:class:`Style <cartoframes.viz.Style>`, optional):
           The style of the visualization: `CARTO VL styling
           <https://carto.com/developers/carto-vl/guides/style-with-expressions/>`__.
-        popup (Union[dict, :py:class:`Popup <cartoframes.viz.Popup>`], optional):
+        popup (dict or :py:class:`Popup <cartoframes.viz.Popup>`, optional):
           This option adds interactivity (click and hover) to a layer to show popups.
           The columns to be shown must be added in a list format for each event. It
           must be written using `CARTO VL expressions syntax
           <https://carto.com/developers/carto-vl/reference/#cartoexpressions>`__.
           See :py:class:`Popup <cartoframes.viz.Popup>` for more information.
-        legend (Union[dict, :py:class:`Legend <cartoframes.viz.Legend>`], optional):
+        legend (dict or :py:class:`Legend <cartoframes.viz.Legend>`, optional):
           The legend definition for a layer. It contains the information
           to show a legend "type" (``color-category``, ``color-bins``,
           ``color-continuous``), "prop" (color) and also text information:
           "title", "description" and "footer". See :py:class:`Legend
           <cartoframes.viz.Legend>` for more information.
-        widgets (Union[dict, list, :py:class `WidgetList <cartoframes.viz.WidgetList>`], optional):
+        widgets (dict, list, or :py:class:`WidgetList <cartoframes.viz.WidgetList>`, optional):
            Widget or list of widgets for a layer. It contains the information to display
            different widget types on the top right of the map. See
            :py:class:`WidgetList` for more information.

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -22,23 +22,27 @@ class Layer(object):
     notebook to get a preview of a Layer.
 
     Args:
-        source (str, :py:class:`Dataset <cartoframes.data.Dataset>`):
+        source (Union[str, :py:class:`Dataset <cartoframes.data.Dataset>`, pandas.DataFrame]):
           The source data.
-        style (str, dict, :py:class:`Style <cartoframes.viz.Style>`, optional):
+        style (Union[str, dict, :py:class:`Style <cartoframes.viz.Style>`], optional):
           The style of the visualization: `CARTO VL styling
-          <https://carto.com/developers/carto-vl/guides/style-with-expressions/>`.
-        popup (dict, :py:class:`Popup <cartoframes.viz.Popup>`, optional):
+          <https://carto.com/developers/carto-vl/guides/style-with-expressions/>`__.
+        popup (Union[dict, :py:class:`Popup <cartoframes.viz.Popup>`], optional):
           This option adds interactivity (click and hover) to a layer to show popups.
           The columns to be shown must be added in a list format for each event. It
           must be written using `CARTO VL expressions syntax
-          <https://carto.com/developers/carto-vl/reference/#cartoexpressions>`.
-        legend (dict, :py:class:`Legend <cartoframes.viz.Legend>`, optional):
+          <https://carto.com/developers/carto-vl/reference/#cartoexpressions>`__.
+          See :py:class:`Popup <cartoframes.viz.Popup>` for more information.
+        legend (Union[dict, :py:class:`Legend <cartoframes.viz.Legend>`], optional):
           The legend definition for a layer. It contains the information
-          to show a legend "type" (color-category, color-bins, color-continuous),
-          "prop" (color) and also text information: "title", "description" and "footer".
-        widgets (dict, :py:class `WidgetList <cartoframes.viz.WidgetList>`, optional):
+          to show a legend "type" (``color-category``, ``color-bins``,
+          ``color-continuous``), "prop" (color) and also text information:
+          "title", "description" and "footer". See :py:class:`Legend
+          <cartoframes.viz.Legend>` for more information.
+        widgets (Union[dict, list, :py:class `WidgetList <cartoframes.viz.WidgetList>`], optional):
            Widget or list of widgets for a layer. It contains the information to display
-           different widget types on the top right of the map.
+           different widget types on the top right of the map. See
+           :py:class:`WidgetList` for more information.
         context (:py:class:`Context <cartoframes.auth.Context>`):
           A Context instance. This is only used for the simplified Source API.
           When a :py:class:`Source <cartoframes.viz.Source>` is pased as source,

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -125,6 +125,10 @@ class Layer(object):
         )
         self.widgets_info = self.widgets.get_widgets_info()
 
+    def _repr_html_(self):
+        from .map import Map 
+        return Map(self)._repr_html_()
+
 
 def _set_source(source, context):
     """Set a Source class from the input"""

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -17,7 +17,9 @@ except ImportError:
 
 
 class Layer(object):
-    """Layer
+    """Layer to display data on a map. This class can be used as one or more
+    layers on :py:class`Map <cartoframes.viz.Map>` or on its own in a Jupyter
+    notebook to get a preview of a Layer.
 
     Args:
         source (str, :py:class:`Dataset <cartoframes.data.Dataset>`):
@@ -45,14 +47,16 @@ class Layer(object):
 
     Example:
 
+        Create a layer with a custom popup, legend, and widget.
+
         .. code::
 
             from cartoframes.auth import set_default_context
             from cartoframes.viz import Layer
 
             set_default_context(
-                base_url='https://your_user_name.carto.com',
-                api_key='your api key'
+                base_url='https://cartovl.carto.com',
+                api_key='default_public'
             )
 
             Layer(
@@ -68,29 +72,51 @@ class Layer(object):
                 },
                 widgets=[{
                     'type': 'formula',
-                    'title': 'Avg $pop_max'
+                    'title': 'Avg $pop_max',
                     'value': 'viewportAvg($pop_max)'
                 }]
             )
 
-        Setting the context.
+        Create a layer specifically tied to a :py:class:`Context
+        <cartoframes.auth.Context>` and display it on a map.
 
         .. code::
 
             from cartoframes.auth import Context
-            from cartoframes.viz import Layer
+            from cartoframes.viz import Layer, Map
 
             context = Context(
                 base_url='https://your_user_name.carto.com',
                 api_key='your api key'
             )
 
-            Layer(
+            pop_layer = Layer(
                 'populated_places',
-                'color: "red"',
+                'color: red',
                 context=context
             )
+            Map(pop_layer)
 
+        Preview a layer in a Jupyter notebook. Note: if in a Jupyter notebook,
+        it is not required to explicitly add a Layer to a :py:class:`Map
+        <cartoframes.viz.Map>` if only visualizing data as a single layer.
+
+        .. code::
+
+            from cartoframes.auth import set_default_context
+            from cartoframes.viz import Layer, Map
+
+            set_default_context('https://cartoframes.carto.com')
+
+            pop_layer = Layer(
+                'brooklyn_poverty',
+                'color: ramp($poverty_per_pop, sunset)',
+                legend={
+                    'type': 'color-continuous',
+                    'title': 'Poverty per pop'
+                }
+            )
+            pop_layer
     """
 
     def __init__(self,

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -18,13 +18,13 @@ except ImportError:
 
 class Layer(object):
     """Layer to display data on a map. This class can be used as one or more
-    layers on :py:class`Map <cartoframes.viz.Map>` or on its own in a Jupyter
+    layers on :py:class:`Map <cartoframes.viz.Map>` or on its own in a Jupyter
     notebook to get a preview of a Layer.
 
     Args:
         source (str, :py:class:`Dataset <cartoframes.data.Dataset>`):
           The source data.
-        style (str, dict, :py:class:`Style <cartoframes.vis.Style>`, optional):
+        style (str, dict, :py:class:`Style <cartoframes.viz.Style>`, optional):
           The style of the visualization: `CARTO VL styling
           <https://carto.com/developers/carto-vl/guides/style-with-expressions/>`.
         popup (dict, :py:class:`Popup <cartoframes.viz.Popup>`, optional):
@@ -39,7 +39,7 @@ class Layer(object):
         widgets (dict, :py:class `WidgetList <cartoframes.viz.WidgetList>`, optional):
            Widget or list of widgets for a layer. It contains the information to display
            different widget types on the top right of the map.
-        context (:py:class:`Context <cartoframes.Context>`):
+        context (:py:class:`Context <cartoframes.auth.Context>`):
           A Context instance. This is only used for the simplified Source API.
           When a :py:class:`Source <cartoframes.viz.Source>` is pased as source,
           this context is simply ignored. If not provided the context will be
@@ -60,7 +60,7 @@ class Layer(object):
             )
 
             Layer(
-                'SELECT * FROM populated_places WHERE adm0name = \'Spain\'',
+                "SELECT * FROM populated_places WHERE adm0name = 'Spain'",
                 'color: ramp(globalQuantiles($pop_max, 5), reverse(purpor))',
                 popup={
                     'hover': '$name',
@@ -86,8 +86,8 @@ class Layer(object):
             from cartoframes.viz import Layer, Map
 
             context = Context(
-                base_url='https://your_user_name.carto.com',
-                api_key='your api key'
+                base_url='https://cartovl.carto.com',
+                api_key='default_public'
             )
 
             pop_layer = Layer(

--- a/cartoframes/viz/legend.py
+++ b/cartoframes/viz/legend.py
@@ -7,10 +7,16 @@ class Legend(object):
     """Legend
 
     Args:
-        data (dict): The legend definition for a layer. It contains the information to render a legend:
-          `type`: color-category, color-bins, color-continuous, size-bins, size-continuous.
-          `prop` (optional): color, width, strokeColor, strokeWidth.
-          The legend also can display text information: `title`, `description` and `footer`.
+        data (dict): The legend definition for a layer. It contains the
+          information to render a legend:
+
+          - `type`: ``color-category``, ``color-bins``, ``color-continuous``,
+            ``size-bins``, or ``size-continuous``
+          - `prop` (optional): ``color``, ``width``, ``strokeColor``, or ``strokeWidth``
+          - `title` (optional): Title of legend
+          - `description` (optional): Description in legend
+          - `footer` (optional): Footer of legend. This is often used to
+            attribute data sources.
 
     Example:
 


### PR DESCRIPTION
The goal of this is to make `Layer` easier to use / more accessible. While the Layer will behave the same way within `Map`, this just adds the `_repr_html_` so that within Jupyter, we get a preview of the layer.
<img width="775" alt="Screen Shot 2019-07-16 at 1 24 14 PM" src="https://user-images.githubusercontent.com/1041056/61315566-08d7b780-a7cd-11e9-8a26-d0167e76a4d6.png">

~~I'm concerned about this being a circular dependency because Map requires Layer, and `Layer()._repr_html_()` requires Map.~~ -> _Not the case. While Map uses layer properties, it doesn't require/import `Layer`._

Besides this, it'd be nice to have a string representation, but that depends on other things, like `Source` and `Dataset` having string representations too, so that should wait for another PR.