### PR TITLE
Helper parameter updates

### DIFF
--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -4,7 +4,7 @@ from ..layer import Layer
 
 
 def animation_layer(
-        source, value, title='', color=None, widget_type='time-series', description=''):
+        source, value, title='', duration=None, fade=None, color=None, widget_type='time-series', description=''):
     """Helper function for quickly creating an animated map.
 
     Args:
@@ -27,7 +27,8 @@ def animation_layer(
         style={
             'point': {
                 'color': 'opacity({0}, 0.8)'.format(color or '#EE4D5A'),
-                'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
+                'filter': 'animation(linear(${0}), {1}, fade({2}))'.format(value,
+                duration or 20, fade or 1,1)
             },
             'line': {
                 'color': 'opacity({0}, 0.8)'.format(color or '#4CC8A3'),

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -4,7 +4,7 @@ from ..layer import Layer
 
 
 def animation_layer(
-        source, value, title='', duration=None, fade=None, color=None, widget_type='time-series', description=''):
+        source, value, title='', color=None, widget_type='time-series', description=''):
     """Helper function for quickly creating an animated map.
 
     Args:
@@ -27,8 +27,7 @@ def animation_layer(
         style={
             'point': {
                 'color': 'opacity({0}, 0.8)'.format(color or '#EE4D5A'),
-                'filter': 'animation(linear(${0}), {1}, fade({2}))'.format(value,
-                duration or 20, fade or 1,1)
+                'filter': 'animation(linear(${0}), 20, fade(1,1))'.format(value)
             },
             'line': {
                 'color': 'opacity({0}, 0.8)'.format(color or '#4CC8A3'),

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -9,8 +9,9 @@ from .. import defaults
 
 def cluster_size_layer(
         source, operation='count', value=None, resolution=32,
-        title='', size=None, color=None, opacity=None, strokewidth=None, strokecolor=None, 
-        description='', footer='', legend=True, popup=True, widget=False, animate=None):
+        title='', size=None, color=None, opacity=None,
+        strokewidth=None, strokecolor=None, description='',
+        footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by cluster.
 
@@ -26,7 +27,7 @@ def cluster_size_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Defaults is '#FFB927' for point geometries and
           '#4CC8A3' for lines.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -10,7 +10,7 @@ from .. import defaults
 def cluster_size_layer(
         source, operation='count', value=None, resolution=32,
         title='', size=None, color=None, opacity=None,
-        strokewidth=None, strokecolor=None, description='',
+        stroke_width=None, stroke_color=None, description='',
         footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by cluster.
@@ -29,8 +29,8 @@ def cluster_size_layer(
           '#4CC8A3' for lines.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -61,9 +61,9 @@ def cluster_size_layer(
                 'color': 'opacity({0}, {1})'.format(
                     color or '#FFB927', opacity or '0.8'),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter,
                 'resolution': '{0}'.format(resolution)
             }

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -4,12 +4,13 @@ from __future__ import division
 from carto.exceptions import CartoException
 from ..constants import CLUSTER_OPERATIONS
 from ..layer import Layer
+from .. import defaults
 
 
 def cluster_size_layer(
         source, operation='count', value=None, resolution=32,
-        title='', size=None, color=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        title='', size=None, color=None, opacity=None, strokewidth=None, strokecolor=None, 
+        description='', footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by cluster.
 
@@ -25,6 +26,11 @@ def cluster_size_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Defaults is '#FFB927' for point geometries and
           '#4CC8A3' for lines.
+        opacity (int, optional): Opacity value for point color and line features. 
+          Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -51,8 +57,12 @@ def cluster_size_layer(
             'point': {
                 'width': 'ramp(linear({0}, viewportMIN({1}), viewportMAX({2})), [{3}])'.format(
                     cluster_operation, cluster_operation, cluster_operation, breakpoints),
-                'color': 'opacity({0}, 0.8)'.format(color or '#FFB927'),
-                'strokeColor': 'opacity(#222, ramp(linear(zoom(), 0, 18),[0, 0.6]))',
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#FFB927', opacity or '0.8'),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter,
                 'resolution': '{0}'.format(resolution)
             }

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -4,11 +4,13 @@ from .utils import serialize_palette
 
 from ..layer import Layer
 
+from .. import defaults
+
 
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, palette=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        breaks=None, size=None, palette=None, opacity=None, strokecolor=None, strokewidth=None, 
+        description='', footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a classed color map.
 
     Args:
@@ -22,6 +24,11 @@ def color_bins_layer(
         breaks (int[], optional): Assign manual class break values.
         palette (str, optional): Palette that can be a named cartocolor palette
           or other valid CARTO VL palette expression. Default is `purpor`.
+        opacity (str, optional): Opacity value for point color and line features. 
+            Default is '0.8'.
+        strokewidth (str, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+            Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -57,18 +64,33 @@ def color_bins_layer(
         source,
         style={
             'point': {
-                'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
+                    func, value, breaks or bins, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['point']['width']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
-                'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
+                    func, value, breaks or bins, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['line']['width']),
                 'filter': animation_filter
             },
             'polygon': {
-                'color': 'opacity(ramp({0}(${1}, {2}), {3}), 0.9)'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}), {4})'.format(
+                    func, value, breaks or bins, serialize_palette(palette) or default_palette, 
+                    opacity or '0.9'),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -8,8 +8,9 @@ from .. import defaults
 
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, size=None, palette=None, opacity=None, strokecolor=None, strokewidth=None, 
-        description='', footer='', legend=True, popup=True, widget=False, animate=None):
+        breaks=None, palette=None, size=None, opacity=None, 
+        strokecolor=None, strokewidth=None, description='', 
+        footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a classed color map.
 
     Args:
@@ -23,11 +24,12 @@ def color_bins_layer(
         breaks (int[], optional): Assign manual class break values.
         palette (str, optional): Palette that can be a named cartocolor palette
           or other valid CARTO VL palette expression. Default is `purpor`.
-        opacity (str, optional): Opacity value for point color and line features. 
-            Default is '0.8'.
-        strokewidth (str, optional): Size of the stroke on point features.
+        size (int, optional): Size of point or line features.
+        opacity (int, optional): Opacity value for point color and line features. 
+          Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.
-            Default is '#222'.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import
 from .utils import serialize_palette
 
 from ..layer import Layer
-
 from .. import defaults
 
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, palette=None, size=None, opacity=None, 
-        strokecolor=None, strokewidth=None, description='', 
+        breaks=None, palette=None, size=None, opacity=None,
+        strokecolor=None, strokewidth=None, description='',
         footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a classed color map.
 
@@ -25,7 +24,7 @@ def color_bins_layer(
         palette (str, optional): Palette that can be a named cartocolor palette
           or other valid CARTO VL palette expression. Default is `purpor`.
         size (int, optional): Size of point or line features.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -8,7 +8,7 @@ from .. import defaults
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, palette=None, size=None, opacity=None,
-        strokecolor=None, strokewidth=None, description='',
+        stroke_color=None, stroke_width=None, description='',
         footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a classed color map.
 
@@ -26,8 +26,8 @@ def color_bins_layer(
         size (int, optional): Size of point or line features.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -70,9 +70,9 @@ def color_bins_layer(
                 'width': '{0}'.format(
                     size or defaults.STYLE['point']['width']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
@@ -88,9 +88,9 @@ def color_bins_layer(
                     func, value, breaks or bins, serialize_palette(palette) or default_palette, 
                     opacity or '0.9'),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
+                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -6,7 +6,6 @@ from ..layer import Layer
 
 from .. import defaults
 
-
 def color_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, size=None, palette=None, opacity=None, strokecolor=None, strokewidth=None, 

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -4,11 +4,13 @@ from .utils import serialize_palette
 
 from ..layer import Layer
 
+from .. import defaults
+
 
 def color_category_layer(
-        source, value, title='', top=11, cat=None,
-        palette=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        source, value, title='', top=11, cat=None, palette=None, 
+        size=None, opacity=None, strokecolor=None, strokewidth=None, 
+        description='', footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a category color map.
 
     Args:
@@ -44,13 +46,23 @@ def color_category_layer(
         source,
         style={
             'point': {
-                'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
+                    func, value, cat or top, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['point']['width']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
-                'color': 'ramp({0}(${1}, {2}), {3})'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
+                    func, value, cat or top, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['line']['width']),
                 'filter': animation_filter
             },
             'polygon': {

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -8,7 +8,7 @@ from .. import defaults
 
 def color_category_layer(
         source, value, title='', top=11, cat=None, palette=None,
-        size=None, opacity=None, strokecolor=None, strokewidth=None,
+        size=None, opacity=None, stroke_color=None, stroke_width=None,
         description='', footer='', legend=True, popup=True,
         widget=False, animate=None):
     """Helper function for quickly creating a category color map.
@@ -27,8 +27,8 @@ def color_category_layer(
         size (int, optional): Size of point or line features.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -58,9 +58,9 @@ def color_category_layer(
                 'width': '{0}'.format(
                     size or defaults.STYLE['point']['width']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
@@ -76,9 +76,9 @@ def color_category_layer(
                     func, value, cat or top, serialize_palette(palette) or default_palette,
                     opacity or '0.9'),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
+                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from .utils import serialize_palette
 
 from ..layer import Layer
-
 from .. import defaults
 
 
 def color_category_layer(
-        source, value, title='', top=11, cat=None, palette=None, 
-        size=None, opacity=None, strokecolor=None, strokewidth=None, 
-        description='', footer='', legend=True, popup=True, widget=False, animate=None):
+        source, value, title='', top=11, cat=None, palette=None,
+        size=None, opacity=None, strokecolor=None, strokewidth=None,
+        description='', footer='', legend=True, popup=True,
+        widget=False, animate=None):
     """Helper function for quickly creating a category color map.
 
     Args:
@@ -25,7 +25,7 @@ def color_category_layer(
         palette (str, optional): Palette that can be a named CARTOColor palette
           or other valid CARTO VL palette expression. Default is `bold`.
         size (int, optional): Size of point or line features.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -24,11 +24,12 @@ def color_category_layer(
           list.
         palette (str, optional): Palette that can be a named CARTOColor palette
           or other valid CARTO VL palette expression. Default is `bold`.
+        size (int, optional): Size of point or line features.
         opacity (int, optional): Opacity value for point color and line features. 
-            Default is '0.8'.
+          Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (int, optional): Color of the stroke on point features.
-            Default is '#222'.
+        strokecolor (str, optional): Color of the stroke on point features.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -71,9 +72,10 @@ def color_category_layer(
                 'filter': animation_filter
             },
             'polygon': {
-                'color': 'opacity(ramp({0}(${1}, {2}), {3}), 0.9)'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette),
-                 'strokeColor': '{0}'.format(
+                'color': 'opacity(ramp({0}(${1}, {2}), {3}), {4})'.format(
+                    func, value, cat or top, serialize_palette(palette) or default_palette,
+                    opacity or '0.9'),
+                'strokeColor': '{0}'.format(
                     strokecolor or defaults.STYLE['polygon']['strokeColor']),
                 'strokeWidth': '{0}'.format(
                     strokewidth or defaults.STYLE['polygon']['strokeWidth']),

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -24,6 +24,11 @@ def color_category_layer(
           list.
         palette (str, optional): Palette that can be a named CARTOColor palette
           or other valid CARTO VL palette expression. Default is `bold`.
+        opacity (int, optional): Opacity value for point color and line features. 
+            Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
+        strokecolor (int, optional): Color of the stroke on point features.
+            Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -68,6 +73,10 @@ def color_category_layer(
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), 0.9)'.format(
                     func, value, cat or top, serialize_palette(palette) or default_palette),
+                 'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import
 from .utils import serialize_palette
 
 from ..layer import Layer
+from .. import defaults
 
 
 def color_continuous_layer(
-        source, value, title='', palette=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        source, value, title='', palette=None, size=None, 
+        opacity=None, strokecolor=None, strokewidth=None, 
+        description='', footer='', legend=True, popup=True, 
+        widget=False, animate=None):
     """Helper function for quickly creating a continuous color map.
 
     Args:
@@ -17,6 +20,12 @@ def color_continuous_layer(
         title (str, optional): Title of legend
         palette (str, optional): Palette that can be a named cartocolor palette
           or other valid CARTO VL palette expression. Default is `bluyl`.
+        size (int, optional): Size of point or line features.
+        opacity (int, optional): Opacity value for point color and line features. 
+          Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -38,18 +47,33 @@ def color_continuous_layer(
         source,
         style={
             'point': {
-                'color': 'ramp(linear(${0}), {1})'.format(
-                    value, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp(linear(${0}), {1}),{2})'.format(
+                    value, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['point']['width']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
-                'color': 'ramp(linear(${0}), {1})'.format(
-                    value, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp(linear(${0}), {1}),{2})'.format(
+                    value, serialize_palette(palette) or default_palette,
+                    opacity or '1'),
+                'width': '{0}'.format(
+                    size or defaults.STYLE['line']['width']),
                 'filter': animation_filter
             },
             'polygon': {
-                'color': 'opacity(ramp(linear(${0}), {1}), 0.9)'.format(
-                    value, serialize_palette(palette) or default_palette),
+                'color': 'opacity(ramp(linear(${0}), {1}), {2})'.format(
+                    value, serialize_palette(palette) or default_palette,
+                    opacity or '0.9'),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -8,7 +8,7 @@ from .. import defaults
 
 def color_continuous_layer(
         source, value, title='', palette=None, size=None,
-        opacity=None, strokecolor=None, strokewidth=None,
+        opacity=None, stroke_color=None, stroke_width=None,
         description='', footer='', legend=True, popup=True,
         widget=False, animate=None):
     """Helper function for quickly creating a continuous color map.
@@ -23,8 +23,8 @@ def color_continuous_layer(
         size (int, optional): Size of point or line features.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -53,9 +53,9 @@ def color_continuous_layer(
                 'width': '{0}'.format(
                     size or defaults.STYLE['point']['width']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'filter': animation_filter
             },
             'line': {
@@ -71,9 +71,9 @@ def color_continuous_layer(
                     value, serialize_palette(palette) or default_palette,
                     opacity or '0.9'),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['polygon']['strokeColor']),
+                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['polygon']['strokeWidth']),
+                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -7,9 +7,9 @@ from .. import defaults
 
 
 def color_continuous_layer(
-        source, value, title='', palette=None, size=None, 
-        opacity=None, strokecolor=None, strokewidth=None, 
-        description='', footer='', legend=True, popup=True, 
+        source, value, title='', palette=None, size=None,
+        opacity=None, strokecolor=None, strokewidth=None,
+        description='', footer='', legend=True, popup=True,
         widget=False, animate=None):
     """Helper function for quickly creating a continuous color map.
 
@@ -21,7 +21,7 @@ def color_continuous_layer(
         palette (str, optional): Palette that can be a named cartocolor palette
           or other valid CARTO VL palette expression. Default is `bluyl`.
         size (int, optional): Size of point or line features.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ..layer import Layer
-
 from .. import defaults
 
 def size_bins_layer(
@@ -27,10 +26,10 @@ def size_bins_layer(
           CARTO VL color. Default is '#EE5D5A' for point geometries and
           '#4CC8A3' for lines.
         opacity (int, optional): Opacity value for point color and line features. 
-            Default is '0.8'.
+          Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (int, optional): Color of the stroke on point features.
-            Default is '#222'.
+        strokecolor (str, optional): Color of the stroke on point features.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -6,7 +6,7 @@ from .. import defaults
 def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, size=None, color=None, opacity=None,
-        strokewidth=None, strokecolor=None, description='',
+        stroke_width=None, stroke_color=None, description='',
         footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
@@ -27,8 +27,8 @@ def size_bins_layer(
           '#4CC8A3' for lines.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -64,9 +64,9 @@ def size_bins_layer(
                 'color': 'opacity({0}, {1})'.format(
                     color or '#EE4D5A', opacity or '0.8'),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter
             },
             'line': {

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -21,15 +21,15 @@ def size_bins_layer(
           Default is "quantiles".
         bins (int, optional): Number of size classes (bins) for map. Default is 5.
         breaks (int[], optional): Assign manual class break values.
-        size (str, optiona): Min/max size array in CARTO VL syntax. Default is
+        size (int, optiona): Min/max size array in CARTO VL syntax. Default is
           '[2, 14]' for point geometries and '[1, 10]' for lines.
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#EE5D5A' for point geometries and
           '#4CC8A3' for lines.
-        opacity (str, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features. 
             Default is '0.8'.
-        strokewidth (str, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        strokewidth (int, optional): Size of the stroke on point features.
+        strokecolor (int, optional): Color of the stroke on point features.
             Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -5,9 +5,9 @@ from .. import defaults
 
 def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, size=None, color=None, opacity=None, strokewidth=None, 
-        strokecolor=None, description='', footer='',legend=True, 
-        popup=True, widget=False, animate=None):
+        breaks=None, size=None, color=None, opacity=None,
+        strokewidth=None, strokecolor=None, description='',
+        footer='',legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
 
@@ -25,7 +25,7 @@ def size_bins_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#EE5D5A' for point geometries and
           '#4CC8A3' for lines.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -2,11 +2,13 @@ from __future__ import absolute_import
 
 from ..layer import Layer
 
+from .. import defaults
 
 def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
-        breaks=None, size=None, color=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        breaks=None, size=None, color=None, opacity=None, strokewidth=None, 
+        strokecolor=None, description='', footer='',legend=True, 
+        popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
 
@@ -24,7 +26,13 @@ def size_bins_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#EE5D5A' for point geometries and
           '#4CC8A3' for lines.
+        opacity (str, optional): Opacity value for point color and line features. 
+            Default is '0.8'.
+        strokewidth (str, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+            Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
+        footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
           Set to "True" by default.
         popup (bool, optional): Display popups on hover and click: "True" or "False".
@@ -54,15 +62,19 @@ def size_bins_layer(
             'point': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [2, 14]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#EE4D5A'),
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#EE4D5A', opacity or '0.8'),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [1, 10]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3'),
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#4CC8A3', opacity or '0.8'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -7,7 +7,7 @@ def size_bins_layer(
         source, value, title='', method='quantiles', bins=5,
         breaks=None, size=None, color=None, opacity=None,
         strokewidth=None, strokecolor=None, description='',
-        footer='',legend=True, popup=True, widget=False, animate=None):
+        footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     classification method/buckets.
 

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 
 from ..layer import Layer
 
+from .. import defaults
 
 def size_category_layer(
         source, value, title='', top=5, cat=None,
-        size=None, color=None, description='', footer='',
+        size=None, color=None, opacity=None, strokewidth=None, 
+        strokecolor=None, description='', footer='',
         legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size category layer.
 
@@ -23,6 +25,11 @@ def size_category_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#F46D43' for point geometries and
           '#4CC8A3' for lines.
+         opacity (str, optional): Opacity value for point color and line features. 
+            Default is '0.8'.
+        strokewidth (str, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+            Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -46,15 +53,19 @@ def size_category_layer(
             'point': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [2, 20]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#F46D43'),
-                'filter': animation_filter
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#F46D43', opacity or '0.8'),
+                'filter': animation_filter,
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor'])
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [1, 10]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3'),
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#4CC8A3', opacity or '0.8'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -25,11 +25,11 @@ def size_category_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#F46D43' for point geometries and
           '#4CC8A3' for lines.
-        opacity (str, optional): Opacity value for point color and line features. 
-            Default is '0.8'.
-        strokewidth (str, optional): Size of the stroke on point features.
+        opacity (int, optional): Opacity value for point color and line features. 
+          Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.
-            Default is '#222'.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -6,8 +6,8 @@ from .. import defaults
 
 def size_category_layer(
         source, value, title='', top=5, cat=None,
-        size=None, color=None, opacity=None, strokewidth=None,
-        strokecolor=None, description='', footer='',
+        size=None, color=None, opacity=None, stroke_width=None,
+        stroke_color=None, description='', footer='',
         legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size category layer.
 
@@ -27,8 +27,8 @@ def size_category_layer(
           '#4CC8A3' for lines.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -57,9 +57,9 @@ def size_category_layer(
                     color or '#F46D43', opacity or '0.8'),
                 'filter': animation_filter,
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor'])
+                    stroke_color or defaults.STYLE['point']['strokeColor'])
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -6,7 +6,7 @@ from .. import defaults
 
 def size_category_layer(
         source, value, title='', top=5, cat=None,
-        size=None, color=None, opacity=None, strokewidth=None, 
+        size=None, color=None, opacity=None, strokewidth=None,
         strokecolor=None, description='', footer='',
         legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size category layer.
@@ -25,7 +25,7 @@ def size_category_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#F46D43' for point geometries and
           '#4CC8A3' for lines.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -25,7 +25,7 @@ def size_category_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Default is '#F46D43' for point geometries and
           '#4CC8A3' for lines.
-         opacity (str, optional): Opacity value for point color and line features. 
+        opacity (str, optional): Opacity value for point color and line features. 
             Default is '0.8'.
         strokewidth (str, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -6,7 +6,7 @@ from .. import defaults
 
 def size_continuous_layer(
         source, value, title='', size=None, color=None, opacity=None,
-        strokewidth=None, strokecolor=None, description='', footer='',
+        stroke_width=None, stroke_color=None, description='', footer='',
         legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by `value`.
@@ -23,8 +23,8 @@ def size_continuous_layer(
           '#4CC8A3' for lines.
         opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
-        strokewidth (int, optional): Size of the stroke on point features.
-        strokecolor (str, optional): Color of the stroke on point features.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
           Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
@@ -51,9 +51,9 @@ def size_continuous_layer(
                 'color': 'opacity({0}, {1})'.format(
                     color or '#FFB927', opacity or '0.8'),
                 'strokeWidth': '{0}'.format(
-                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                    stroke_width or defaults.STYLE['point']['strokeWidth']),
                 'strokeColor': '{0}'.format(
-                    strokecolor or defaults.STYLE['point']['strokeColor']),
+                    stroke_color or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter
             },
             'line': {

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -5,9 +5,9 @@ from ..layer import Layer
 from .. import defaults
 
 def size_continuous_layer(
-        source, value, title='', size=None,
-        color=None, opacity=None, strokewidth=None, strokecolor=None, 
-        description='', footer='', legend=True, popup=True, widget=False, animate=None):
+        source, value, title='', size=None, color=None, opacity=None,
+        strokewidth=None, strokecolor=None, description='', footer='',
+        legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by `value`.
 
@@ -21,7 +21,7 @@ def size_continuous_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Defaults is '#FFB927' for point geometries and
           '#4CC8A3' for lines.
-        opacity (int, optional): Opacity value for point color and line features. 
+        opacity (int, optional): Opacity value for point color and line features.
           Default is '0.8'.
         strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 
 from ..layer import Layer
 
+from .. import defaults
 
 def size_continuous_layer(
         source, value, title='', size=None,
-        color=None, description='', footer='',
-        legend=True, popup=True, widget=False, animate=None):
+        color=None, opacity=None, strokewidth=None, strokecolor=None, 
+        description='', footer='', legend=True, popup=True, widget=False, animate=None):
     """Helper function for quickly creating a size symbol map with
     continuous size scaled by `value`.
 
@@ -20,6 +21,11 @@ def size_continuous_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Defaults is '#FFB927' for point geometries and
           '#4CC8A3' for lines.
+        opacity (str, optional): Opacity value for point color and line features. 
+            Default is '0.8'.
+        strokewidth (str, optional): Size of the stroke on point features.
+        strokecolor (str, optional): Color of the stroke on point features.
+            Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".
@@ -42,16 +48,19 @@ def size_continuous_layer(
             'point': {
                 'width': 'ramp(linear(sqrt(${0}), sqrt(globalMin(${0})), sqrt(globalMax(${0}))), {1})'.format(
                     value, size or [2, 40]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#FFB927'),
-                'strokeColor': 'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))',
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#FFB927', opacity or '0.8'),
+                'strokeWidth': '{0}'.format(
+                    strokewidth or defaults.STYLE['point']['strokeWidth']),
+                'strokeColor': '{0}'.format(
+                    strokecolor or defaults.STYLE['point']['strokeColor']),
                 'filter': animation_filter
             },
             'line': {
                 'width': 'ramp(linear(${0}), {1})'.format(
                     value, size or [1, 10]),
-                'color': 'opacity({0}, 0.8)'.format(
-                    color or '#4CC8A3'),
+                'color': 'opacity({0}, {1})'.format(
+                    color or '#4CC8A3', opacity or '0.8'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -21,11 +21,11 @@ def size_continuous_layer(
         color (str, optional): Hex value, rgb expression, or other valid
           CARTO VL color. Defaults is '#FFB927' for point geometries and
           '#4CC8A3' for lines.
-        opacity (str, optional): Opacity value for point color and line features. 
-            Default is '0.8'.
-        strokewidth (str, optional): Size of the stroke on point features.
+        opacity (int, optional): Opacity value for point color and line features. 
+          Default is '0.8'.
+        strokewidth (int, optional): Size of the stroke on point features.
         strokecolor (str, optional): Color of the stroke on point features.
-            Default is '#222'.
+          Default is '#222'.
         description (str, optional): Description text legend placed under legend title.
         footer (str, optional): Footer text placed under legend items.
         legend (bool, optional): Display map legend: "True" or "False".

--- a/test/viz/helpers/test_cluster_size_layer.py
+++ b/test/viz/helpers/test_cluster_size_layer.py
@@ -36,7 +36,7 @@ class TestClusterSizeLayerHelper(unittest.TestCase):
         self.assertEqual(layer.style._style['point']['color'],
                          'opacity(#FFB927, 0.8)')
         self.assertEqual(layer.style._style['point']['strokeColor'],
-                         'opacity(#222, ramp(linear(zoom(), 0, 18),[0, 0.6]))')
+                         'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))')
         self.assertEqual(layer.style._style['point']['filter'], '1')
         self.assertEqual(layer.style._style['point']['resolution'], '32')
         self.assertNotEqual(layer.popup, None)

--- a/test/viz/helpers/test_color_bins_layer.py
+++ b/test/viz/helpers/test_color_bins_layer.py
@@ -26,8 +26,8 @@ class TestColorBinsLayerHelper(unittest.TestCase):
         )
 
         self.assertNotEqual(layer.style, None)
-        self.assertEqual(layer.style._style['point']['color'], 'ramp(globalQuantiles($name, 5), purpor)')
-        self.assertEqual(layer.style._style['line']['color'], 'ramp(globalQuantiles($name, 5), purpor)')
+        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(globalQuantiles($name, 5), purpor),1)')
+        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(globalQuantiles($name, 5), purpor),1)')
         self.assertEqual(layer.style._style['polygon']['color'],
                          'opacity(ramp(globalQuantiles($name, 5), purpor), 0.9)')
         self.assertNotEqual(layer.popup, None)
@@ -56,7 +56,7 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(globalQuantiles($name, 3), prism)'
+            'opacity(ramp(globalQuantiles($name, 3), prism),1)'
         )
 
     def test_color_bins_layer_line(self):
@@ -73,7 +73,7 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(globalQuantiles($name, 3), [blue,#F00])'
+            'opacity(ramp(globalQuantiles($name, 3), [blue,#F00]),1)'
         )
 
     def test_color_bins_layer_polygon(self):
@@ -103,11 +103,11 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(globalQuantiles($name, 5), purpor)'
+            'opacity(ramp(globalQuantiles($name, 5), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(globalQuantiles($name, 5), purpor)'
+            'opacity(ramp(globalQuantiles($name, 5), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['polygon']['color'],
@@ -122,11 +122,11 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(globalEqIntervals($name, 5), purpor)'
+            'opacity(ramp(globalEqIntervals($name, 5), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(globalEqIntervals($name, 5), purpor)'
+            'opacity(ramp(globalEqIntervals($name, 5), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['polygon']['color'],
@@ -141,11 +141,11 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(globalStandardDev($name, 5), temps)'
+            'opacity(ramp(globalStandardDev($name, 5), temps),1)'
         )
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(globalStandardDev($name, 5), temps)'
+            'opacity(ramp(globalStandardDev($name, 5), temps),1)'
         )
         self.assertEqual(
             layer.style._style['polygon']['color'],
@@ -170,11 +170,11 @@ class TestColorBinsLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(buckets($name, [0, 1, 2]), purpor)'
+            'opacity(ramp(buckets($name, [0, 1, 2]), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(buckets($name, [0, 1, 2]), purpor)'
+            'opacity(ramp(buckets($name, [0, 1, 2]), purpor),1)'
         )
         self.assertEqual(
             layer.style._style['polygon']['color'],

--- a/test/viz/helpers/test_color_category_layer.py
+++ b/test/viz/helpers/test_color_category_layer.py
@@ -29,8 +29,8 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
         )
 
         self.assertNotEqual(layer.style, None)
-        self.assertEqual(layer.style._style['point']['color'], 'ramp(top($name, 11), bold)')
-        self.assertEqual(layer.style._style['line']['color'], 'ramp(top($name, 11), bold)')
+        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(top($name, 11), bold),1)')
+        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(top($name, 11), bold),1)')
         self.assertEqual(layer.style._style['polygon']['color'], 'opacity(ramp(top($name, 11), bold), 0.9)')
         self.assertNotEqual(layer.popup, None)
         self.assertEqual(layer.popup._hover, [{
@@ -58,7 +58,7 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(top($name, 5), prism)'
+            'opacity(ramp(top($name, 5), prism),1)'
         )
 
         layer = helpers.color_category_layer(
@@ -71,7 +71,7 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            "ramp(buckets($name, ['A', 'B']), [red,blue])"
+            "opacity(ramp(buckets($name, ['A', 'B']), [red,blue]),1)"
         )
 
     def test_color_category_layer_line(self):
@@ -88,7 +88,7 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(top($name, 5), prism)'
+            'opacity(ramp(top($name, 5), prism),1)'
         )
 
         layer = helpers.color_category_layer(
@@ -101,7 +101,7 @@ class TestColorCategoryLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['line']['color'],
-            "ramp(buckets($name, ['A', 'B']), [red,blue])"
+            "opacity(ramp(buckets($name, ['A', 'B']), [red,blue]),1)"
         )
 
     def test_color_category_layer_polygon(self):

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -28,8 +28,8 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
         )
 
         self.assertNotEqual(layer.style, None)
-        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
-        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
+        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(linear($name), bluyl), 1)')
+        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(linear($name), bluyl), 1)')
         self.assertEqual(layer.style._style['polygon']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
         self.assertNotEqual(layer.popup, None)
         self.assertEqual(layer.popup._hover, [{

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -28,8 +28,8 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
         )
 
         self.assertNotEqual(layer.style, None)
-        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(linear($name), bluyl), 1)')
-        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(linear($name), bluyl), 1)')
+        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(linear($name), bluyl),1)')
+        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(linear($name), bluyl),1)')
         self.assertEqual(layer.style._style['polygon']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
         self.assertNotEqual(layer.popup, None)
         self.assertEqual(layer.popup._hover, [{
@@ -56,7 +56,7 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'opacity(ramp(linear($name), prism), 1)'
+            'opacity(ramp(linear($name), prism),1)'
         )
 
     def test_color_continuous_layer_line(self):
@@ -72,7 +72,7 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['line']['color'],
-            'opacity(ramp(linear($name), [blue,#F00]), 1)'
+            'opacity(ramp(linear($name), [blue,#F00]),1)'
         )
 
     def test_color_continuous_layer_polygon(self):

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -56,7 +56,7 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['point']['color'],
-            'ramp(linear($name), prism)'
+            'opacity(ramp(linear($name), prism), 1)'
         )
 
     def test_color_continuous_layer_line(self):
@@ -72,7 +72,7 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
 
         self.assertEqual(
             layer.style._style['line']['color'],
-            'ramp(linear($name), [blue,#F00])'
+            'opacity(ramp(linear($name), [blue,#F00]), 1)'
         )
 
     def test_color_continuous_layer_polygon(self):

--- a/test/viz/helpers/test_color_continuous_layer.py
+++ b/test/viz/helpers/test_color_continuous_layer.py
@@ -28,8 +28,8 @@ class TestColorContinuousLayerHelper(unittest.TestCase):
         )
 
         self.assertNotEqual(layer.style, None)
-        self.assertEqual(layer.style._style['point']['color'], 'ramp(linear($name), bluyl)')
-        self.assertEqual(layer.style._style['line']['color'], 'ramp(linear($name), bluyl)')
+        self.assertEqual(layer.style._style['point']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
+        self.assertEqual(layer.style._style['line']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
         self.assertEqual(layer.style._style['polygon']['color'], 'opacity(ramp(linear($name), bluyl), 0.9)')
         self.assertNotEqual(layer.popup, None)
         self.assertEqual(layer.popup._hover, [{


### PR DESCRIPTION
@elenatorro this is a WIP to expose additional parameters in the helper methods as we discussed today.

so far,

## Color (point, line, polygon)
color_bins
- added size for points and lines
- opacity for all geometries
- strokewidth and strokecolor for points and polygons

color_cat
- added size for points and lines
- opacity for all geometries
- strokewidth and strokecolor for points and polygons

## Size (points and lines only)

size_bins
- added opacity for all geometries
- strokewidth and strokecolor for points

size_category
- added opacity for all geometries
- strokewidth and strokecolor for points

size_continuous
- added opacity for all geometries
- strokewidth and strokecolor for points

will finish the others tomorrow, do additional tests, and make sure all the examples are updated