### PR TITLE
removing Dataset state changes

### DIFF
--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -277,7 +277,8 @@ class Dataset(object):
             self._strategy.schema = schema
 
         self._strategy.upload(if_exists, with_lnglat)
-        return self
+
+        return Dataset(self._strategy.table_name, self._strategy.credentials, self._strategy.schema)
 
     def delete(self):
         """Delete table on CARTO account associated with a Dataset instance

--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -104,12 +104,6 @@ class Dataset(object):
 
         raise ValueError('We can not detect the Dataset type')
 
-    def _init_saved_in_carto(self):
-        return self.is_remote()
-
-    def _set_strategy(self, strategy, data, credentials=None, schema=None):
-        self._strategy = strategy(data, credentials, schema)
-
     def _get_strategies_registry(self):
         return StrategiesRegistry()
 

--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -235,19 +235,7 @@ class Dataset(object):
                 d = Dataset('brooklyn_poverty')
                 df = d.download(decode_geom=True)
         """
-        data = self._strategy.download(limit, decode_geom, retry_times)
-
-        table_name = self._strategy.table_name
-        credentials = self._strategy.credentials
-        schema = self._strategy.schema
-
-        self._set_strategy(DataFrameDataset, data)
-
-        self._strategy.table_name = table_name
-        self._strategy.credentials = credentials
-        self._strategy.schema = schema
-
-        return data
+        return self._strategy.download(limit, decode_geom, retry_times)
 
     def upload(self, with_lnglat=None, if_exists=FAIL, table_name=None, schema=None, credentials=None):
         """Upload Dataset to CARTO account associated with `credentials`.
@@ -295,15 +283,6 @@ class Dataset(object):
             self._strategy.schema = schema
 
         self._strategy.upload(if_exists, with_lnglat)
-        self._is_saved_in_carto = True
-
-        if isinstance(self._strategy, QueryDataset):
-            self._set_strategy(
-                TableDataset,
-                self._strategy.table_name,
-                self._strategy.credentials,
-                self._strategy.schema)
-
         return self
 
     def delete(self):

--- a/cartoframes/data/dataset.py
+++ b/cartoframes/data/dataset.py
@@ -95,7 +95,6 @@ class Dataset(object):
     def __init__(self, data, credentials=None, schema=None):
         self._registry = self._get_strategies_registry()
         self._strategy = self._init_strategy(data, credentials, schema)
-        self._is_saved_in_carto = self._init_saved_in_carto()
 
     def _init_strategy(self, data, credentials=None, schema=None):
         credentials = credentials or get_default_credentials()
@@ -152,11 +151,6 @@ class Dataset(object):
         return self._strategy.get_geodataframe()
 
     @property
-    def is_saved_in_carto(self):
-        """Property on whether Dataset is saved in CARTO account"""
-        return self._is_saved_in_carto
-
-    @property
     def dataset_info(self):
         """:py:class:`DatasetInfo <cartoframes.data.DatasetInfo>` associated with Dataset instance
 
