### PR TITLE
Avoid sidebar footer overlap

### DIFF
--- a/cartoframes/assets/style/map.html.j2
+++ b/cartoframes/assets/style/map.html.j2
@@ -25,6 +25,7 @@
     line-height: 24px;
     color: #162945;
     text-align: center;
+    z-index: 2;
   }
 
   .map-footer a {


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/product/issues/389#issuecomment-512882133

<img width="693" alt="Screenshot 2019-08-13 at 14 57 42" src="https://user-images.githubusercontent.com/3824953/62943410-b3e28d80-bdda-11e9-855b-3c1d8e6dcbd3.png">
