### PR TITLE
Fix popup style for dark mode

### DIFF
--- a/cartoframes/assets/style/themes/dark.html.j2
+++ b/cartoframes/assets/style/themes/dark.html.j2
@@ -38,4 +38,28 @@
     --as--color--text-contrast: #000;
     --as--color--shadow: #000;
   }
+
+  .mapboxgl-popup-content {
+    background: var(--as--color--secondary);
+  }
+
+  .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
+  .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip,
+  .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
+    border-top-color: var(--as--color--secondary);
+  }
+
+  .mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
+  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip,
+  .mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip {
+    border-bottom-color: var(--as--color--secondary);
+  }
+
+  .mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+    border-right-color: var(--as--color--secondary);
+  }
+
+  .mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+    border-left-color: var(--as--color--secondary);
+  }
 </style>


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartoframes/issues/1099

This PR Fixes the popup style when using the Dark mode:

![Screenshot 2019-10-14 at 10 33 54](https://user-images.githubusercontent.com/3824953/66738240-469cb880-ee6e-11e9-8315-51ce6c96dac2.png)
![Screenshot 2019-10-14 at 10 33 57](https://user-images.githubusercontent.com/3824953/66738241-469cb880-ee6e-11e9-9737-3f7a624a7835.png)
![Screenshot 2019-10-14 at 10 34 01](https://user-images.githubusercontent.com/3824953/66738242-47354f00-ee6e-11e9-8fa1-067e9ff7da8a.png)
![Screenshot 2019-10-14 at 10 34 04](https://user-images.githubusercontent.com/3824953/66738243-47354f00-ee6e-11e9-9337-2825b9b9a29f.png)
![Screenshot 2019-10-14 at 10 31 19](https://user-images.githubusercontent.com/3824953/66738247-4997a900-ee6e-11e9-94bd-60421763966d.png)
![Screenshot 2019-10-14 at 10 33 44](https://user-images.githubusercontent.com/3824953/66738248-4997a900-ee6e-11e9-9707-9e7bf7462ff8.png)
![Screenshot 2019-10-14 at 10 33 49](https://user-images.githubusercontent.com/3824953/66738250-4a303f80-ee6e-11e9-85a7-0008c9fc0387.png)
