### PR TITLE
Animation helper

### DIFF
--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -1,3 +1,5 @@
+from carto.exceptions import CartoException
+
 from .registry.strategies_registry import StrategiesRegistry
 from .registry.dataframe_dataset import DataFrameDataset
 from .registry.query_dataset import QueryDataset

--- a/cartoframes/viz/helpers/__init__.py
+++ b/cartoframes/viz/helpers/__init__.py
@@ -9,6 +9,7 @@ from .color_continuous_layer import color_continuous_layer
 from .size_bins_layer import size_bins_layer
 from .size_category_layer import size_category_layer
 from .size_continuous_layer import size_continuous_layer
+from .animation_layer import animation_layer
 
 
 def _inspect(helper):
@@ -23,5 +24,6 @@ __all__ = [
     'color_continuous_layer',
     'size_bins_layer',
     'size_category_layer',
-    'size_continuous_layer'
+    'size_continuous_layer',
+    'animation_layer'
 ]

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -4,7 +4,7 @@ from ..layer import Layer
 
 
 def animation_layer(
-        source, value, title='', widget='animation', description=''):
+        source, value, title='', color=None, widget_type='time-series', description=''):
     """Helper function for quickly creating an animated map
 
     Args:
@@ -12,8 +12,11 @@ def animation_layer(
           or text representing a table or query associated with user account.
         value (str): Column to symbolize by.
         title (str, optional): Title of legend.
-        widget (str, optional): Type of animation widget: "animation" or "time-series".
-          The default is "animation".
+        color (str, optional): Hex value, rgb expression, or other valid
+          CARTO VL color. Default is '#EE5D5A' for point geometries,
+          '#4CC8A3' for lines and 'TODO' for polygons.
+        widget_type (str, optional): Type of animation widget: "animation" or "time-series".
+          The default is "time-series".
         description (str, optional): Description text legend placed under legend title.
 
     Returns:
@@ -22,10 +25,21 @@ def animation_layer(
     return Layer(
         source,
         style={
-            'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+            'point': {
+                'color': 'opacity({0}, 0.8)'.format(color or '#EE4D5A'),
+                'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+            },
+            'line': {
+                'color': 'opacity({0}, 0.8)'.format(color or '#4CC8A3'),
+                'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+            },
+            'polygon': {
+                'color': 'opacity({0}, 0.8)'.format(color or 'TODO'),
+                'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+            }
         },
         widgets=[{
-            'type': widget,
+            'type': widget_type,
             'value': value,
             'title': title,
             'description': description

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -5,7 +5,7 @@ from ..layer import Layer
 
 def animation_layer(
         source, value, title='', color=None, widget_type='time-series', description=''):
-    """Helper function for quickly creating an animated map
+    """Helper function for quickly creating an animated map.
 
     Args:
         source (:py:class:`Dataset <cartoframes.data.Dataset>` or str): Dataset

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from ..layer import Layer
+
+
+def animation_layer(
+        source, value, title='', widget='animation', description=''):
+    """Helper function for quickly creating an animated map
+
+    Args:
+        source (:py:class:`Dataset <cartoframes.data.Dataset>` or str): Dataset
+          or text representing a table or query associated with user account.
+        value (str): Column to symbolize by.
+        title (str, optional): Title of legend.
+        widget (str, optional): Type of animation widget: "animation" or "time-series".
+          The default is "animation".
+        description (str, optional): Description text legend placed under legend title.
+
+    Returns:
+        cartoframes.viz.Layer: Layer styled by `value`. Includes Widget `value`.
+    """
+    return Layer(
+        source,
+        style={
+            'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+        },
+        widgets=[{
+            'type': widget,
+            'value': value,
+            'title': title,
+            'description': description
+        }]
+    )

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -7,7 +7,7 @@ def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, palette=None, description='', footer='',
         legend=True, popup=True, widget=True, animate=None):
-    """Helper function for quickly creating a classed color map
+    """Helper function for quickly creating a classed color map.
 
     Args:
         source (:py:class:`Dataset <cartoframes.data.Dataset>` or str): Dataset

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -22,10 +22,13 @@ def color_bins_layer(
           or other valid CARTO VL palette expression. Default is `purpor`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "True" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -28,8 +28,8 @@ def color_bins_layer(
         animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
     if method not in ('quantiles', 'equal', 'stdev'):
         raise ValueError('Available methods are: "quantiles", "equal", "stdev".')

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -5,7 +5,8 @@ from ..layer import Layer
 
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, palette=None, description='', footer=''):
+        breaks=None, palette=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a classed color map
 
     Args:
@@ -21,6 +22,10 @@ def color_bins_layer(
           or other valid CARTO VL palette expression. Default is `purpor`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
@@ -40,30 +45,35 @@ def color_bins_layer(
         'equal': 'purpor',
         'stdev': 'temps'
     }.get(method)
+    
+    animation_filter = 'animation(linear(${0}), 20, fade(1,1))'.format(animate) if animate else '1'
 
     return Layer(
         source,
         style={
             'point': {
                 'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, breaks or bins, palette or default_palette)
+                    func, value, breaks or bins, palette or default_palette),
+                'filter': animation_filter
             },
             'line': {
                 'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, breaks or bins, palette or default_palette)
+                    func, value, breaks or bins, palette or default_palette),
+                'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), 0.9)'.format(
-                    func, value, breaks or bins, palette or default_palette)
+                    func, value, breaks or bins, palette or default_palette),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'color-bins-point',
                 'line': 'color-bins-line',
@@ -72,5 +82,17 @@ def color_bins_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'histogram',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -46,7 +46,7 @@ def color_bins_layer(
         'stdev': 'temps'
     }.get(method)
     
-    animation_filter = 'animation(linear(${0}), 20, fade(1,1))'.format(animate) if animate else '1'
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, palette=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a classed color map.
 
     Args:
@@ -26,8 +26,8 @@ def color_bins_layer(
             Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
             Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
-            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data: "True" or "False". 
+            Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -23,10 +23,10 @@ def color_bins_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data: "True" or "False". 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data: "True" or "False".
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
@@ -48,7 +48,7 @@ def color_bins_layer(
         'equal': 'purpor',
         'stdev': 'temps'
     }.get(method)
-    
+
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
     return Layer(

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -23,11 +23,11 @@ def color_bins_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data: "True" or "False". 
-            Set to "False" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def color_category_layer(
         source, value, title='', top=11, cat=None,
         palette=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a category color map.
 
     Args:
@@ -22,10 +22,13 @@ def color_category_layer(
           or other valid CARTO VL palette expression. Default is `bold`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "False" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.
@@ -78,7 +81,7 @@ def color_category_layer(
             widget and {
                 'type': 'category',
                 'value': value,
-                'title': 'Distribution'
+                'title': 'Categories'
             }
         ]
     )

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -23,11 +23,11 @@ def color_category_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data. 
-            Set to "False" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -28,8 +28,8 @@ def color_category_layer(
         animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
     func = 'buckets' if cat else 'top'
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -23,10 +23,10 @@ def color_category_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -5,7 +5,8 @@ from ..layer import Layer
 
 def color_category_layer(
         source, value, title='', top=11, cat=None,
-        palette=None, description='', footer=''):
+        palette=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a category color map.
 
     Args:
@@ -21,35 +22,44 @@ def color_category_layer(
           or other valid CARTO VL palette expression. Default is `bold`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
         popup on `value`.
     """
     func = 'buckets' if cat else 'top'
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
+
     return Layer(
         source,
         style={
             'point': {
                 'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, cat or top, palette or 'bold')
+                    func, value, cat or top, palette or 'bold'),
+                'filter': animation_filter
             },
             'line': {
                 'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, cat or top, palette or 'bold')
+                    func, value, cat or top, palette or 'bold'),
+                'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), 0.9)'.format(
-                    func, value, cat or top, palette or 'bold')
+                    func, value, cat or top, palette or 'bold'),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'color-category-point',
                 'line': 'color-category-line',
