### PR TITLE
Fix layout grid and map height

### DIFF
--- a/cartoframes/assets/templates/viz/main_layout.html.j2
+++ b/cartoframes/assets/templates/viz/main_layout.html.j2
@@ -42,11 +42,11 @@
   {% for i in range(n) %}
     <div class="layout-map-row">
     {% for j in range(m) %}
-      {% set index = i + j * m if n >= m else j + i * m %}
+      {% set index = i * m + j %}
       {% set title = maps[index]['title'] %}
       {% set has_legends = maps[index]['has_legends'] %}
       
-      <div class="layout-map-cell {{'layout-map-cell-legend' if has_legends }}">
+      <div class="layout-map-cell {{'layout-map-cell-legend' if has_legends }}" style="height: {{ map_height }}px">
           {% if title %}<p>{{ title }}</p>{% endif %}
           {% if has_legends %}
             {% set layers = maps[index]['layers'] %}

--- a/cartoframes/viz/html/HTMLLayout.py
+++ b/cartoframes/viz/html/HTMLLayout.py
@@ -6,7 +6,6 @@ from .. import constants
 class HTMLLayout(object):
     def __init__(self, template_path='templates/viz/layout.html.j2'):
         self.width = None
-        self.height = None
         self.srcdoc = None
         self._env = Environment(
             loader=PackageLoader('cartoframes', 'assets'),
@@ -22,14 +21,14 @@ class HTMLLayout(object):
 
     def set_content(self, maps, size=None, show_info=None, theme=None, _carto_vl_path=None,
                     _airship_path=None, title='CARTOframes', is_embed=False,
-                    is_static=False, viewport=None, n=None, m=None):
+                    is_static=False, map_height=None, viewport=None, n=None, m=None):
         self.html = self._parse_html_content(
             maps, size, show_info, theme, _carto_vl_path, _airship_path, title,
-            is_embed, is_static, viewport, n, m)
+            is_embed, is_static, map_height, viewport, n, m)
 
     def _parse_html_content(self, maps, size, show_info=None, theme=None, _carto_vl_path=None,
                             _airship_path=None, title=None, is_embed=False, is_static=False,
-                            viewport=None, n=None, m=None):
+                            map_height=None, viewport=None, n=None, m=None):
 
         if _carto_vl_path is None:
             carto_vl_path = constants.CARTO_VL_URL
@@ -64,6 +63,7 @@ class HTMLLayout(object):
             title=title,
             is_embed=is_embed,
             is_static=is_static,
+            map_height=map_height,
             n=n,
             m=m
         )

--- a/cartoframes/viz/html/HTMLLayout.py
+++ b/cartoframes/viz/html/HTMLLayout.py
@@ -5,7 +5,6 @@ from .. import constants
 
 class HTMLLayout(object):
     def __init__(self, template_path='templates/viz/layout.html.j2'):
-        self.width = None
         self.srcdoc = None
         self._env = Environment(
             loader=PackageLoader('cartoframes', 'assets'),

--- a/cartoframes/viz/layout.py
+++ b/cartoframes/viz/layout.py
@@ -97,21 +97,24 @@ class Layout(object):
                  N_SIZE=None,
                  M_SIZE=None,
                  viewport=None,
+                 map_height=250,
                  is_static=True):
         self._layout = _init_layout(maps, is_static, viewport)
         self._N_SIZE = N_SIZE if N_SIZE is not None else len(self._layout)
         self._M_SIZE = M_SIZE if M_SIZE is not None else constants.DEFAULT_LAYOUT_M_SIZE
         self._viewport = viewport
         self._is_static = is_static
+        self._map_height = map_height
 
     def _repr_html_(self):
         self._htmlLayout = HTMLLayout()
         self._htmlLayout.set_content(
             maps=self._layout,
-            size=['100%', 250 * self._M_SIZE],
+            size=['100%', self._map_height * self._M_SIZE],
             n=self._N_SIZE,
             m=self._M_SIZE,
-            is_static=self._is_static
+            is_static=self._is_static,
+            map_height=self._map_height
         )
 
         return self._htmlLayout.html


### PR DESCRIPTION
Related issues: https://github.com/CartoDB/cartoframes/issues/919

This PR:

- Fixes the index generation for the grid Layout
- Adds a `map_height` parameter in order to be able to customize the height of the maps contained in the Layout

![Screenshot 2019-09-25 at 13 38 46](https://user-images.githubusercontent.com/3824953/65600930-62b0e680-dfa1-11e9-915b-b7fe3208e8e7.png)