@@ -180,10 +174,10 @@ class Dataset(object):
                d.dataset_info
 
         """
-        if not self._is_saved_in_carto:
-            raise CartoException('Your data is not synchronized with CARTO.'
-                                 'First of all, you should call upload method '
-                                 'to save your data in CARTO.')
+        if self.is_local():
+            raise CartoException('Your data is not synchronized with CARTO. If you want to upload it to CARTO, '
+                                 'you should use: `Dataset.upload(table_name="new_table")` '
+                                 'Then, if you want to work with the remote data, use `Dataset("new_table")`')
 
         return self._strategy.dataset_info
 
@@ -335,9 +329,9 @@ class Dataset(object):
 
     def get_table_names(self):
         """Get table names used by Dataset instance"""
-        if not self._is_saved_in_carto:
-            raise CartoException('Your data is not synchronized with CARTO. '
-                                 'First of all, you should call the Dataset.upload() method '
-                                 'to save your data in CARTO.')
+        if self.is_local():
+            raise CartoException('Your data is not synchronized with CARTO. If you want to upload it to CARTO, '
+                                 'you should use: `Dataset.upload(table_name="new_table")` '
+                                 'Then, if you want to work with the remote data, use `Dataset("new_table")`')
 
         return self._strategy.get_table_names()

--- a/cartoframes/data/registry/base_dataset.py
+++ b/cartoframes/data/registry/base_dataset.py
@@ -22,6 +22,7 @@ class BaseDataset():
         self._verbose = 0
         self._credentials = credentials
         self._context = self._create_context()
+        self._df = None
         self._table_name = None
         self._schema = None
         self._dataset_info = None
@@ -59,6 +60,11 @@ class BaseDataset():
         self._credentials = credentials
         self._context = self._create_context()
         self._schema = self._get_schema()
+
+    @property
+    def dataframe(self):
+        """Dataset DataFrame"""
+        return self._df
 
     @property
     def table_name(self):

--- a/cartoframes/data/registry/query_dataset.py
+++ b/cartoframes/data/registry/query_dataset.py
@@ -35,7 +35,8 @@ class QueryDataset(BaseDataset):
         self._is_ready_for_dowload_validation()
         columns = self._get_query_columns()
         query = self._get_read_query(columns, limit)
-        return self._copyto(columns, query, limit, decode_geom, retry_times)
+        self._df = self._copyto(columns, query, limit, decode_geom, retry_times)
+        return self._df
 
     def upload(self, if_exists, with_lnglat):
         self._is_ready_for_upload_validation()

--- a/cartoframes/data/registry/table_dataset.py
+++ b/cartoframes/data/registry/table_dataset.py
@@ -29,7 +29,8 @@ class TableDataset(BaseDataset):
         self._is_ready_for_dowload_validation()
         columns = self._get_table_columns()
         query = self._get_read_query(columns, limit)
-        return self._copyto(columns, query, limit, decode_geom, retry_times)
+        self._df = self._copyto(columns, query, limit, decode_geom, retry_times)
+        return self._df
 
     def upload(self, if_exists, with_lnglat):
         raise ValueError('Nothing to upload. Dataset needs a DataFrame, a '

--- a/cartoframes/viz/kuviz.py
+++ b/cartoframes/viz/kuviz.py
@@ -32,7 +32,7 @@ class KuvizPublisher(object):
         return _create_kuviz(html=html, name=name, auth_client=self._auth_client, password=password)
 
     def is_sync(self):
-        return all(layer.source.dataset.is_saved_in_carto for layer in self._layers)
+        return all(layer.source.dataset.is_remote() for layer in self._layers)
 
     def is_public(self):
         return all(layer.source.dataset.is_public() for layer in self._layers)
@@ -58,7 +58,7 @@ class KuvizPublisher(object):
             self._sync_layer(layer, table_name, dataset_credentials)
 
     def _sync_layer(self, layer, table_name, credentials):
-        if not layer.source.dataset.is_saved_in_carto:
+        if layer.source.dataset.is_local():
             layer.source.dataset.upload(table_name=table_name, credentials=credentials)
             layer.source = Source(table_name, credentials=credentials)
             warn('Table `{}` created. In order to publish the map, you will need to create a new Regular API '

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -193,8 +193,10 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
         dataset.upload(table_name=self.test_write_table)
 
         dataset = Dataset(self.test_write_table, credentials=self.credentials)
-        dataset.download()
-        dataset.upload(table_name=self.test_write_table, if_exists=Dataset.REPLACE)
+        df = dataset.download()
+
+        dataset = Dataset(df)
+        dataset.upload(table_name=self.test_write_table, credentials=self.credentials, if_exists=Dataset.REPLACE)
 
     def test_dataset_download_bool_null(self):
         self.assertNotExistsTable(self.test_write_table)
@@ -475,12 +477,16 @@ class TestDatasetInfo(unittest.TestCase):
         query = 'SELECT 1'
         dataset = DatasetMock(query, credentials=self.credentials)
         dataset.upload(table_name='fake_table')
+
+        dataset = DatasetMock('fake_table', credentials=self.credentials)
         self.assertEqual(dataset.dataset_info.privacy, Dataset.PRIVATE)
 
     def test_dataset_set_privacy_to_new_table(self):
         query = 'SELECT 1'
         dataset = DatasetMock(query, credentials=self.credentials)
         dataset.upload(table_name='fake_table')
+
+        dataset = DatasetMock('fake_table', credentials=self.credentials)
         dataset.update_dataset_info(privacy=Dataset.PUBLIC)
         self.assertEqual(dataset.dataset_info.privacy, Dataset.PUBLIC)
 
@@ -518,6 +524,8 @@ class TestDatasetInfo(unittest.TestCase):
         df = pd.DataFrame.from_dict({'test': [True, [1, 2]]})
         dataset = DatasetMock(df)
         dataset.upload(table_name='fake_table', credentials=self.credentials)
+
+        dataset = DatasetMock('fake_table', credentials=self.credentials)
         self.assertEqual(dataset.dataset_info.privacy, Dataset.PRIVATE)
 
     def test_dataset_info_from_query(self):

--- a/test/data/test_dataset_strategy_changes.py
+++ b/test/data/test_dataset_strategy_changes.py
@@ -71,3 +71,25 @@ class TestDatasetStrategyChanges(unittest.TestCase):
         dataset = DatasetMock(geojson)
         self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
         self.assertTrue(dataset.is_local())
+
+    def test_local_dataset_upload_returns_table_dataset(self):
+        gdf = load_geojson(self.test_geojson)
+        local_dataset = DatasetMock(gdf)
+        table_dataset = local_dataset.upload(table_name='fake_table', credentials=self.credentials)
+        self.assertTrue(isinstance(local_dataset._strategy, DataFrameDataset))
+        self.assertTrue(isinstance(table_dataset._strategy, TableDataset))
+
+    def test_table_dataset_download_returns_dataframe(self):
+        table_dataset = DatasetMock('fake_table', credentials=self.credentials)
+        df = table_dataset.download()
+        self.assertTrue(isinstance(df, pd.DataFrame))
+        self.assertTrue(df.equals(table_dataset.dataframe))
+        self.assertTrue(isinstance(table_dataset._strategy, TableDataset))
+
+    def test_query_dataset_download_returns_dataframe(self):
+        query = 'SELECT * FROM fake_table'
+        query_dataset = DatasetMock(query, credentials=self.credentials)
+        df = query_dataset.download()
+        self.assertTrue(isinstance(df, pd.DataFrame))
+        self.assertTrue(df.equals(query_dataset.dataframe))
+        self.assertTrue(isinstance(query_dataset._strategy, QueryDataset))

--- a/test/data/test_dataset_strategy_changes.py
+++ b/test/data/test_dataset_strategy_changes.py
@@ -53,102 +53,21 @@ class TestDatasetStrategyChanges(unittest.TestCase):
         dataset = DatasetMock(table_name, credentials=self.credentials)
         self.assertTrue(isinstance(dataset._strategy, TableDataset))
         self.assertTrue(dataset.is_remote())
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_table_after_download(self):
-        table_name = 'fake_table'
-        dataset = DatasetMock(table_name, credentials=self.credentials)
-        self.assertTrue(isinstance(dataset._strategy, TableDataset))
-        self.assertTrue(dataset.is_remote())
-        self.assertTrue(dataset.is_saved_in_carto)
-        dataset.download()
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_table_after_upload(self):
-        table_name = 'fake_table'
-        dataset = DatasetMock(table_name, credentials=self.credentials)
-        dataset.download()
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertTrue(dataset.is_saved_in_carto)
-        dataset.upload(table_name='another_table')
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertEqual(dataset.table_name, 'another_table')
-        self.assertTrue(dataset.is_saved_in_carto)
 
     def test_dataset_from_query(self):
         query = "SELECT 1"
         dataset = DatasetMock(query, credentials=self.credentials)
         self.assertTrue(isinstance(dataset._strategy, QueryDataset))
         self.assertTrue(dataset.is_remote())
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_query_after_download(self):
-        query = "SELECT 1"
-        dataset = DatasetMock(query, credentials=self.credentials)
-        self.assertTrue(isinstance(dataset._strategy, QueryDataset))
-        self.assertTrue(dataset.is_remote())
-        self.assertTrue(dataset.is_saved_in_carto)
-        dataset.download()
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_query_and_upload(self):
-        query = "SELECT 1"
-        dataset = DatasetMock(query, credentials=self.credentials)
-        self.assertTrue(isinstance(dataset._strategy, QueryDataset))
-        self.assertTrue(dataset.is_remote())
-        self.assertTrue(dataset.is_saved_in_carto)
-        dataset.upload(table_name='another_table')
-        self.assertTrue(isinstance(dataset._strategy, TableDataset))
-        self.assertTrue(dataset.is_remote())
-        self.assertEqual(dataset.table_name, 'another_table')
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_dataframe(self):
-        df = pd.DataFrame({'column_name': [2]})
-        dataset = DatasetMock(df)
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertFalse(dataset.is_saved_in_carto)
-
-    def test_dataset_from_dataframe_upload(self):
-        df = pd.DataFrame({'column_name': [2]})
-        dataset = DatasetMock(df)
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertFalse(dataset.is_saved_in_carto)
-        dataset.upload(table_name='another_table', credentials=self.credentials)
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertEqual(dataset.table_name, 'another_table')
-        self.assertTrue(dataset.is_saved_in_carto)
-
-    def test_dataset_from_dataframe_upload_append(self):
-        df = pd.DataFrame({'column_name': [2]})
-        dataset = DatasetMock(df)
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertFalse(dataset.is_saved_in_carto)
-        dataset.upload(table_name='another_table', credentials=self.credentials, if_exists=DatasetMock.APPEND)
-        self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
-        self.assertTrue(dataset.is_local())
-        self.assertTrue(dataset.is_saved_in_carto)
 
     def test_dataset_from_geodataframe(self):
         gdf = load_geojson(self.test_geojson)
         dataset = DatasetMock(gdf)
         self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
         self.assertTrue(dataset.is_local())
-        self.assertFalse(dataset.is_saved_in_carto)
 
     def test_dataset_from_geojson(self):
         geojson = self.test_geojson
         dataset = DatasetMock(geojson)
         self.assertTrue(isinstance(dataset._strategy, DataFrameDataset))
         self.assertTrue(dataset.is_local())
-        self.assertFalse(dataset.is_saved_in_carto)

--- a/test/mocks/dataset_mock.py
+++ b/test/mocks/dataset_mock.py
@@ -100,15 +100,5 @@ class DatasetMock(Dataset):
     def _get_strategies_registry(self):
         return StrategiesRegistryMock()
 
-    def _set_strategy(self, strategy, data, credentials=None, schema=None):
-        if strategy == DataFrameDataset:
-            strategy = DataFrameDatasetMock
-        elif strategy == TableDataset:
-            strategy = TableDatasetMock
-        elif strategy == QueryDataset:
-            strategy = QueryDatasetMock
-
-        super(DatasetMock, self)._set_strategy(strategy, data, credentials, schema)
-
     def compute_geom_type(self):
         return Dataset.GEOM_TYPE_POINT

--- a/test/mocks/kuviz_mock.py
+++ b/test/mocks/kuviz_mock.py
@@ -1,7 +1,7 @@
 from carto.kuvizs import Kuviz
 
 from cartoframes.viz.kuviz import KuvizPublisher, kuviz_to_dict
-from dataset_mock import DatasetMock
+from .dataset_mock import DatasetMock
 
 PRIVACY_PUBLIC = 'public'
 PRIVACY_PASSWORD = 'password'

--- a/test/mocks/kuviz_mock.py
+++ b/test/mocks/kuviz_mock.py
@@ -1,6 +1,7 @@
 from carto.kuvizs import Kuviz
 
 from cartoframes.viz.kuviz import KuvizPublisher, kuviz_to_dict
+from dataset_mock import DatasetMock
 
 PRIVACY_PUBLIC = 'public'
 PRIVACY_PASSWORD = 'password'
@@ -32,7 +33,7 @@ class KuvizPublisherMock(KuvizPublisher):
         return _create_kuviz(html=html, name=name, credentials=self._credentials, password=password)
 
     def _sync_layer(self, layer, table_name, credentials):
-        layer.source.dataset._is_saved_in_carto = True
+        layer.source.dataset = DatasetMock(table_name, credentials)
 
     def is_public(self):
         return True

--- a/test/viz/test_map.py
+++ b/test/viz/test_map.py
@@ -173,6 +173,23 @@ class TestMapPublication(unittest.TestCase):
         self.credentials = Credentials(username=self.username, api_key=self.api_key)
         self._context_mock = ContextMock()
 
+        self.test_geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            -3.1640625,
+                            42.032974332441405
+                        ]
+                    }
+                }
+            ]
+        }
+
         # Mock create_context method
         self.original_create_context = context.create_context
         context.create_context = lambda c: self._context_mock
@@ -205,8 +222,7 @@ class TestMapPublication(unittest.TestCase):
         self.assert_kuviz(map._kuviz, name, PRIVACY_PUBLIC)
 
     def test_map_publish_unsync_fails(self):
-        local_data = {}
-        dataset = DatasetMock(local_data, credentials=self.credentials)
+        dataset = DatasetMock(self.test_geojson)
         map = MapMock(Layer(Source(dataset)))
 
         msg = 'The map layers are not synchronized with CARTO. Please, use the `sync_data` before publishing the map'
@@ -214,8 +230,7 @@ class TestMapPublication(unittest.TestCase):
             map.publish('test', credentials=self.credentials)
 
     def test_map_publish_unsync_sync_data_and_publish(self):
-        local_data = {}
-        dataset = DatasetMock(local_data, credentials=self.credentials)
+        dataset = DatasetMock(self.test_geojson)
         map = MapMock(Layer(Source(dataset)))
 
         map.sync_data(table_name='fake_table', credentials=self.credentials)

--- a/test/viz/test_map.py
+++ b/test/viz/test_map.py
@@ -205,9 +205,8 @@ class TestMapPublication(unittest.TestCase):
         self.assert_kuviz(map._kuviz, name, PRIVACY_PUBLIC)
 
     def test_map_publish_unsync_fails(self):
-        query = "SELECT 1"
-        dataset = DatasetMock(query, credentials=self.credentials)
-        dataset._is_saved_in_carto = False
+        local_data = {}
+        dataset = DatasetMock(local_data, credentials=self.credentials)
         map = MapMock(Layer(Source(dataset)))
 
         msg = 'The map layers are not synchronized with CARTO. Please, use the `sync_data` before publishing the map'
@@ -215,9 +214,8 @@ class TestMapPublication(unittest.TestCase):
             map.publish('test', credentials=self.credentials)
 
     def test_map_publish_unsync_sync_data_and_publish(self):
-        query = "SELECT 1"
-        dataset = DatasetMock(query, credentials=self.credentials)
-        dataset._is_saved_in_carto = False
+        local_data = {}
+        dataset = DatasetMock(local_data, credentials=self.credentials)
         map = MapMock(Layer(Source(dataset)))
 
         map.sync_data(table_name='fake_table', credentials=self.credentials)


### PR DESCRIPTION
Fix: https://github.com/CartoDB/cartoframes/issues/861

As it is explained in the issue, we are allowing dataset state changes in 2 cases. We are going to avoid this state changes, passing the responsibility to the user, making the class easier to understand to the user and easier to maintain for us.

Things to do:
- [x] remove state changes
- [x]  sync in kuviz
- [x] return Dataset('table_name') instance in upload method 
- [x] shared props between Dataset classes

Things to check:
- [x] does `_is_saved_in_carto` prop make sense?
- [x] review state usage in Source class (nothing to do)
- [x] docs (nothing to do)