### PR TITLE
Get list of entities by list of ids or slugs

### DIFF
--- a/cartoframes/data/observatory/entity.py
+++ b/cartoframes/data/observatory/entity.py
@@ -37,6 +37,10 @@ class CatalogEntity(ABC):
     def get_all(cls, filters=None):
         return cls.entity_repo.get_all(filters)
 
+    @classmethod
+    def get_list(cls, id_list):
+        return cls.entity_repo.get_by_id_list(id_list)
+
     def to_series(self):
         return pd.Series(self.data)
 

--- a/cartoframes/data/observatory/repository/entity_repo.py
+++ b/cartoframes/data/observatory/repository/entity_repo.py
@@ -16,9 +16,9 @@ class EntityRepository(ABC):
 
         self.id_field = id_field
         self.allowed_filters = filters + [id_field]
+        self.slug_field = slug_field
 
         if slug_field:
-            self.slug_field = slug_field
             self.allowed_filters.append(slug_field)
 
     def get_all(self, filters=None):

--- a/cartoframes/data/observatory/repository/entity_repo.py
+++ b/cartoframes/data/observatory/repository/entity_repo.py
@@ -11,12 +11,15 @@ except ImportError:
 
 class EntityRepository(ABC):
 
-    def __init__(self, id_field, filters, slug_field=None):
+    def __init__(self, id_field, filters=[], slug_field=None):
         self.client = RepoClient()
 
         self.id_field = id_field
-        self.slug_field = slug_field
         self.allowed_filters = filters + [id_field]
+
+        if slug_field:
+            self.slug_field = slug_field
+            self.allowed_filters.append(slug_field)
 
     def get_all(self, filters=None):
         return self._get_filtered_entities(filters)
@@ -30,6 +33,9 @@ class EntityRepository(ABC):
 
         data = self._map_row(result[0])
         return self._to_catalog_entity(data)
+
+    def get_by_id_list(self, id_list):
+        return self._get_filtered_entities(self._get_id_list_filters(id_list))
 
     def _get_filtered_entities(self, filters=None):
         cleaned_filters = self._get_filters(filters)
@@ -51,6 +57,28 @@ class EntityRepository(ABC):
             return {self.slug_field: id_}
 
         return {self.id_field: id_}
+
+    def _get_id_list_filters(self, id_list):
+        if self.slug_field is None:
+            return {self.id_field: id_list}
+
+        ids = []
+        slugs = []
+        filters = {}
+
+        for id_ in id_list:
+            if is_slug_value(id_):
+                slugs.append(id_)
+            else:
+                ids.append(id_)
+
+        if len(ids) > 0:
+            filters[self.id_field] = ids
+
+        if len(slugs) > 0:
+            filters[self.slug_field] = slugs
+
+        return filters
 
     @classmethod
     def _to_catalog_entity(cls, result):

--- a/cartoframes/data/observatory/repository/repo_client.py
+++ b/cartoframes/data/observatory/repository/repo_client.py
@@ -72,9 +72,17 @@ class RepoClient(object):
         conditions = extra_conditions or []
 
         if filters is not None and len(filters) > 0:
-            conditions.extend(["t.{} = '{}'".format(key, value) for key, value in filters.items()])
+            conditions.extend([self._generate_condition(key, value) for key, value in filters.items()])
 
         return conditions
+
+    @staticmethod
+    def _generate_condition(key, value):
+        if type(value) == list:
+            value_list = ','.join(["'" + v + "'" for v in value])
+            return "t.{} IN ({})".format(key, value_list)
+
+        return "t.{} = '{}'".format(key, value)
 
     def _get_purchased_dataset_ids(self):
         purchased_datasets = self._fetch_purchased_datasets()

--- a/test/data/observatory/repository/test_category_repo.py
+++ b/test/data/observatory/repository/test_category_repo.py
@@ -68,6 +68,20 @@ class TestCategoryRepo(unittest.TestCase):
         with self.assertRaises(DiscoveryException):
             repo.get_by_id(requested_id)
 