@@ -58,5 +68,17 @@ def color_category_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'category',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -18,11 +18,11 @@ def color_continuous_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data. 
-            Set to "False" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def color_continuous_layer(
         source, value, title='', palette=None, description='', footer='',
         legend=True, popup=True, widget=True, animate=None):
-    """Helper function for quickly creating a continuous color map
+    """Helper function for quickly creating a continuous color map.
 
     Args:
         source (:py:class:`Dataset <cartoframes.data.Dataset>` or str): Dataset

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -18,10 +18,10 @@ def color_continuous_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -5,7 +5,7 @@ from ..layer import Layer
 
 def color_continuous_layer(
         source, value, title='', palette=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a continuous color map.
 
     Args:
@@ -17,10 +17,13 @@ def color_continuous_layer(
           or other valid CARTO VL palette expression. Default is `bluyl`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "False" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -4,7 +4,8 @@ from ..layer import Layer
 
 
 def color_continuous_layer(
-        source, value, title='', palette=None, description='', footer=''):
+        source, value, title='', palette=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a continuous color map
 
     Args:
@@ -16,34 +17,43 @@ def color_continuous_layer(
           or other valid CARTO VL palette expression. Default is `bluyl`.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
+
     return Layer(
         source,
         style={
             'point': {
                 'color': 'ramp(linear(${0}), {1})'.format(
-                    value, palette or 'bluyl')
+                    value, palette or 'bluyl'),
+                'filter': animation_filter
             },
             'line': {
                 'color': 'ramp(linear(${0}), {1})'.format(
-                    value, palette or 'bluyl')
+                    value, palette or 'bluyl'),
+                'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp(linear(${0}), {1}), 0.9)'.format(
-                    value, palette or 'bluyl')
+                    value, palette or 'bluyl'),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'color-continuous-point',
                 'line': 'color-continuous-line',
@@ -52,5 +62,17 @@ def color_continuous_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'histogram',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -5,7 +5,8 @@ from ..layer import Layer
 
 def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, size=None, color=None, description='', footer=''):
+        breaks=None, size=None, color=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
 
@@ -25,10 +26,14 @@ def size_bins_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
     if method not in ('quantiles', 'equal', 'stdev'):
         raise ValueError('Available methods are: "quantiles", "equal", "stdev".')
@@ -39,6 +44,8 @@ def size_bins_layer(
         'stdev': 'globalStandardDev'
     }.get(method)
 
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
+
     return Layer(
         source,
         style={
@@ -46,22 +53,24 @@ def size_bins_layer(
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [2, 14]),
                 'color': 'opacity({0}, 0.8)'.format(
-                    color or '#EE4D5A')
+                    color or '#EE4D5A'),
+                'filter': animation_filter
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [1, 10]),
                 'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3')
+                    color or '#4CC8A3'),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'size-bins-point',
                 'line': 'size-bins-line',
