### PR TITLE
avoid circular dep

### DIFF
--- a/cartoframes/utils.py
+++ b/cartoframes/utils.py
@@ -13,8 +13,6 @@ import numpy as np
 from functools import wraps
 from warnings import filterwarnings, catch_warnings
 
-from .data.columns import normalize_name
-
 GEOM_TYPE_POINT = 'point'
 GEOM_TYPE_LINE = 'line'
 GEOM_TYPE_POLYGON = 'polygon'
@@ -302,4 +300,6 @@ def is_geojson(data):
 
 
 def is_table_name(data):
+    # avoid circular dependecies
+    from .data.columns import normalize_name
     return isinstance(data, str) and normalize_name(data) == data


### PR DESCRIPTION
If you do for example:
```
from cartoframes.client import DataObsClient
```
The circular dep:
- data_obs_client
- utils
- data.columns
(reading the data __init__)
- dataset
- dataframe_dataset
- utils


The solution proposal is a PITA, but I don't see any good solution right now