### PR TITLE
updates mapping of int64 to appropriate pg type

### DIFF
--- a/cartoframes/data/registry/dataframe_dataset.py
+++ b/cartoframes/data/registry/dataframe_dataset.py
@@ -207,7 +207,7 @@ def _dtypes2pg(dtype):
     """Returns equivalent PostgreSQL type for input `dtype`"""
     mapping = {
         'float64': 'numeric',
-        'int64': 'integer',
+        'int64': 'bigint',
         'float32': 'numeric',
         'int32': 'integer',
         'object': 'text',


### PR DESCRIPTION
NumPy int64 has range -9223372036854775808 to 9223372036854775807 ([source](https://docs.scipy.org/doc/numpy-1.10.1/user/basics.types.html))
PG bigint has range -9223372036854775808 to +9223372036854775807 ([source](https://www.postgresql.org/docs/10/datatype-numeric.html))

int64 -> bigint is the correct mapping instead of int64 -> int