@@ -70,5 +79,17 @@ def size_bins_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'histogram',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -26,10 +26,10 @@ def size_bins_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, size=None, color=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
 
@@ -25,11 +25,13 @@ def size_bins_layer(
           CARTO VL color. Default is '#EE5D5A' for point geometries and
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
-        footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "True" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -26,11 +26,11 @@ def size_bins_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data. 
-            Set to "True" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -83,7 +83,7 @@ def size_category_layer(
             widget and {
                 'type': 'category',
                 'value': value,
-                'title': 'Distribution'
+                'title': 'Categories'
             }
         ]
     )

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -26,10 +26,10 @@ def size_category_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -26,11 +26,11 @@ def size_category_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data. 
-            Set to "True" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def size_category_layer(
         source, value, title='', top=5, cat=None,
         size=None, color=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size category layer.
 
     Args:
@@ -25,10 +25,13 @@ def size_category_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "True" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -5,7 +5,8 @@ from ..layer import Layer
 
 def size_category_layer(
         source, value, title='', top=5, cat=None,
-        size=None, color=None, description='', footer=''):
+        size=None, color=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a size category layer.
 
     Args:
@@ -24,12 +25,18 @@ def size_category_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
     func = 'buckets' if cat else 'top'
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
+
     return Layer(
         source,
         style={
@@ -37,22 +44,24 @@ def size_category_layer(
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [2, 20]),
                 'color': 'opacity({0}, 0.8)'.format(
-                    color or '#F46D43')
+                    color or '#F46D43'),
+                'filter': animation_filter
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [1, 10]),
                 'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3')
+                    color or '#4CC8A3'),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'size-category-point',
                 'line': 'size-category-line',
@@ -61,5 +70,17 @@ def size_category_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'category',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -6,7 +6,7 @@ from ..layer import Layer
 def size_continuous_layer(
         source, value, title='', size=None,
         color=None, description='', footer='',
-        legend=True, popup=True, widget=True, animate=None):
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by `value`.
 
