### PR TITLE
removing carto dep from master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If the bug is not already reported, open a new issue. Please give the following 
 ### External contributors
 
 CARTOframes has automated testing against a working CARTO account, and the authentication information is not public. Because of this, external pull requests currently cannot successfully run the full suite of tests.
- 
+
 To run tests, rename the file `secret.json.sample` to `secret.json` and fill in the credentials for a CARTO account to which you have access. NOTE: the tests require access to different CARTO services like the Data Observatory, so the tests consume quota.
 
 To open a pull request:
@@ -29,6 +29,16 @@ To open a pull request:
 1. Open against the `develop` branch, which we will keep up-to-date with `master`
 2. Tag @andy-esch for review
 3. Once the PR has been approved, we'll merge it into `develop`, and then open a fresh pull request against `master` for running the continuous integration. Once tests are successful, we will tag the original contributor there and give final notice before merging in.
+
+### `carto-python` dependency
+
+CARTOframes uses [carto-python](https://github.com/CartoDB/carto-python) intensively. It has the clients to connect to the different CARTO APIs. Usually, when we are developing in CARTOframes, we should add the following line in the `requirements.txt` file to work with the last code in the master branch:
+
+```
+-e git+https://github.com/CartoDB/carto-python.git#egg=carto
+```
+
+Of course, it should be removed before a release is done.
 
 ### Internal contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To open a pull request:
 
 ### `carto-python` dependency
 
-CARTOframes uses [carto-python](https://github.com/CartoDB/carto-python) intensively. It has the clients to connect to the different CARTO APIs. Usually, when we are developing in CARTOframes, we should add the following line in the `requirements.txt` file to work with the last code in the master branch:
+CARTOframes uses [carto-python](https://github.com/CartoDB/carto-python) intensively. It has the clients to connect to the different CARTO APIs. Usually, when we are developing in CARTOframes, we add the following line in the `requirements.txt` file to work with the last code in the master branch:
 
 ```
 -e git+https://github.com/CartoDB/carto-python.git#egg=carto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
--e git+https://github.com/CartoDB/carto-python.git#egg=carto
 .


### PR DESCRIPTION
For developing purposes, we use the master branch of `carto-python`, but we need to remove it before a new release (the dependency is already in setup.py https://github.com/CartoDB/cartoframes/blob/develop/setup.py#L23)