+    @patch.object(RepoClient, 'get_categories')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_category1, db_category2]
+        repo = CategoryRepository()
+
+        # When
+        categories = repo.get_by_id_list([db_category1['id'], db_category2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_category1['id'], db_category2['id']]})
+        assert isinstance(categories, CatalogList)
+        assert categories == test_categories
+
     @patch.object(RepoClient, '_run_query')
     def test_get_by_country(self, mocked_repo):
         # Given

--- a/test/data/observatory/repository/test_country_repo.py
+++ b/test/data/observatory/repository/test_country_repo.py
@@ -57,7 +57,7 @@ class TestCountryRepo(unittest.TestCase):
         assert country == test_country1
 
     @patch.object(RepoClient, 'get_countries')
-    def test_get_by_iso_code_unknown_fails(self, mocked_repo):
+    def test_get_by_id_unknown_fails(self, mocked_repo):
         # Given
         mocked_repo.return_value = []
         requested_iso_code = 'fra'
@@ -66,6 +66,20 @@ class TestCountryRepo(unittest.TestCase):
         # Then
         with self.assertRaises(DiscoveryException):
             repo.get_by_id(requested_iso_code)
+
+    @patch.object(RepoClient, 'get_countries')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_country1, db_country2]
+        repo = CountryRepository()
+
+        # When
+        countries = repo.get_by_id_list([db_country1['id'], db_country2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'country_id': [db_country1['id'], db_country2['id']]})
+        assert isinstance(countries, CatalogList)
+        assert countries == test_countries
 
     @patch.object(RepoClient, 'get_countries')
     def test_missing_fields_are_mapped_as_None(self, mocked_repo):

--- a/test/data/observatory/repository/test_dataset_repo.py
+++ b/test/data/observatory/repository/test_dataset_repo.py
@@ -101,6 +101,48 @@ class TestDatasetRepo(unittest.TestCase):
         assert dataset == test_dataset1
 
     @patch.object(RepoClient, 'get_datasets')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_dataset1, db_dataset2]
+        repo = DatasetRepository()
+
+        # When
+        datasets = repo.get_by_id_list([db_dataset1['id'], db_dataset2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_dataset1['id'], db_dataset2['id']]})
+        assert isinstance(datasets, CatalogList)
+        assert datasets == test_datasets
+
+    @patch.object(RepoClient, 'get_datasets')
+    def test_get_by_slug_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_dataset1, db_dataset2]
+        repo = DatasetRepository()
+
+        # When
+        datasets = repo.get_by_id_list([db_dataset1['slug'], db_dataset2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'slug': [db_dataset1['slug'], db_dataset2['slug']]})
+        assert isinstance(datasets, CatalogList)
+        assert datasets == test_datasets
+
+    @patch.object(RepoClient, 'get_datasets')
+    def test_get_by_slug_and_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_dataset1, db_dataset2]
+        repo = DatasetRepository()
+
+        # When
+        datasets = repo.get_by_id_list([db_dataset1['id'], db_dataset2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_dataset1['id']], 'slug': [db_dataset2['slug']]})
+        assert isinstance(datasets, CatalogList)
+        assert datasets == test_datasets
+
+    @patch.object(RepoClient, 'get_datasets')
     def test_get_by_country(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_dataset1, db_dataset2]

--- a/test/data/observatory/repository/test_geography_repo.py
+++ b/test/data/observatory/repository/test_geography_repo.py
@@ -82,6 +82,48 @@ class TestGeographyRepo(unittest.TestCase):
         mocked_repo.assert_called_once_with({'slug': requested_slug})
         assert geography == test_geography1
 