@@ -22,10 +22,13 @@ def size_continuous_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
-        legend (bool, optional): TODO.
-        popup (bool, optional): TODO.
-        widget (bool, optional): TODO.
-        animate (str, optional): TODO.
+        legend (bool, optional): Display map legend: "True" or "False".
+            Set to "True" by default. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False". 
+            Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data. 
+            Set to "False" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:
         cartoframes.viz.Layer: Layer styled by `value`.

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -23,10 +23,10 @@ def size_continuous_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-          Set to "True" by default. 
-        popup (bool, optional): Display popups on hover and click: "True" or "False". 
           Set to "True" by default.
-        widget (bool, optional): Display a widget for mapped data. 
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
           Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -23,11 +23,11 @@ def size_continuous_layer(
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
-            Set to "True" by default. 
+          Set to "True" by default. 
         popup (bool, optional): Display popups on hover and click: "True" or "False". 
-            Set to "True" by default.
+          Set to "True" by default.
         widget (bool, optional): Display a widget for mapped data. 
-            Set to "False" by default.
+          Set to "False" by default.
         animate (str, optional): Animate features by date/time or other numeric field.
 
     Returns:

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -5,7 +5,8 @@ from ..layer import Layer
 
 def size_continuous_layer(
         source, value, title='', size=None,
-        color=None, description='', footer=''):
+        color=None, description='', footer='',
+        legend=True, popup=True, widget=True, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by `value`.
 
@@ -21,11 +22,17 @@ def size_continuous_layer(
           '#4CC8A3' for lines.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): TODO.
+        popup (bool, optional): TODO.
+        widget (bool, optional): TODO.
+        animate (str, optional): TODO.
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`. Includes Legend and
-        popup on `value`.
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
     """
+    animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
+
     return Layer(
         source,
         style={
@@ -34,22 +41,24 @@ def size_continuous_layer(
                     value, size or [2, 40]),
                 'color': 'opacity({0}, 0.8)'.format(
                     color or '#FFB927'),
-                'strokeColor': 'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))'
+                'strokeColor': 'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))',
+                'filter': animation_filter
             },
             'line': {
                 'width': 'ramp(linear(${0}), {1})'.format(
                     value, size or [1, 10]),
                 'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3')
+                    color or '#4CC8A3'),
+                'filter': animation_filter
             }
         },
-        popup={
+        popup=popup and not animate and {
             'hover': {
                 'title': title or value,
                 'value': '$' + value
             }
         },
-        legend={
+        legend=legend and {
             'type': {
                 'point': 'size-continuous-point',
                 'line': 'size-continuous-line',
@@ -58,5 +67,17 @@ def size_continuous_layer(
             'title': title or value,
             'description': description,
             'footer': footer
-        }
+        },
+        widgets=[
+            animate and {
+                'type': 'time-series',
+                'value': animate,
+                'title': 'Animation'
+            },
+            widget and {
+                'type': 'histogram',
+                'value': value,
+                'title': 'Distribution'
+            }
+        ]
     )

--- a/cartoframes/viz/source.py
+++ b/cartoframes/viz/source.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import re
 import pandas
 
 from . import defaults

--- a/cartoframes/viz/widget_list.py
+++ b/cartoframes/viz/widget_list.py
@@ -25,7 +25,7 @@ class WidgetList(object):
     """
 
     def __init__(self, widgets=None):
-        self.widgets = self._init_widgets(widgets)
+        self._widgets = self._init_widgets(widgets)
 
     def _init_widgets(self, widgets):
         if isinstance(widgets, list):
@@ -45,7 +45,7 @@ class WidgetList(object):
 
     def get_widgets_info(self):
         widgets_info = []
-        for widget in self.widgets:
+        for widget in self._widgets:
             if widget:
                 widgets_info.append(widget.get_info())
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -500,6 +500,7 @@ class TestDatasetInfo(unittest.TestCase):
 
 class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
     """Unit tests for cartoframes.Dataset"""
+
     def setUp(self):
         self.username = 'fake_username'
         self.api_key = 'fake_api_key'

--- a/test/viz/helpers/test_color_bins_layer.py
+++ b/test/viz/helpers/test_color_bins_layer.py
@@ -242,7 +242,7 @@ class TestColorBinsLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
 
 
-    def test_color_bins_layer_animation(self):
+    def test_color_bins_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.color_bins_layer(
             'sf_neighborhoods',

--- a/test/viz/helpers/test_color_bins_layer.py
+++ b/test/viz/helpers/test_color_bins_layer.py
@@ -176,3 +176,81 @@ class TestColorBinsLayerHelper(unittest.TestCase):
             layer.style._style['polygon']['color'],
             'opacity(ramp(buckets($name, [0, 1, 2]), purpor), 0.9)'
         )
+
+    def test_color_bins_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'color-bins-point',
+            'line': 'color-bins-line',
+            'polygon': 'color-bins-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_color_bins_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_color_bins_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
+
+
+    def test_color_bins_layer_animation(self):
+        "should animate a property and disable the popups"
+        layer = helpers.color_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/helpers/test_color_bins_layer.py
+++ b/test/viz/helpers/test_color_bins_layer.py
@@ -241,7 +241,6 @@ class TestColorBinsLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
         self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
 
-
     def test_color_bins_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.color_bins_layer(

--- a/test/viz/helpers/test_color_category_layer.py
+++ b/test/viz/helpers/test_color_category_layer.py
@@ -126,3 +126,81 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
             layer.style._style['polygon']['color'],
             "opacity(ramp(buckets($name, ['A', 'B']), [red, blue]), 0.9)"
         )
+
+    def test_color_category_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'color-category-point',
+            'line': 'color-category-line',
+            'polygon': 'color-category-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_color_category_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_color_category_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'category')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Categories')
+
+
+    def test_color_category_layer_animate(self):
+        "should animate a property and disable the popups"
+        layer = helpers.color_category_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/helpers/test_color_category_layer.py
+++ b/test/viz/helpers/test_color_category_layer.py
@@ -191,7 +191,6 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._type, 'category')
         self.assertEqual(layer.widgets._widgets[0]._title, 'Categories')
 
-
     def test_color_category_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.color_category_layer(

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -148,7 +148,6 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
         self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
 
-
     def test_color_continuous_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.color_continuous_layer(

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -83,3 +83,81 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
             layer.style._style['polygon']['color'],
             'opacity(ramp(linear($name), prism), 0.9)'
         )
+
+    def test_color_continuous_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'color-continuous-point',
+            'line': 'color-continuous-line',
+            'polygon': 'color-continuous-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_color_continuous_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_color_continuous_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
+
+
+    def test_color_continuous_layer_animate(self):
+        "should animate a property and disable the popups"
+        layer = helpers.color_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/helpers/test_size_bins_layer.py
+++ b/test/viz/helpers/test_size_bins_layer.py
@@ -218,7 +218,6 @@ class TestSizeBinsLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
         self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
 
-
     def test_size_bins_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.size_bins_layer(

--- a/test/viz/helpers/test_size_bins_layer.py
+++ b/test/viz/helpers/test_size_bins_layer.py
@@ -153,3 +153,81 @@ class TestSizeBinsLayerHelper(unittest.TestCase):
             layer.style._style['line']['width'],
             'ramp(buckets($name, [0, 1, 2]), [1, 10])'
         )
+
+    def test_size_bins_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'size-bins-point',
+            'line': 'size-bins-line',
+            'polygon': 'size-bins-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_size_bins_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_size_bins_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
+
+
+    def test_size_bins_layer_animate(self):
+        "should animate a property and disable the popups"
+        layer = helpers.size_bins_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/helpers/test_size_category_layer.py
+++ b/test/viz/helpers/test_size_category_layer.py
@@ -181,7 +181,6 @@ class TestSizeCategoryLayerHelper(unittest.TestCase):
         self.assertEqual(layer.widgets._widgets[0]._type, 'category')
         self.assertEqual(layer.widgets._widgets[0]._title, 'Categories')
 
-
     def test_size_category_layer_animate(self):
         "should animate a property and disable the popups"
         layer = helpers.size_category_layer(

--- a/test/viz/helpers/test_size_category_layer.py
+++ b/test/viz/helpers/test_size_category_layer.py
@@ -116,3 +116,81 @@ class TestSizeCategoryLayerHelper(unittest.TestCase):
             layer.style._style['line']['color'],
             'opacity(blue, 0.8)'
         )
+
+    def test_size_category_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'size-category-point',
+            'line': 'size-category-line',
+            'polygon': 'size-category-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_size_category_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_size_category_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'category')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Categories')
+
+
+    def test_size_category_layer_animate(self):
+        "should animate a property and disable the popups"
+        layer = helpers.size_category_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/helpers/test_size_continuous_layer.py
+++ b/test/viz/helpers/test_size_continuous_layer.py
@@ -79,3 +79,80 @@ class TestSizeContinuousLayerHelper(unittest.TestCase):
             layer.style._style['line']['color'],
             'opacity(blue, 0.8)'
         )
+
+    def test_size_continuous_layer_legend(self):
+        "should show/hide the legend"
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=False
+        )
+
+        self.assertEqual(layer.legend._type, '')
+        self.assertEqual(layer.legend._title, '')
+
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            legend=True
+        )
+
+        self.assertEqual(layer.legend._type, {
+            'point': 'size-continuous-point',
+            'line': 'size-continuous-line',
+            'polygon': 'size-continuous-polygon'
+        })
+        self.assertEqual(layer.legend._title, 'name')
+
+    def test_size_continuous_layer_popup(self):
+        "should show/hide the popup"
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=False
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            popup=True
+        )
+
+        self.assertEqual(layer.popup._hover, [{
+            'title': 'name',
+            'value': '$name'
+        }])
+
+    def test_size_continuous_layer_widget(self):
+        "should show/hide the widget"
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=False
+        )
+
+        self.assertEqual(layer.widgets._widgets, [])
+
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            widget=True
+        )
+
+        self.assertEqual(layer.widgets._widgets[0]._type, 'histogram')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Distribution')
+
+    def test_size_continuous_layer_animate(self):
+        "should animate a property and disable the popups"
+        layer = helpers.size_continuous_layer(
+            'sf_neighborhoods',
+            'name',
+            animate='time'
+        )
+
+        self.assertEqual(layer.popup._hover, [])
+        self.assertEqual(layer.widgets._widgets[0]._type, 'time-series')
+        self.assertEqual(layer.widgets._widgets[0]._title, 'Animation')
+        self.assertEqual(layer.widgets._widgets[0]._value, 'time')

--- a/test/viz/test_widget_list.py
+++ b/test/viz/test_widget_list.py
@@ -26,35 +26,35 @@ class TestWidgetList(unittest.TestCase):
         """WidgetList should be properly initialized"""
         widget_list = WidgetList(widget_a)
 
-        self.assertEqual(widget_list.widgets[0]._type, 'formula')
-        self.assertEqual(widget_list.widgets[0]._value, 'viewportSum($amount)')
-        self.assertEqual(widget_list.widgets[0]._title, '[TITLE]')
-        self.assertEqual(widget_list.widgets[0]._description, '[description]')
-        self.assertEqual(widget_list.widgets[0]._footer, '[footer]')
-        self.assertTrue(isinstance(widget_list.widgets[0], Widget))
+        self.assertEqual(widget_list._widgets[0]._type, 'formula')
+        self.assertEqual(widget_list._widgets[0]._value, 'viewportSum($amount)')
+        self.assertEqual(widget_list._widgets[0]._title, '[TITLE]')
+        self.assertEqual(widget_list._widgets[0]._description, '[description]')
+        self.assertEqual(widget_list._widgets[0]._footer, '[footer]')
+        self.assertTrue(isinstance(widget_list._widgets[0], Widget))
 
     def test_widget_list_init_with_a_list_of_dict(self):
         """WidgetList should be properly initialized"""
 
         widget_list = WidgetList([widget_a, widget_b])
 
-        self.assertEqual(widget_list.widgets[0]._type, 'formula')
-        self.assertEqual(widget_list.widgets[0]._value, 'viewportSum($amount)')
-        self.assertEqual(widget_list.widgets[0]._title, '[TITLE]')
-        self.assertEqual(widget_list.widgets[0]._description, '[description]')
-        self.assertEqual(widget_list.widgets[0]._footer, '[footer]')
-        self.assertTrue(isinstance(widget_list.widgets[0], Widget))
+        self.assertEqual(widget_list._widgets[0]._type, 'formula')
+        self.assertEqual(widget_list._widgets[0]._value, 'viewportSum($amount)')
+        self.assertEqual(widget_list._widgets[0]._title, '[TITLE]')
+        self.assertEqual(widget_list._widgets[0]._description, '[description]')
+        self.assertEqual(widget_list._widgets[0]._footer, '[footer]')
+        self.assertTrue(isinstance(widget_list._widgets[0], Widget))
 
-        self.assertEqual(widget_list.widgets[1]._type, 'default')
-        self.assertEqual(widget_list.widgets[1]._title, '"Custom Info"')
-        self.assertEqual(widget_list.widgets[1]._description, '')
-        self.assertEqual(widget_list.widgets[1]._footer, '')
-        self.assertTrue(isinstance(widget_list.widgets[1], Widget))
+        self.assertEqual(widget_list._widgets[1]._type, 'default')
+        self.assertEqual(widget_list._widgets[1]._title, '"Custom Info"')
+        self.assertEqual(widget_list._widgets[1]._description, '')
+        self.assertEqual(widget_list._widgets[1]._footer, '')
+        self.assertTrue(isinstance(widget_list._widgets[1], Widget))
 
     def test_widget_list_init_with_a_widget(self):
         """WidgetList should be properly initialized"""
         widget_list = WidgetList(Widget(widget_a))
-        self.assertTrue(isinstance(widget_list.widgets[0], Widget))
+        self.assertTrue(isinstance(widget_list._widgets[0], Widget))
 
     def test_widget_list_init_with_a_list_of_widgets(self):
         """WidgetList should be properly initialized"""
@@ -64,8 +64,8 @@ class TestWidgetList(unittest.TestCase):
             Widget(widget_b)
         ])
 
-        self.assertTrue(isinstance(widget_list.widgets[0], Widget))
-        self.assertTrue(isinstance(widget_list.widgets[1], Widget))
+        self.assertTrue(isinstance(widget_list._widgets[0], Widget))
+        self.assertTrue(isinstance(widget_list._widgets[1], Widget))
 
     def test_widget_list_get_widgets_info(self):
         """Widget List should return a proper widgets info object"""


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/cartoframes/issues/657

Hiiii @Jesus89 

In this PR I did the following:
- [x] Updated all the doc descriptions for each helper
- [x] For the mean time, I'm setting the widgets for each helper (other than animation and if animation is activated inside of other helpers) to false because there are some things that I want to look at in more detail (described below) which is part of the widgets review I still need to complete and Elena and I have our weekly meeting tomorrow so we can review some of it together during that time.

To do:
- [ ] Test animation layer helper across all geometries (mainly to see if I need to make any modifications to the symbology based on lines and polygons). 

If we can merge what we have here into develop, I can continue with my testing tomorrow morning when I get to the office.

More details about the widgets:
(_I realize some of these are widget related and another thing I'm working on this week is a widget review so part of this is related to that but want to just to note down some initial observations from this work today) :

- with category helpers, when you define your own buckets, all of the values still show in the category widget (I need to check this because I thought that defining buckets helps with ordering). 

- In addition, the ordering of categories in the widget isn't matching the bucket order in these cases:
<img width="1186" alt="Screen Shot 2019-07-17 at 3 02 25 PM" src="https://user-images.githubusercontent.com/1566273/61411619-fed4b800-a8a3-11e9-866e-55430b0bba5b.png">

- Related, I am pretty sure we can't have the order from `top` show in the category widget, but I'd like to check that first
<img width="1053" alt="Screen Shot 2019-07-17 at 3 28 01 PM" src="https://user-images.githubusercontent.com/1566273/61413109-e49cd900-a8a7-11e9-9ee7-563976447cd7.png">

- For numeric helpers, I'm worried about the frequency which we'd see a distribution like the one below and if we'd need to provide more parameters to users to adjust things like number of histogram bins, etc.

<img width="1123" alt="Screen Shot 2019-07-17 at 3 25 51 PM" src="https://user-images.githubusercontent.com/1566273/61412919-68a29100-a8a7-11e9-9efa-a69d853276fc.png">

- hovering over histogram widget bars, I'm not seeing the values in a popup. I want to check if this is happening in other cases, or specifically with the helpers.

- also seeing the spacing from the edge of the category widget
<img width="1053" alt="Screen Shot 2019-07-17 at 3 28 01 PM" src="https://user-images.githubusercontent.com/1566273/61425698-ff397700-a8d4-11e9-9922-6d79ea57b8ba.png">

If we think that there are too many additional parameters that we'd need to expose, we can rethink this idea but before doing that, just want to spend more time with it all across different scenarios.

@elenatorro some of this is related to the widgets review I'm doing. I will gather this and other feedback into the appropriate ticket, so don't worry about this for right now, we can discuss more tomorrow!

Thanks!
