### PR TITLE
Fix histogram widget filter

### DIFF
--- a/cartoframes/assets/src/bundle.js
+++ b/cartoframes/assets/src/bundle.js
@@ -372,15 +372,10 @@ var init = (function () {
     widget.element = widget.element || document.querySelector(`#${widget.id}`);
     const type = mapLayer.metadata.properties[widget.value].type;
 
-    console.log('!!! renderBridge', widget);
-
     switch (widget.type) {
       case 'histogram':
-        if (type === 'category') {
-          bridge.categoricalHistogram(widget.element, widget.value, widget.options);
-        } else {
-          bridge.numericalHistogram(widget.element, widget.value, widget.options);
-        }
+        const histogram = type === 'category' ? 'categoricalHistogram' : 'numericalHistogram';
+        bridge[histogram](widget.element, widget.value, widget.options);
 
         break;
       case 'category':

--- a/cartoframes/assets/src/bundle.js
+++ b/cartoframes/assets/src/bundle.js
@@ -362,18 +362,26 @@ var init = (function () {
 
   function renderWidget(widget, value) {
     widget.element = widget.element || document.querySelector(`#${widget.id}-value`);
-    
+
     if (value && widget.element) {
       widget.element.innerText = typeof value === 'number' ? format(value) : value;
     }
   }
 
-  function renderBridge(bridge, widget) {
+  function renderBridge(bridge, widget, mapLayer) {
     widget.element = widget.element || document.querySelector(`#${widget.id}`);
+    const type = mapLayer.metadata.properties[widget.value].type;
+
+    console.log('!!! renderBridge', widget);
 
     switch (widget.type) {
       case 'histogram':
-        bridge.histogram(widget.element, widget.value, widget.options);
+        if (type === 'category') {
+          bridge.categoricalHistogram(widget.element, widget.value, widget.options);
+        } else {
+          bridge.numericalHistogram(widget.element, widget.value, widget.options);
+        }
+
         break;
       case 'category':
         bridge.category(widget.element, widget.value, widget.options);
@@ -397,11 +405,13 @@ var init = (function () {
       map: map
     });
 
-    widgets
-      .filter((widget) => widget.has_bridge)
-      .forEach((widget) => renderBridge(bridge, widget));
+    mapLayer.on('loaded', () => {
+      widgets
+        .filter((widget) => widget.has_bridge)
+        .forEach((widget) => renderBridge(bridge, widget, mapLayer));
 
-    bridge.build();
+      bridge.build();
+    });
   }
 
   function SourceFactory() {

--- a/cartoframes/assets/src/widgets.js
+++ b/cartoframes/assets/src/widgets.js
@@ -2,18 +2,26 @@ import { format } from './utils';
 
 export function renderWidget(widget, value) {
   widget.element = widget.element || document.querySelector(`#${widget.id}-value`);
-  
+
   if (value && widget.element) {
     widget.element.innerText = typeof value === 'number' ? format(value) : value;
   }
 }
 
-export function renderBridge(bridge, widget) {
+export function renderBridge(bridge, widget, mapLayer) {
   widget.element = widget.element || document.querySelector(`#${widget.id}`);
+  const type = mapLayer.metadata.properties[widget.value].type;
+
+  console.log('!!! renderBridge', widget);
 
   switch (widget.type) {
     case 'histogram':
-      bridge.histogram(widget.element, widget.value, widget.options);
+      if (type === 'category') {
+        bridge.categoricalHistogram(widget.element, widget.value, widget.options);
+      } else {
+        bridge.numericalHistogram(widget.element, widget.value, widget.options);
+      }
+
       break;
     case 'category':
       bridge.category(widget.element, widget.value, widget.options);
@@ -37,9 +45,11 @@ export function bridgeLayerWidgets(map, mapLayer, mapSource, widgets) {
     map: map
   });
 
-  widgets
-    .filter((widget) => widget.has_bridge)
-    .forEach((widget) => renderBridge(bridge, widget));
+  mapLayer.on('loaded', () => {
+    widgets
+      .filter((widget) => widget.has_bridge)
+      .forEach((widget) => renderBridge(bridge, widget, mapLayer));
 
-  bridge.build();
+    bridge.build();
+  });
 }

--- a/cartoframes/assets/src/widgets.js
+++ b/cartoframes/assets/src/widgets.js
@@ -12,15 +12,10 @@ export function renderBridge(bridge, widget, mapLayer) {
   widget.element = widget.element || document.querySelector(`#${widget.id}`);
   const type = mapLayer.metadata.properties[widget.value].type;
 
-  console.log('!!! renderBridge', widget);
-
   switch (widget.type) {
     case 'histogram':
-      if (type === 'category') {
-        bridge.categoricalHistogram(widget.element, widget.value, widget.options);
-      } else {
-        bridge.numericalHistogram(widget.element, widget.value, widget.options);
-      }
+      const histogram = type === 'category' ? 'categoricalHistogram' : 'numericalHistogram';
+      bridge[histogram](widget.element, widget.value, widget.options);
 
       break;
     case 'category':

--- a/cartoframes/viz/widget.py
+++ b/cartoframes/viz/widget.py
@@ -95,4 +95,6 @@ class Widget():
                 options[key] = value
 
         options['read_only'] = data.get('read_only', False)
+        options['buckets'] = data.get('buckets', 20)
+
         return options

--- a/test/viz/test_widget.py
+++ b/test/viz/test_widget.py
@@ -42,7 +42,10 @@ class TestWidget(unittest.TestCase):
             'has_bridge': False,
             'prop': '',
             'variable_name': 'vb6dbcf',
-            'options': {'readOnly': False}
+            'options': {
+                'readOnly': False,
+                'buckets': 20
+            }
         })
 
     def test_wrong_input(self):
@@ -73,7 +76,10 @@ class TestWidget(unittest.TestCase):
             'has_bridge': True,
             'prop': 'filter',
             'variable_name': '',
-            'options': {'readOnly': False}
+            'options': {
+                'readOnly': False,
+                'buckets': 20
+            }
         })
 
     def test_animation_widget_prop(self):
@@ -92,5 +98,8 @@ class TestWidget(unittest.TestCase):
             'has_bridge': True,
             'prop': 'width',
             'variable_name': '',
-            'options': {'readOnly': False}
+            'options': {
+                'readOnly': False,
+                'buckets': 20
+            }
         })

--- a/test/viz/test_widget_list.py
+++ b/test/viz/test_widget_list.py
@@ -86,7 +86,10 @@ class TestWidgetList(unittest.TestCase):
                 'footer': '[footer]',
                 'has_bridge': False,
                 'variable_name': 'vb6dbcf',
-                'options': {'readOnly': False}
+                'options': {
+                    'readOnly': False,
+                    'buckets': 20
+                }
             }, {
                 'type': 'default',
                 'title': '"Custom Info"',
@@ -96,5 +99,8 @@ class TestWidgetList(unittest.TestCase):
                 'footer': '',
                 'has_bridge': False,
                 'variable_name': '',
-                'options': {'readOnly': False}
+                'options': {
+                    'readOnly': False,
+                    'buckets': 20
+                }
             }])


### PR DESCRIPTION
Use categorical or numeric histogram depending on the property type instead of the buckets

Related issues:
* https://github.com/CartoDB/cartoframes/issues/929
* https://github.com/CartoDB/cartoframes/issues/940

![histogram_filter](https://user-images.githubusercontent.com/3824953/63843594-e5388d00-c986-11e9-87c4-67174c947552.gif)