+    @patch.object(RepoClient, 'get_geographies')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_geography1, db_geography2]
+        repo = GeographyRepository()
+
+        # When
+        geographies = repo.get_by_id_list([db_geography1['id'], db_geography2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_geography1['id'], db_geography2['id']]})
+        assert isinstance(geographies, CatalogList)
+        assert geographies == test_geographies
+
+    @patch.object(RepoClient, 'get_geographies')
+    def test_get_by_slug_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_geography1, db_geography2]
+        repo = GeographyRepository()
+
+        # When
+        geographies = repo.get_by_id_list([db_geography1['slug'], db_geography2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'slug': [db_geography1['slug'], db_geography2['slug']]})
+        assert isinstance(geographies, CatalogList)
+        assert geographies == test_geographies
+
+    @patch.object(RepoClient, 'get_geographies')
+    def test_get_by_slug_and_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_geography1, db_geography2]
+        repo = GeographyRepository()
+
+        # When
+        geographies = repo.get_by_id_list([db_geography1['id'], db_geography2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_geography1['id']], 'slug': [db_geography2['slug']]})
+        assert isinstance(geographies, CatalogList)
+        assert geographies == test_geographies
+
     @patch.object(RepoClient, 'get_geographies_joined_datasets')
     def test_get_by_country(self, mocked_repo):
         # Given

--- a/test/data/observatory/repository/test_repo_client.py
+++ b/test/data/observatory/repository/test_repo_client.py
@@ -1,0 +1,65 @@
+import unittest
+
+from cartoframes.data.clients import SQLClient
+from cartoframes.data.observatory.repository.repo_client import RepoClient
+
+from ..examples import db_dataset1, db_dataset2
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
+
+class TestRepoClient(unittest.TestCase):
+
+    @patch.object(SQLClient, 'query')
+    def test_run_query_with_one_filter(self, mocked_client):
+        # Given
+        mocked_client.return_value = [db_dataset1, db_dataset2]
+        repo = RepoClient()
+        query = 'SELECT t.* FROM datasets t'
+        filters = {'category_id': 'demographics'}
+        expected_query = "SELECT t.* FROM datasets t WHERE t.category_id = 'demographics'"
+
+        # When
+        categories = repo._run_query(query, filters)
+
+        # Then
+        mocked_client.assert_called_once_with(expected_query)
+        assert categories == [db_dataset1, db_dataset2]
+
+    @patch.object(SQLClient, 'query')
+    def test_run_query_with_multiple_filter(self, mocked_client):
+        # Given
+        mocked_client.return_value = [db_dataset1, db_dataset2]
+        repo = RepoClient()
+        query = 'SELECT t.* FROM datasets t'
+        filters = {
+            'category_id': 'demographics',
+            'country_id': 'usa'}
+        expected_query = "SELECT t.* FROM datasets t WHERE t.category_id = 'demographics' AND t.country_id = 'usa'"
+
+        # When
+        datasets = repo._run_query(query, filters)
+
+        # Then
+        mocked_client.assert_called_once_with(expected_query)
+        assert datasets == [db_dataset1, db_dataset2]
+
+    @patch.object(SQLClient, 'query')
+    def test_run_query_with_id_list(self, mocked_client):
+        # Given
+        mocked_client.return_value = [db_dataset1, db_dataset2]
+        repo = RepoClient()
+        query = 'SELECT t.* FROM datasets t'
+        filters = {'id': ['carto-do.dataset.census', 'carto-do.dataset.municipalities']}
+        expected_query = "SELECT t.* FROM datasets t " \
+                         "WHERE t.id IN ('carto-do.dataset.census','carto-do.dataset.municipalities')"
+
+        # When
+        datasets = repo._run_query(query, filters)
+
+        # Then
+        mocked_client.assert_called_once_with(expected_query)
+        assert datasets == [db_dataset1, db_dataset2]

--- a/test/data/observatory/repository/test_variable_group_repo.py
+++ b/test/data/observatory/repository/test_variable_group_repo.py
@@ -69,6 +69,62 @@ class TestVariableGroupRepo(unittest.TestCase):
             repo.get_by_id(requested_id)
 
     @patch.object(RepoClient, 'get_variables_groups')
+    def test_get_by_slug(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable_group1]
+        requested_slug = db_variable_group1['slug']
+        repo = VariableGroupRepository()
+
+        # When
+        variable = repo.get_by_id(requested_slug)
+
+        # Then
+        mocked_repo.assert_called_once_with({'slug': requested_slug})
+        assert variable == test_variable_group1
+
+    @patch.object(RepoClient, 'get_variables_groups')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable_group1, db_variable_group2]
+        repo = VariableGroupRepository()
+
+        # When
+        variable_groups = repo.get_by_id_list([db_variable_group1['id'], db_variable_group2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_variable_group1['id'], db_variable_group2['id']]})
+        assert isinstance(variable_groups, CatalogList)
+        assert variable_groups == test_variables_groups
+
+    @patch.object(RepoClient, 'get_variables_groups')
+    def test_get_by_slug_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable_group1, db_variable_group2]
+        repo = VariableGroupRepository()
+
+        # When
+        variable_groups = repo.get_by_id_list([db_variable_group1['slug'], db_variable_group2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'slug': [db_variable_group1['slug'], db_variable_group2['slug']]})
+        assert isinstance(variable_groups, CatalogList)
+        assert variable_groups == test_variables_groups
+
+    @patch.object(RepoClient, 'get_variables_groups')
+    def test_get_by_slug_and_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable_group1, db_variable_group2]
+        repo = VariableGroupRepository()
+
+        # When
+        variable_groups = repo.get_by_id_list([db_variable_group1['id'], db_variable_group2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_variable_group1['id']], 'slug': [db_variable_group2['slug']]})
+        assert isinstance(variable_groups, CatalogList)
+        assert variable_groups == test_variables_groups
+
+    @patch.object(RepoClient, 'get_variables_groups')
     def test_get_by_dataset(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_variable_group1, db_variable_group2]

--- a/test/data/observatory/repository/test_variable_repo.py
+++ b/test/data/observatory/repository/test_variable_repo.py
@@ -83,6 +83,48 @@ class TestVariableRepo(unittest.TestCase):
         assert variable == test_variable1
 
     @patch.object(RepoClient, 'get_variables')
+    def test_get_by_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable1, db_variable2]
+        repo = VariableRepository()
+
+        # When
+        variables = repo.get_by_id_list([db_variable1['id'], db_variable2['id']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_variable1['id'], db_variable2['id']]})
+        assert isinstance(variables, CatalogList)
+        assert variables == test_variables
+
+    @patch.object(RepoClient, 'get_variables')
+    def test_get_by_slug_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable1, db_variable2]
+        repo = VariableRepository()
+
+        # When
+        variables = repo.get_by_id_list([db_variable1['slug'], db_variable2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'slug': [db_variable1['slug'], db_variable2['slug']]})
+        assert isinstance(variables, CatalogList)
+        assert variables == test_variables
+
+    @patch.object(RepoClient, 'get_variables')
+    def test_get_by_slug_and_id_list(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable1, db_variable2]
+        repo = VariableRepository()
+
+        # When
+        variables = repo.get_by_id_list([db_variable1['id'], db_variable2['slug']])
+
+        # Then
+        mocked_repo.assert_called_once_with({'id': [db_variable1['id']], 'slug': [db_variable2['slug']]})
+        assert isinstance(variables, CatalogList)
+        assert variables == test_variables
+
+    @patch.object(RepoClient, 'get_variables')
     def test_get_by_dataset(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_variable1, db_variable2]


### PR DESCRIPTION
Closes https://github.com/CartoDB/data-observatory/issues/237

Given a list of ids, the new method `get_list` returns the list of entities corresponding to those ids. If the entity also has a slug defined (Dataset, Geography, Variable, VariableGroup) the method can also receive a list of slugs or a mixed list (ids and slugs).