### PR TITLE
Feature/1100-catalog-tweaks

### DIFF
--- a/cartoframes/data/observatory/__init__.py
+++ b/cartoframes/data/observatory/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .catalog import Catalog
 from .category import Category
 from .country import Country
-from .dataset import Dataset
+from .dataset import CatalogDataset
 from .geography import Geography
 from .provider import Provider
 from .variable import Variable
@@ -13,7 +13,7 @@ __all__ = [
     'Catalog',
     'Category',
     'Country',
-    'Dataset',
+    'CatalogDataset',
     'Geography',
     'Provider',
     'Variable'

--- a/cartoframes/data/observatory/catalog.py
+++ b/cartoframes/data/observatory/catalog.py
@@ -4,7 +4,7 @@ from .entity import is_slug_value
 from .category import Category
 from .country import Country
 from .geography import Geography
-from .dataset import Dataset
+from .dataset import CatalogDataset
 from .repository.constants import COUNTRY_FILTER, CATEGORY_FILTER, GEOGRAPHY_FILTER
 
 
@@ -45,7 +45,7 @@ class Catalog(object):
 
         """
 
-        return Dataset.get_all(self.filters)
+        return CatalogDataset.get_all(self.filters)
 
     @property
     def geographies(self):
@@ -128,4 +128,4 @@ class Catalog(object):
 
         """
 
-        return Dataset.get_all(self.filters, credentials)
+        return CatalogDataset.get_all(self.filters, credentials)

--- a/cartoframes/data/observatory/category.py
+++ b/cartoframes/data/observatory/category.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+from cartoframes.data.observatory.repository.constants import CATEGORY_FILTER
+
+from cartoframes.data.observatory.repository.geography_repo import get_geography_repo
+
 from .entity import CatalogEntity
 from .repository.category_repo import get_category_repo
 from .repository.dataset_repo import get_dataset_repo
@@ -11,7 +15,11 @@ class Category(CatalogEntity):
 
     @property
     def datasets(self):
-        return get_dataset_repo().get_by_category(self.id)
+        return get_dataset_repo().get_all({CATEGORY_FILTER: self.id})
+
+    @property
+    def geographies(self):
+        return get_geography_repo().get_all({CATEGORY_FILTER: self.id})
 
     @property
     def name(self):

--- a/cartoframes/data/observatory/country.py
+++ b/cartoframes/data/observatory/country.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 
+
 from .entity import CatalogEntity
 from .repository.geography_repo import get_geography_repo
 from .repository.country_repo import get_country_repo
 from .repository.dataset_repo import get_dataset_repo
+from .repository.category_repo import get_category_repo
+from .repository.constants import COUNTRY_FILTER
 
 
 class Country(CatalogEntity):
@@ -12,8 +15,12 @@ class Country(CatalogEntity):
 
     @property
     def datasets(self):
-        return get_dataset_repo().get_by_country(self.id)
+        return get_dataset_repo().get_all({COUNTRY_FILTER: self.id})
 
     @property
     def geographies(self):
-        return get_geography_repo().get_by_country(self.id)
+        return get_geography_repo().get_all({COUNTRY_FILTER: self.id})
+
+    @property
+    def categories(self):
+        return get_category_repo().get_all({COUNTRY_FILTER: self.id})

--- a/cartoframes/data/observatory/dataset.py
+++ b/cartoframes/data/observatory/dataset.py
@@ -8,7 +8,7 @@ from .repository.variable_group_repo import get_variable_group_repo
 from .repository.constants import DATASET_FILTER
 
 
-class Dataset(CatalogEntity):
+class CatalogDataset(CatalogEntity):
     entity_repo = get_dataset_repo()
 
     @property

--- a/cartoframes/data/observatory/dataset.py
+++ b/cartoframes/data/observatory/dataset.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
+
 from .entity import CatalogEntity
 from .repository.dataset_repo import get_dataset_repo
 from .repository.variable_repo import get_variable_repo
 from .repository.variable_group_repo import get_variable_group_repo
+from .repository.constants import DATASET_FILTER
 
 
 class Dataset(CatalogEntity):
@@ -11,11 +13,11 @@ class Dataset(CatalogEntity):
 
     @property
     def variables(self):
-        return get_variable_repo().get_by_dataset(self.id)
+        return get_variable_repo().get_all({DATASET_FILTER: self.id})
 
     @property
     def variables_groups(self):
-        return get_variable_group_repo().get_by_dataset(self.id)
+        return get_variable_group_repo().get_all({DATASET_FILTER: self.id})
 
     @property
     def name(self):

--- a/cartoframes/data/observatory/entity.py
+++ b/cartoframes/data/observatory/entity.py
@@ -29,6 +29,13 @@ class CatalogEntity(ABC):
     def id(self):
         return self.data[self.id_field]
 
+    @property
+    def slug(self):
+        try:
+            return self.data['slug']
+        except KeyError:
+            return None
+
     @classmethod
     def get(cls, id_):
         return cls.entity_repo.get_by_id(id_)
@@ -102,7 +109,7 @@ class CatalogList(list):
         super(CatalogList, self).__init__(data)
 
     def get(self, item_id):
-        return next(filter(lambda item: item.id == item_id, self), None)
+        return next(filter(lambda item: item.id == item_id or item.slug == item_id, self), None)
 
     def to_dataframe(self):
         return pd.DataFrame([item.data for item in self])

--- a/cartoframes/data/observatory/entity.py
+++ b/cartoframes/data/observatory/entity.py
@@ -109,7 +109,7 @@ class CatalogList(list):
         super(CatalogList, self).__init__(data)
 
     def get(self, item_id):
-        return next(filter(lambda item: item.id == item_id or item.slug == item_id, self), None)
+        return next(iter(filter(lambda item: item.id == item_id or item.slug == item_id, self)), None)
 
     def to_dataframe(self):
         return pd.DataFrame([item.data for item in self])

--- a/cartoframes/data/observatory/entity.py
+++ b/cartoframes/data/observatory/entity.py
@@ -21,6 +21,7 @@ class CatalogEntity(ABC):
 
     id_field = 'id'
     entity_repo = None
+    export_excluded_fields = ['summary_jsonb']
 
     def __init__(self, data):
         self.data = data
@@ -52,7 +53,7 @@ class CatalogEntity(ABC):
         return pd.Series(self.data)
 
     def to_dict(self):
-        return self.data
+        return {key: value for key, value in self.data.items() if key not in self.export_excluded_fields}
 
     def __eq__(self, other):
         return self.data == other.data

--- a/cartoframes/data/observatory/geography.py
+++ b/cartoframes/data/observatory/geography.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+
 from .entity import CatalogEntity
 from .repository.dataset_repo import get_dataset_repo
 from .repository.geography_repo import get_geography_repo
+from .repository.constants import GEOGRAPHY_FILTER
 
 
 class Geography(CatalogEntity):
@@ -11,7 +13,7 @@ class Geography(CatalogEntity):
 
     @property
     def datasets(self):
-        return get_dataset_repo().get_by_geography(self.id)
+        return get_dataset_repo().get_all({GEOGRAPHY_FILTER: self.id})
 
     @property
     def name(self):

--- a/cartoframes/data/observatory/provider.py
+++ b/cartoframes/data/observatory/provider.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from .entity import CatalogEntity
 from .repository.provider_repo import get_provider_repo
 from .repository.dataset_repo import get_dataset_repo
+from .repository.constants import PROVIDER_FILTER
 
 
 class Provider(CatalogEntity):
@@ -11,7 +12,7 @@ class Provider(CatalogEntity):
 
     @property
     def datasets(self):
-        return get_dataset_repo().get_by_provider(self.id)
+        return get_dataset_repo().get_all({PROVIDER_FILTER: self.id})
 
     @property
     def name(self):

--- a/cartoframes/data/observatory/repository/dataset_repo.py
+++ b/cartoframes/data/observatory/repository/dataset_repo.py
@@ -22,21 +22,6 @@ class DatasetRepository(EntityRepository):
         self.client.set_user_credentials(credentials)
         return self._get_filtered_entities(filters)
 
-    def get_by_country(self, iso_code3):
-        return self._get_filtered_entities({COUNTRY_FILTER: iso_code3})
-
-    def get_by_category(self, category_id):
-        return self._get_filtered_entities({CATEGORY_FILTER: category_id})
-
-    def get_by_variable(self, variable_id):
-        return self._get_filtered_entities({VARIABLE_FILTER: variable_id})
-
-    def get_by_geography(self, geography_id):
-        return self._get_filtered_entities({GEOGRAPHY_FILTER: geography_id})
-
-    def get_by_provider(self, provider_id):
-        return self._get_filtered_entities({PROVIDER_FILTER: provider_id})
-
     @classmethod
     def _get_entity_class(cls):
         from cartoframes.data.observatory.dataset import Dataset

--- a/cartoframes/data/observatory/repository/dataset_repo.py
+++ b/cartoframes/data/observatory/repository/dataset_repo.py
@@ -24,8 +24,8 @@ class DatasetRepository(EntityRepository):
 
     @classmethod
     def _get_entity_class(cls):
-        from cartoframes.data.observatory.dataset import Dataset
-        return Dataset
+        from cartoframes.data.observatory.dataset import CatalogDataset
+        return CatalogDataset
 
     def _get_rows(self, filters=None):
         return self.client.get_datasets(filters)

--- a/cartoframes/data/observatory/repository/geography_repo.py
+++ b/cartoframes/data/observatory/repository/geography_repo.py
@@ -18,9 +18,6 @@ class GeographyRepository(EntityRepository):
     def __init__(self):
         super(GeographyRepository, self).__init__(_GEOGRAPHY_ID_FIELD, _ALLOWED_FILTERS, _GEOGRAPHY_SLUG_FIELD)
 
-    def get_by_country(self, iso_code3):
-        return self._get_filtered_entities({COUNTRY_FILTER: iso_code3})
-
     @classmethod
     def _get_entity_class(cls):
         from cartoframes.data.observatory.geography import Geography

--- a/cartoframes/data/observatory/repository/repo_client.py
+++ b/cartoframes/data/observatory/repository/repo_client.py
@@ -72,7 +72,7 @@ class RepoClient(object):
         conditions = extra_conditions or []
 
         if filters is not None and len(filters) > 0:
-            conditions.extend([self._generate_condition(key, value) for key, value in filters.items()])
+            conditions.extend([self._generate_condition(key, value) for key, value in sorted(filters.items())])
 
         return conditions
 

--- a/cartoframes/data/observatory/repository/variable_group_repo.py
+++ b/cartoframes/data/observatory/repository/variable_group_repo.py
@@ -19,9 +19,6 @@ class VariableGroupRepository(EntityRepository):
         super(VariableGroupRepository, self).__init__(_VARIABLE_GROUP_ID_FIELD, _ALLOWED_FILTERS,
                                                       _VARIABLE_GROUP_SLUG_FIELD)
 
-    def get_by_dataset(self, dataset_id):
-        return self._get_filtered_entities({DATASET_FILTER: dataset_id})
-
     @classmethod
     def _get_entity_class(cls):
         from cartoframes.data.observatory.variable_group import VariableGroup

--- a/cartoframes/data/observatory/repository/variable_repo.py
+++ b/cartoframes/data/observatory/repository/variable_repo.py
@@ -18,12 +18,6 @@ class VariableRepository(EntityRepository):
     def __init__(self):
         super(VariableRepository, self).__init__(_VARIABLE_ID_FIELD, _ALLOWED_DATASETS, _VARIABLE_SLUG_FIELD)
 
-    def get_by_dataset(self, dataset_id):
-        return self._get_filtered_entities({DATASET_FILTER: dataset_id})
-
-    def get_by_variable_group(self, variable_group_id):
-        return self._get_filtered_entities({VARIABLE_GROUP_FILTER: variable_group_id})
-
     @classmethod
     def _get_entity_class(cls):
         from cartoframes.data.observatory.variable import Variable

--- a/cartoframes/data/observatory/variable.py
+++ b/cartoframes/data/observatory/variable.py
@@ -6,6 +6,9 @@ from .repository.variable_repo import get_variable_repo
 from .repository.constants import VARIABLE_FILTER
 
 
+_DESCRIPTION_LENGTH_LIMIT = 20
+
+
 class Variable(CatalogEntity):
 
     entity_repo = get_variable_repo()
@@ -64,3 +67,13 @@ class Variable(CatalogEntity):
     def dataset_name(self):
         _, _, dataset, _ = self.id.split('.')
         return dataset
+
+    def __repr__(self):
+        descr = self.description
+
+        if len(descr) > _DESCRIPTION_LENGTH_LIMIT:
+            descr = descr[0:_DESCRIPTION_LENGTH_LIMIT] + '...'
+
+        return "<{classname}('{entity_id}','{descr}')>"\
+               .format(classname=self.__class__.__name__, entity_id=self._get_print_id(), descr=descr)
+

--- a/cartoframes/data/observatory/variable.py
+++ b/cartoframes/data/observatory/variable.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from .entity import CatalogEntity
 from .repository.dataset_repo import get_dataset_repo
 from .repository.variable_repo import get_variable_repo
+from .repository.constants import VARIABLE_FILTER
 
 
 class Variable(CatalogEntity):
@@ -11,7 +12,7 @@ class Variable(CatalogEntity):
 
     @property
     def datasets(self):
-        return get_dataset_repo().get_by_variable(self.id)
+        return get_dataset_repo().get_all({VARIABLE_FILTER: self.id})
 
     @property
     def name(self):

--- a/cartoframes/data/observatory/variable_group.py
+++ b/cartoframes/data/observatory/variable_group.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from .entity import CatalogEntity
 from .repository.variable_group_repo import get_variable_group_repo
 from .repository.variable_repo import get_variable_repo
+from .repository.constants import VARIABLE_GROUP_FILTER
 
 
 class VariableGroup(CatalogEntity):
@@ -11,7 +12,7 @@ class VariableGroup(CatalogEntity):
 
     @property
     def variables(self):
-        return get_variable_repo().get_by_variable_group(self.id)
+        return get_variable_repo().get_all({VARIABLE_GROUP_FILTER: self.id})
 
     @property
     def name(self):

--- a/test/data/observatory/examples.py
+++ b/test/data/observatory/examples.py
@@ -101,7 +101,7 @@ db_variable1 = {
     'id': 'carto-do.variable.var1',
     'slug': 'var1',
     'name': 'Population',
-    'description': 'The number of people within each geography',
+    'description': 'Number of people',
     'column_name': 'pop',
     'db_type': 'Numeric',
     'dataset_id': 'dataset1',

--- a/test/data/observatory/examples.py
+++ b/test/data/observatory/examples.py
@@ -1,5 +1,5 @@
 from cartoframes.data.observatory.variable import Variable
-from cartoframes.data.observatory.dataset import Dataset
+from cartoframes.data.observatory.dataset import CatalogDataset
 from cartoframes.data.observatory.category import Category
 from cartoframes.data.observatory.geography import Geography
 from cartoframes.data.observatory.country import Country
@@ -93,8 +93,8 @@ db_dataset2 = {
     'is_public_data': False,
     'summary_jsonb': {}
 }
-test_dataset1 = Dataset(db_dataset1)
-test_dataset2 = Dataset(db_dataset2)
+test_dataset1 = CatalogDataset(db_dataset1)
+test_dataset2 = CatalogDataset(db_dataset2)
 test_datasets = CatalogList([test_dataset1, test_dataset2])
 
 db_variable1 = {

--- a/test/data/observatory/repository/test_category_repo.py
+++ b/test/data/observatory/repository/test_category_repo.py
@@ -67,7 +67,6 @@ class TestCategoryRepo(unittest.TestCase):
         })
         assert categories == test_categories
 
-
     @patch.object(RepoClient, 'get_categories')
     def test_get_by_id(self, mocked_repo):
         # Given

--- a/test/data/observatory/repository/test_category_repo.py
+++ b/test/data/observatory/repository/test_category_repo.py
@@ -43,6 +43,31 @@ class TestCategoryRepo(unittest.TestCase):
         mocked_repo.assert_called_once_with(None)
         assert categories is None
 
+    @patch.object(RepoClient, 'get_categories_joined_datasets')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_category1, db_category2]
+        repo = CategoryRepository()
+        filters = {
+            'country_id': 'usa',
+            'dataset_id': 'carto-do.project.census2011',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        categories = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'country_id': 'usa'
+        })
+        assert categories == test_categories
+
+
     @patch.object(RepoClient, 'get_categories')
     def test_get_by_id(self, mocked_repo):
         # Given

--- a/test/data/observatory/repository/test_country_repo.py
+++ b/test/data/observatory/repository/test_country_repo.py
@@ -42,6 +42,30 @@ class TestCountryRepo(unittest.TestCase):
         assert countries is None
 
     @patch.object(RepoClient, 'get_countries')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_country1, db_country2]
+        repo = CountryRepository()
+        filters = {
+            'dataset_id': 'carto-do.project.census2011',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        countries = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'category_id': 'demographics'
+        })
+        assert countries == test_countries
+
+    @patch.object(RepoClient, 'get_countries')
     def test_get_by_id(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_country1, db_country2]

--- a/test/data/observatory/repository/test_dataset_repo.py
+++ b/test/data/observatory/repository/test_dataset_repo.py
@@ -62,6 +62,34 @@ class TestDatasetRepo(unittest.TestCase):
         assert datasets is None
 
     @patch.object(RepoClient, 'get_datasets')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_dataset1, db_dataset2]
+        repo = DatasetRepository()
+        filters = {
+            'country_id': 'usa',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        datasets = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'country_id': 'usa',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'provider_id': 'open_data'
+        })
+        assert datasets == test_datasets
+
+    @patch.object(RepoClient, 'get_datasets')
     def test_get_by_id(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_dataset1]
@@ -139,66 +167,6 @@ class TestDatasetRepo(unittest.TestCase):
 
         # Then
         mocked_repo.assert_called_once_with({'id': [db_dataset1['id']], 'slug': [db_dataset2['slug']]})
-        assert isinstance(datasets, CatalogList)
-        assert datasets == test_datasets
-
-    @patch.object(RepoClient, 'get_datasets')
-    def test_get_by_country(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_dataset1, db_dataset2]
-        country_code = 'esp'
-        repo = DatasetRepository()
-
-        # When
-        datasets = repo.get_by_country(country_code)
-
-        # Then
-        mocked_repo.assert_called_once_with({'country_id': country_code})
-        assert isinstance(datasets, CatalogList)
-        assert datasets == test_datasets
-
-    @patch.object(RepoClient, 'get_datasets')
-    def test_get_by_category(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_dataset1, db_dataset2]
-        category_id = 'cat1'
-        repo = DatasetRepository()
-
-        # When
-        datasets = repo.get_by_category(category_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'category_id': category_id})
-        assert isinstance(datasets, CatalogList)
-        assert datasets == test_datasets
-
-    @patch.object(RepoClient, 'get_datasets')
-    def test_get_by_variable(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_dataset1, db_dataset2]
-        variable_id = 'var1'
-        repo = DatasetRepository()
-
-        # When
-        datasets = repo.get_by_variable(variable_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'variable_id': variable_id})
-        assert isinstance(datasets, CatalogList)
-        assert datasets == test_datasets
-
-    @patch.object(RepoClient, 'get_datasets')
-    def test_get_by_geography(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_dataset1, db_dataset2]
-        geography_id = 'geo_id'
-        repo = DatasetRepository()
-
-        # When
-        datasets = repo.get_by_geography(geography_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'geography_id': geography_id})
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets
 

--- a/test/data/observatory/repository/test_dataset_repo.py
+++ b/test/data/observatory/repository/test_dataset_repo.py
@@ -1,7 +1,7 @@
 import unittest
 
 from cartoframes.auth import Credentials
-from cartoframes.data.observatory.dataset import Dataset
+from cartoframes.data.observatory.dataset import CatalogDataset
 
 from cartoframes.exceptions import DiscoveryException
 from cartoframes.data.observatory.entity import CatalogList
@@ -176,7 +176,7 @@ class TestDatasetRepo(unittest.TestCase):
         mocked_repo.return_value = [{'id': 'dataset1'}]
         repo = DatasetRepository()
 
-        expected_datasets = CatalogList([Dataset({
+        expected_datasets = CatalogList([CatalogDataset({
             'id': 'dataset1',
             'slug': None,
             'name': None,

--- a/test/data/observatory/repository/test_geography_repo.py
+++ b/test/data/observatory/repository/test_geography_repo.py
@@ -42,6 +42,32 @@ class TestGeographyRepo(unittest.TestCase):
         mocked_repo.assert_called_once_with(None)
         assert geographies is None
 
+    @patch.object(RepoClient, 'get_geographies_joined_datasets')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_geography1, db_geography2]
+        repo = GeographyRepository()
+        filters = {
+            'country_id': 'usa',
+            'dataset_id': 'carto-do.project.census2011',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        geographies = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'country_id': 'usa',
+            'category_id': 'demographics'
+        })
+        assert geographies == test_geographies
+
     @patch.object(RepoClient, 'get_geographies')
     def test_get_by_id(self, mocked_repo):
         # Given
@@ -121,21 +147,6 @@ class TestGeographyRepo(unittest.TestCase):
 
         # Then
         mocked_repo.assert_called_once_with({'id': [db_geography1['id']], 'slug': [db_geography2['slug']]})
-        assert isinstance(geographies, CatalogList)
-        assert geographies == test_geographies
-
-    @patch.object(RepoClient, 'get_geographies_joined_datasets')
-    def test_get_by_country(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_geography1, db_geography2]
-        country_code = 'esp'
-        repo = GeographyRepository()
-
-        # When
-        geographies = repo.get_by_country(country_code)
-
-        # Then
-        mocked_repo.assert_called_once_with({'country_id': country_code})
         assert isinstance(geographies, CatalogList)
         assert geographies == test_geographies
 

--- a/test/data/observatory/repository/test_variable_group_repo.py
+++ b/test/data/observatory/repository/test_variable_group_repo.py
@@ -43,6 +43,31 @@ class TestVariableGroupRepo(unittest.TestCase):
         assert variables_groups is None
 
     @patch.object(RepoClient, 'get_variables_groups')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable_group1, db_variable_group2]
+        repo = VariableGroupRepository()
+        filters = {
+            'country_id': 'usa',
+            'dataset_id': 'carto-do.project.census2011',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        variables_groups = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'dataset_id': 'carto-do.project.census2011'
+        })
+        assert variables_groups == test_variables_groups
+
+    @patch.object(RepoClient, 'get_variables_groups')
     def test_get_by_id(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_variable_group1, db_variable_group2]
@@ -123,21 +148,6 @@ class TestVariableGroupRepo(unittest.TestCase):
         mocked_repo.assert_called_once_with({'id': [db_variable_group1['id']], 'slug': [db_variable_group2['slug']]})
         assert isinstance(variable_groups, CatalogList)
         assert variable_groups == test_variables_groups
-
-    @patch.object(RepoClient, 'get_variables_groups')
-    def test_get_by_dataset(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_variable_group1, db_variable_group2]
-        dataset_id = 'dataset1'
-        repo = VariableGroupRepository()
-
-        # When
-        variables_groups = repo.get_by_dataset(dataset_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'dataset_id': dataset_id})
-        assert isinstance(variables_groups, CatalogList)
-        assert variables_groups == test_variables_groups
 
     @patch.object(RepoClient, 'get_variables_groups')
     def test_missing_fields_are_mapped_as_None(self, mocked_repo):

--- a/test/data/observatory/repository/test_variable_repo.py
+++ b/test/data/observatory/repository/test_variable_repo.py
@@ -43,6 +43,32 @@ class TestVariableRepo(unittest.TestCase):
         assert variables is None
 
     @patch.object(RepoClient, 'get_variables')
+    def test_get_all_only_uses_allowed_filters(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = [db_variable1, db_variable2]
+        repo = VariableRepository()
+        filters = {
+            'country_id': 'usa',
+            'dataset_id': 'carto-do.project.census2011',
+            'category_id': 'demographics',
+            'variable_id': 'population',
+            'geography_id': 'census-geo',
+            'variable_group_id': 'var-group',
+            'provider_id': 'open_data',
+            'fake_field_id': 'fake_value'
+        }
+
+        # When
+        variables = repo.get_all(filters)
+
+        # Then
+        mocked_repo.assert_called_once_with({
+            'dataset_id': 'carto-do.project.census2011',
+            'variable_group_id': 'var-group'
+        })
+        assert variables == test_variables
+
+    @patch.object(RepoClient, 'get_variables')
     def test_get_by_id(self, mocked_repo):
         # Given
         mocked_repo.return_value = [db_variable1, db_variable2]
@@ -121,36 +147,6 @@ class TestVariableRepo(unittest.TestCase):
 
         # Then
         mocked_repo.assert_called_once_with({'id': [db_variable1['id']], 'slug': [db_variable2['slug']]})
-        assert isinstance(variables, CatalogList)
-        assert variables == test_variables
-
-    @patch.object(RepoClient, 'get_variables')
-    def test_get_by_dataset(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_variable1, db_variable2]
-        dataset_id = 'dataset1'
-        repo = VariableRepository()
-
-        # When
-        variables = repo.get_by_dataset(dataset_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'dataset_id': dataset_id})
-        assert isinstance(variables, CatalogList)
-        assert variables == test_variables
-
-    @patch.object(RepoClient, 'get_variables')
-    def test_get_by_variable_group(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = [db_variable1, db_variable2]
-        variable_group_id = 'vargroup1'
-        repo = VariableRepository()
-
-        # When
-        variables = repo.get_by_variable_group(variable_group_id)
-
-        # Then
-        mocked_repo.assert_called_once_with({'variable_group_id': variable_group_id})
         assert isinstance(variables, CatalogList)
         assert variables == test_variables
 

--- a/test/data/observatory/test_catalog.py
+++ b/test/data/observatory/test_catalog.py
@@ -5,7 +5,7 @@ from cartoframes.auth import Credentials
 from cartoframes.data.observatory.geography import Geography
 from cartoframes.data.observatory.country import Country
 from cartoframes.data.observatory.category import Category
-from cartoframes.data.observatory.dataset import Dataset
+from cartoframes.data.observatory.dataset import CatalogDataset
 from cartoframes.data.observatory.catalog import Catalog
 from cartoframes.data.observatory.repository.geography_repo import GeographyRepository
 from .examples import test_country2, test_country1, test_category1, test_category2, test_dataset1, test_dataset2, \
@@ -45,7 +45,7 @@ class TestCatalog(unittest.TestCase):
         # Then
         assert categories == expected_categories
 
-    @patch.object(Dataset, 'get_all')
+    @patch.object(CatalogDataset, 'get_all')
     def test_datasets(self, mocked_datasets):
         # Given
         expected_datasets = [test_dataset1, test_dataset2]
@@ -84,7 +84,7 @@ class TestCatalog(unittest.TestCase):
         mocked_categories.called_once_with({'country_id': 'usa'})
         assert categories == test_categories
 
-    @patch.object(Dataset, 'get_all')
+    @patch.object(CatalogDataset, 'get_all')
     def test_filters_on_datasets(self, mocked_datasets):
         # Given
         mocked_datasets.return_value = test_datasets
@@ -110,7 +110,7 @@ class TestCatalog(unittest.TestCase):
         mocked_geographies.called_once_with({'country_id': 'usa', 'category_id': 'demographics'})
         assert geographies == test_geographies
 
-    @patch.object(Dataset, 'get_all')
+    @patch.object(CatalogDataset, 'get_all')
     def test_all_filters(self, mocked_datasets):
         # Given
         mocked_datasets.return_value = test_datasets
@@ -128,7 +128,7 @@ class TestCatalog(unittest.TestCase):
 
         assert datasets == test_datasets
 
-    @patch.object(Dataset, 'get_all')
+    @patch.object(CatalogDataset, 'get_all')
     @patch.object(GeographyRepository, 'get_by_id')
     def test_geography_filter_by_slug(self, mocked_repo, mocked_datasets):
         # Given
@@ -145,7 +145,7 @@ class TestCatalog(unittest.TestCase):
         mocked_datasets.assert_called_once_with({'geography_id': test_geography1.id})
         assert datasets == test_datasets
 
-    @patch.object(Dataset, 'get_all')
+    @patch.object(CatalogDataset, 'get_all')
     def test_purchased_datasets(self, mocked_purchased_datasets):
         # Given
         expected_datasets = [test_dataset1, test_dataset2]

--- a/test/data/observatory/test_category.py
+++ b/test/data/observatory/test_category.py
@@ -104,7 +104,7 @@ class TestCategory(unittest.TestCase):
         assert isinstance(category_dict, dict)
         assert category_dict == db_category1
 
-    def test_category_is_represented_with_id(self):
+    def test_category_is_represented_with_classname_and_id(self):
         # Given
         category = Category(db_category1)
 
@@ -137,7 +137,7 @@ class TestCategory(unittest.TestCase):
         assert isinstance(categories, CatalogList)
         assert categories == test_categories
 
-    def test_category_list_is_printed_with_classname(self):
+    def test_category_list_is_printed_with_classname_and_ids(self):
         # Given
         categories = CatalogList([test_category1, test_category2])
 
@@ -148,7 +148,7 @@ class TestCategory(unittest.TestCase):
         assert categories_str == "[<Category('{id1}')>, <Category('{id2}')>]" \
                                  .format(id1=db_category1['id'], id2=db_category2['id'])
 
-    def test_category_list_is_represented_with_ids(self):
+    def test_category_list_is_represented_with_classname_and_ids(self):
         # Given
         categories = CatalogList([test_category1, test_category2])
 

--- a/test/data/observatory/test_category.py
+++ b/test/data/observatory/test_category.py
@@ -30,6 +30,18 @@ class TestCategory(unittest.TestCase):
         assert isinstance(category, Category)
         assert category == test_category1
 
+    def test_get_category_by_id_from_categories_list(self):
+        # Given
+        categories = CatalogList([test_category1, test_category2])
+
+        # When
+        category = categories.get(test_category1.id)
+
+        # Then
+        assert isinstance(category, object)
+        assert isinstance(category, Category)
+        assert category == test_category1
+
     @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_category(self, mocked_repo):
         # Given
@@ -146,19 +158,6 @@ class TestCategory(unittest.TestCase):
         # Then
         assert categories_repr == "[<Category('{id1}')>, <Category('{id2}')>]"\
                                   .format(id1=db_category1['id'], id2=db_category2['id'])
-
-    @patch.object(CategoryRepository, 'get_by_id')
-    def test_get_category_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_category1
-
-        # When
-        category = Category.get('cat1')
-
-        # Then
-        assert isinstance(category, object)
-        assert isinstance(category, Category)
-        assert category == test_category1
 
     def test_categories_items_are_obtained_as_category(self):
         # Given

--- a/test/data/observatory/test_category.py
+++ b/test/data/observatory/test_category.py
@@ -1,11 +1,13 @@
 import unittest
 import pandas as pd
+from cartoframes.data.observatory.repository.geography_repo import GeographyRepository
 
 from cartoframes.data.observatory.category import Category
 from cartoframes.data.observatory.repository.category_repo import CategoryRepository
 from cartoframes.data.observatory.repository.dataset_repo import DatasetRepository
 from cartoframes.data.observatory.entity import CatalogList
-from .examples import test_category1, test_datasets, test_categories, db_category1, test_category2, db_category2
+from .examples import test_category1, test_datasets, test_categories, db_category1, test_category2, db_category2, \
+    test_geographies
 
 try:
     from unittest.mock import Mock, patch
@@ -28,7 +30,7 @@ class TestCategory(unittest.TestCase):
         assert isinstance(category, Category)
         assert category == test_category1
 
-    @patch.object(DatasetRepository, 'get_by_category')
+    @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_category(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_datasets
@@ -37,9 +39,24 @@ class TestCategory(unittest.TestCase):
         datasets = test_category1.datasets
 
         # Then
+        mocked_repo.assert_called_once_with({'category_id': test_category1.id})
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets
+
+    @patch.object(GeographyRepository, 'get_all')
+    def test_get_geographies_by_category(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = test_geographies
+
+        # When
+        geographies = test_category1.geographies
+
+        # Then
+        mocked_repo.assert_called_once_with({'category_id': test_category1.id})
+        assert isinstance(geographies, list)
+        assert isinstance(geographies, CatalogList)
+        assert geographies == test_geographies
 
     def test_category_properties(self):
         # Given

--- a/test/data/observatory/test_country.py
+++ b/test/data/observatory/test_country.py
@@ -59,20 +59,6 @@ class TestCountry(unittest.TestCase):
         assert isinstance(geographies, CatalogList)
         assert geographies == test_geographies
 
-    @patch.object(DatasetRepository, 'get_all')
-    def test_get_datasets_by_country(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_datasets
-
-        # When
-        datasets = test_country1.datasets
-
-        # Then
-        mocked_repo.assert_called_once_with({'country_id': test_country1.id})
-        assert isinstance(datasets, list)
-        assert isinstance(datasets, CatalogList)
-        assert datasets == test_datasets
-
     @patch.object(CategoryRepository, 'get_all')
     def test_get_categories_by_country(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_country.py
+++ b/test/data/observatory/test_country.py
@@ -1,5 +1,6 @@
 import unittest
 import pandas as pd
+from cartoframes.data.observatory.repository.category_repo import CategoryRepository
 
 from cartoframes.data.observatory.entity import CatalogList
 from cartoframes.data.observatory.country import Country
@@ -7,7 +8,7 @@ from cartoframes.data.observatory.repository.geography_repo import GeographyRepo
 from cartoframes.data.observatory.repository.dataset_repo import DatasetRepository
 from cartoframes.data.observatory.repository.country_repo import CountryRepository
 from .examples import test_country1, test_datasets, test_countries, test_geographies, db_country1, test_country2, \
-    db_country2
+    db_country2, test_categories
 
 try:
     from unittest.mock import Mock, patch
@@ -30,7 +31,7 @@ class TestCountry(unittest.TestCase):
         assert isinstance(country, Country)
         assert country == test_country1
 
-    @patch.object(DatasetRepository, 'get_by_country')
+    @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_country(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_datasets
@@ -39,11 +40,12 @@ class TestCountry(unittest.TestCase):
         datasets = test_country1.datasets
 
         # Then
+        mocked_repo.assert_called_once_with({'country_id': test_country1.id})
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets
 
-    @patch.object(GeographyRepository, 'get_by_country')
+    @patch.object(GeographyRepository, 'get_all')
     def test_get_geographies_by_country(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_geographies
@@ -52,9 +54,38 @@ class TestCountry(unittest.TestCase):
         geographies = test_country1.geographies
 
         # Then
+        mocked_repo.assert_called_once_with({'country_id': test_country1.id})
         assert isinstance(geographies, list)
         assert isinstance(geographies, CatalogList)
         assert geographies == test_geographies
+
+    @patch.object(DatasetRepository, 'get_all')
+    def test_get_datasets_by_country(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = test_datasets
+
+        # When
+        datasets = test_country1.datasets
+
+        # Then
+        mocked_repo.assert_called_once_with({'country_id': test_country1.id})
+        assert isinstance(datasets, list)
+        assert isinstance(datasets, CatalogList)
+        assert datasets == test_datasets
+
+    @patch.object(CategoryRepository, 'get_all')
+    def test_get_categories_by_country(self, mocked_repo):
+        # Given
+        mocked_repo.return_value = test_categories
+
+        # When
+        categories = test_country1.categories
+
+        # Then
+        mocked_repo.assert_called_once_with({'country_id': test_country1.id})
+        assert isinstance(categories, list)
+        assert isinstance(categories, CatalogList)
+        assert categories == test_categories
 
     def test_country_properties(self):
         # Given

--- a/test/data/observatory/test_country.py
+++ b/test/data/observatory/test_country.py
@@ -31,6 +31,18 @@ class TestCountry(unittest.TestCase):
         assert isinstance(country, Country)
         assert country == test_country1
 
+    def test_get_country_by_id_from_countries_list(self):
+        # Given
+        countries = CatalogList([test_country1, test_country2])
+
+        # When
+        country = countries.get(test_country1.id)
+
+        # Then
+        assert isinstance(country, object)
+        assert isinstance(country, Country)
+        assert country == test_country1
+
     @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_country(self, mocked_repo):
         # Given
@@ -159,19 +171,6 @@ class TestCountry(unittest.TestCase):
         # Then
         assert countries_repr == "[<Country('{id1}')>, <Country('{id2}')>]"\
                                  .format(id1=db_country1['id'], id2=db_country2['id'])
-
-    @patch.object(CountryRepository, 'get_by_id')
-    def test_get_country_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_country1
-
-        # When
-        country = Country.get('esp')
-
-        # Then
-        assert isinstance(country, object)
-        assert isinstance(country, Country)
-        assert country == test_country1
 
     def test_countries_items_are_obtained_as_country(self):
         # Given

--- a/test/data/observatory/test_country.py
+++ b/test/data/observatory/test_country.py
@@ -117,7 +117,7 @@ class TestCountry(unittest.TestCase):
         assert isinstance(country_dict, dict)
         assert country_dict == db_country1
 
-    def test_country_is_represented_with_id(self):
+    def test_country_is_represented_with_classname_and_id(self):
         # Given
         country = Country(db_country1)
 
@@ -150,7 +150,7 @@ class TestCountry(unittest.TestCase):
         assert isinstance(countries, CatalogList)
         assert countries == test_countries
 
-    def test_country_list_is_printed_with_classname(self):
+    def test_country_list_is_printed_with_classname_and_ids(self):
         # Given
         countries = CatalogList([test_country1, test_country2])
 
@@ -161,7 +161,7 @@ class TestCountry(unittest.TestCase):
         assert countries_str == "[<Country('{id1}')>, <Country('{id2}')>]" \
                                 .format(id1=db_country1['id'], id2=db_country2['id'])
 
-    def test_country_list_is_represented_with_ids(self):
+    def test_country_list_is_represented_with_classname_and_ids(self):
         # Given
         countries = CatalogList([test_country1, test_country2])
 

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -36,6 +36,30 @@ class TestDataset(unittest.TestCase):
         assert isinstance(dataset, Dataset)
         assert dataset == test_dataset1
 
+    def test_get_dataset_by_id_from_datasets_list(self):
+        # Given
+        datasets = CatalogList([test_dataset1, test_dataset2])
+
+        # When
+        dataset = datasets.get(test_dataset1.id)
+
+        # Then
+        assert isinstance(dataset, object)
+        assert isinstance(dataset, Dataset)
+        assert dataset == test_dataset1
+
+    def test_get_dataset_by_slug_from_datasets_list(self):
+        # Given
+        datasets = CatalogList([test_dataset1, test_dataset2])
+
+        # When
+        dataset = datasets.get(test_dataset1.slug)
+
+        # Then
+        assert isinstance(dataset, object)
+        assert isinstance(dataset, Dataset)
+        assert dataset == test_dataset1
+
     @patch.object(VariableRepository, 'get_all')
     def test_get_variables_by_dataset(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -36,7 +36,7 @@ class TestDataset(unittest.TestCase):
         assert isinstance(dataset, Dataset)
         assert dataset == test_dataset1
 
-    @patch.object(VariableRepository, 'get_by_dataset')
+    @patch.object(VariableRepository, 'get_all')
     def test_get_variables_by_dataset(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_variables
@@ -45,11 +45,12 @@ class TestDataset(unittest.TestCase):
         variables = test_dataset1.variables
 
         # Then
+        mocked_repo.assert_called_once_with({'dataset_id': test_dataset1.id})
         assert isinstance(variables, list)
         assert isinstance(variables, CatalogList)
         assert variables == test_variables
 
-    @patch.object(VariableGroupRepository, 'get_by_dataset')
+    @patch.object(VariableGroupRepository, 'get_all')
     def test_get_variables_groups_by_dataset(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_variables_groups
@@ -58,6 +59,7 @@ class TestDataset(unittest.TestCase):
         variables_groups = test_dataset1.variables_groups
 
         # Then
+        mocked_repo.assert_called_once_with({'dataset_id': test_dataset1.id})
         assert isinstance(variables_groups, list)
         assert isinstance(variables_groups, CatalogList)
         assert variables_groups == test_variables_groups

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -94,6 +94,7 @@ class TestDataset(unittest.TestCase):
 
         # When
         dataset_id = dataset.id
+        slug = dataset.slug
         name = dataset.name
         description = dataset.description
         provider = dataset.provider
@@ -111,6 +112,7 @@ class TestDataset(unittest.TestCase):
 
         # Then
         assert dataset_id == db_dataset1['id']
+        assert slug == db_dataset1['slug']
         assert name == db_dataset1['name']
         assert description == db_dataset1['description']
         assert provider == db_dataset1['provider_id']

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -142,13 +142,14 @@ class TestDataset(unittest.TestCase):
     def test_dataset_is_exported_as_dict(self):
         # Given
         dataset = Dataset(db_dataset1)
+        expected_dict = {key: value for key, value in db_dataset1.items() if key is not 'summary_jsonb'}
 
         # When
         dataset_dict = dataset.to_dict()
 
         # Then
         assert isinstance(dataset_dict, dict)
-        assert dataset_dict == db_dataset1
+        assert dataset_dict == expected_dict
 
     def test_dataset_is_represented_with_id(self):
         # Given

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -151,7 +151,7 @@ class TestDataset(unittest.TestCase):
         assert isinstance(dataset_dict, dict)
         assert dataset_dict == expected_dict
 
-    def test_dataset_is_represented_with_id(self):
+    def test_dataset_is_represented_with_classname_and_slug(self):
         # Given
         dataset = CatalogDataset(db_dataset1)
 
@@ -197,7 +197,7 @@ class TestDataset(unittest.TestCase):
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
 
-    def test_dataset_list_is_printed_with_classname(self):
+    def test_dataset_list_is_printed_with_classname_and_slugs(self):
         # Given
         datasets = CatalogList([test_dataset1, test_dataset2])
 
@@ -208,7 +208,7 @@ class TestDataset(unittest.TestCase):
         assert datasets_str == "[<CatalogDataset('{id1}')>, <CatalogDataset('{id2}')>]"\
                                .format(id1=db_dataset1['slug'], id2=db_dataset2['slug'])
 
-    def test_dataset_list_is_represented_with_slugs(self):
+    def test_dataset_list_is_represented_with_classname_and_slugs(self):
         # Given
         datasets = CatalogList([test_dataset1, test_dataset2])
 

--- a/test/data/observatory/test_dataset.py
+++ b/test/data/observatory/test_dataset.py
@@ -7,7 +7,7 @@ from carto.exceptions import CartoException
 
 from cartoframes.auth import Credentials
 from cartoframes.data.observatory.entity import CatalogList
-from cartoframes.data.observatory.dataset import Dataset
+from cartoframes.data.observatory.dataset import CatalogDataset
 from cartoframes.data.observatory.repository.variable_repo import VariableRepository
 from cartoframes.data.observatory.repository.variable_group_repo import VariableGroupRepository
 from cartoframes.data.observatory.repository.dataset_repo import DatasetRepository
@@ -29,11 +29,11 @@ class TestDataset(unittest.TestCase):
         mocked_repo.return_value = test_dataset1
 
         # When
-        dataset = Dataset.get(test_dataset1.id)
+        dataset = CatalogDataset.get(test_dataset1.id)
 
         # Then
         assert isinstance(dataset, object)
-        assert isinstance(dataset, Dataset)
+        assert isinstance(dataset, CatalogDataset)
         assert dataset == test_dataset1
 
     def test_get_dataset_by_id_from_datasets_list(self):
@@ -45,7 +45,7 @@ class TestDataset(unittest.TestCase):
 
         # Then
         assert isinstance(dataset, object)
-        assert isinstance(dataset, Dataset)
+        assert isinstance(dataset, CatalogDataset)
         assert dataset == test_dataset1
 
     def test_get_dataset_by_slug_from_datasets_list(self):
@@ -57,7 +57,7 @@ class TestDataset(unittest.TestCase):
 
         # Then
         assert isinstance(dataset, object)
-        assert isinstance(dataset, Dataset)
+        assert isinstance(dataset, CatalogDataset)
         assert dataset == test_dataset1
 
     @patch.object(VariableRepository, 'get_all')
@@ -90,7 +90,7 @@ class TestDataset(unittest.TestCase):
 
     def test_dataset_properties(self):
         # Given
-        dataset = Dataset(db_dataset1)
+        dataset = CatalogDataset(db_dataset1)
 
         # When
         dataset_id = dataset.id
@@ -141,7 +141,7 @@ class TestDataset(unittest.TestCase):
 
     def test_dataset_is_exported_as_dict(self):
         # Given
-        dataset = Dataset(db_dataset1)
+        dataset = CatalogDataset(db_dataset1)
         expected_dict = {key: value for key, value in db_dataset1.items() if key is not 'summary_jsonb'}
 
         # When
@@ -153,23 +153,23 @@ class TestDataset(unittest.TestCase):
 
     def test_dataset_is_represented_with_id(self):
         # Given
-        dataset = Dataset(db_dataset1)
+        dataset = CatalogDataset(db_dataset1)
 
         # When
         dataset_repr = repr(dataset)
 
         # Then
-        assert dataset_repr == "<Dataset('{id}')>".format(id=db_dataset1['slug'])
+        assert dataset_repr == "<CatalogDataset('{id}')>".format(id=db_dataset1['slug'])
 
     def test_dataset_is_printed_with_classname(self):
         # Given
-        dataset = Dataset(db_dataset1)
+        dataset = CatalogDataset(db_dataset1)
 
         # When
         dataset_str = str(dataset)
 
         # Then
-        assert dataset_str == 'Dataset({dict_str})'.format(dict_str=str(db_dataset1))
+        assert dataset_str == 'CatalogDataset({dict_str})'.format(dict_str=str(db_dataset1))
 
     @patch.object(DatasetRepository, 'get_all')
     def test_get_all_datasets(self, mocked_repo):
@@ -177,7 +177,7 @@ class TestDataset(unittest.TestCase):
         mocked_repo.return_value = test_datasets
 
         # When
-        datasets = Dataset.get_all()
+        datasets = CatalogDataset.get_all()
 
         # Then
         assert isinstance(datasets, list)
@@ -190,7 +190,7 @@ class TestDataset(unittest.TestCase):
         credentials = Credentials('user', '1234')
 
         # When
-        datasets = Dataset.get_all(credentials=credentials)
+        datasets = CatalogDataset.get_all(credentials=credentials)
 
         # Then
         mocked_repo.assert_called_once_with(None, credentials)
@@ -205,7 +205,7 @@ class TestDataset(unittest.TestCase):
         datasets_str = str(datasets)
 
         # Then
-        assert datasets_str == "[<Dataset('{id1}')>, <Dataset('{id2}')>]"\
+        assert datasets_str == "[<CatalogDataset('{id1}')>, <CatalogDataset('{id2}')>]"\
                                .format(id1=db_dataset1['slug'], id2=db_dataset2['slug'])
 
     def test_dataset_list_is_represented_with_slugs(self):
@@ -216,7 +216,7 @@ class TestDataset(unittest.TestCase):
         datasets_repr = repr(datasets)
 
         # Then
-        assert datasets_repr == "[<Dataset('{id1}')>, <Dataset('{id2}')>]"\
+        assert datasets_repr == "[<CatalogDataset('{id1}')>, <CatalogDataset('{id2}')>]"\
                                 .format(id1=db_dataset1['slug'], id2=db_dataset2['slug'])
 
     def test_datasets_items_are_obtained_as_dataset(self):
@@ -227,7 +227,7 @@ class TestDataset(unittest.TestCase):
         dataset = datasets[0]
 
         # Then
-        assert isinstance(dataset, Dataset)
+        assert isinstance(dataset, CatalogDataset)
         assert dataset == test_dataset1
 
     def test_datasets_are_exported_as_dataframe(self):
@@ -258,7 +258,7 @@ class TestDataset(unittest.TestCase):
         username = 'fake_user'
         credentials = CredentialsMock(username)
 
-        dataset = Dataset.get(test_dataset1.id)
+        dataset = CatalogDataset.get(test_dataset1.id)
         response = dataset.download(credentials)
 
         assert response == file_path
@@ -276,6 +276,6 @@ class TestDataset(unittest.TestCase):
         username = 'fake_user'
         credentials = CredentialsMock(username)
 
-        dataset = Dataset.get(test_dataset1.id)
+        dataset = CatalogDataset.get(test_dataset1.id)
         with self.assertRaises(CartoException):
             dataset.download(credentials)

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -154,19 +154,6 @@ class TestGeography(unittest.TestCase):
         assert categories_repr == "[<Geography('{id1}')>, <Geography('{id2}')>]"\
                                   .format(id1=db_geography1['slug'], id2=db_geography2['slug'])
 
-    @patch.object(GeographyRepository, 'get_by_id')
-    def test_get_geography_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_geography1
-
-        # When
-        geography = Geography.get(test_geography1.id)
-
-        # Then
-        assert isinstance(geography, object)
-        assert isinstance(geography, Geography)
-        assert geography == test_geography1
-
     def test_geographies_items_are_obtained_as_geography(self):
         # Given
         geographies = test_geographies

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -77,6 +77,7 @@ class TestGeography(unittest.TestCase):
 
         # When
         geography_id = geography.id
+        slug = geography.slug
         name = geography.name
         description = geography.description
         country = geography.country
@@ -90,6 +91,7 @@ class TestGeography(unittest.TestCase):
 
         # Then
         assert geography_id == db_geography1['id']
+        assert slug == db_geography1['slug']
         assert name == db_geography1['name']
         assert description == db_geography1['description']
         assert country == db_geography1['country_id']

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -33,6 +33,30 @@ class TestGeography(unittest.TestCase):
         assert isinstance(geography, Geography)
         assert geography == test_geography1
 
+    def test_get_geography_by_id_from_geographies_list(self):
+        # Given
+        geographies = CatalogList([test_geography1, test_geography2])
+
+        # When
+        geography = geographies.get(test_geography1.id)
+
+        # Then
+        assert isinstance(geography, object)
+        assert isinstance(geography, Geography)
+        assert geography == test_geography1
+
+    def test_get_geography_by_slug_from_geographies_list(self):
+        # Given
+        geographies = CatalogList([test_geography1, test_geography2])
+
+        # When
+        geography = geographies.get(test_geography1.slug)
+
+        # Then
+        assert isinstance(geography, object)
+        assert isinstance(geography, Geography)
+        assert geography == test_geography1
+
     @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_geography(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -117,13 +117,14 @@ class TestGeography(unittest.TestCase):
     def test_geography_is_exported_as_dict(self):
         # Given
         geography = Geography(db_geography1)
+        expected_dict = {key: value for key, value in db_geography1.items() if key is not 'summary_jsonb'}
 
         # When
         geography_dict = geography.to_dict()
 
         # Then
         assert isinstance(geography_dict, dict)
-        assert geography_dict == db_geography1
+        assert geography_dict == expected_dict
 
     def test_geography_is_represented_with_id(self):
         # Given

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -126,7 +126,7 @@ class TestGeography(unittest.TestCase):
         assert isinstance(geography_dict, dict)
         assert geography_dict == expected_dict
 
-    def test_geography_is_represented_with_id(self):
+    def test_geography_is_represented_with_classname_and_slug(self):
         # Given
         geography = Geography(db_geography1)
 
@@ -159,7 +159,7 @@ class TestGeography(unittest.TestCase):
         assert isinstance(geographies, CatalogList)
         assert geographies == test_geographies
 
-    def test_geography_list_is_printed_with_classname(self):
+    def test_geography_list_is_printed_with_classname_and_slugs(self):
         # Given
         geographies = CatalogList([test_geography1, test_geography2])
 
@@ -170,7 +170,7 @@ class TestGeography(unittest.TestCase):
         assert categories_str == "[<Geography('{id1}')>, <Geography('{id2}')>]" \
                                  .format(id1=db_geography1['slug'], id2=db_geography2['slug'])
 
-    def test_geography_list_is_represented_with_ids(self):
+    def test_geography_list_is_represented_with_classname_and_slugs(self):
         # Given
         geographies = CatalogList([test_geography1, test_geography2])
 

--- a/test/data/observatory/test_geography.py
+++ b/test/data/observatory/test_geography.py
@@ -33,7 +33,7 @@ class TestGeography(unittest.TestCase):
         assert isinstance(geography, Geography)
         assert geography == test_geography1
 
-    @patch.object(DatasetRepository, 'get_by_geography')
+    @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_geography(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_datasets
@@ -42,6 +42,7 @@ class TestGeography(unittest.TestCase):
         datasets = test_geography1.datasets
 
         # Then
+        mocked_repo.assert_called_once_with({'geography_id': test_geography1.id})
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets

--- a/test/data/observatory/test_provider.py
+++ b/test/data/observatory/test_provider.py
@@ -28,7 +28,7 @@ class TestProvider(unittest.TestCase):
         assert isinstance(provider, Provider)
         assert provider == test_provider1
 
-    @patch.object(DatasetRepository, 'get_by_provider')
+    @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_provider(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_datasets
@@ -37,6 +37,7 @@ class TestProvider(unittest.TestCase):
         datasets = test_provider1.datasets
 
         # Then
+        mocked_repo.assert_called_once_with({'provider_id': test_provider1.id})
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets

--- a/test/data/observatory/test_provider.py
+++ b/test/data/observatory/test_provider.py
@@ -131,19 +131,6 @@ class TestProvider(unittest.TestCase):
         assert providers_repr == "[<Provider('{id1}')>, <Provider('{id2}')>]"\
                                  .format(id1=db_provider1['id'], id2=db_provider2['id'])
 
-    @patch.object(ProviderRepository, 'get_by_id')
-    def test_get_provider_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_provider1
-
-        # When
-        provider = Provider.get('bbva')
-
-        # Then
-        assert isinstance(provider, object)
-        assert isinstance(provider, Provider)
-        assert provider == test_provider1
-
     def test_providers_items_are_obtained_as_provider(self):
         # Given
         providers = test_providers

--- a/test/data/observatory/test_provider.py
+++ b/test/data/observatory/test_provider.py
@@ -28,6 +28,18 @@ class TestProvider(unittest.TestCase):
         assert isinstance(provider, Provider)
         assert provider == test_provider1
 
+    def test_get_provider_by_id_from_providers_list(self):
+        # Given
+        providers = CatalogList([test_provider1, test_provider2])
+
+        # When
+        provider = providers.get(test_provider1.id)
+
+        # Then
+        assert isinstance(provider, object)
+        assert isinstance(provider, Provider)
+        assert provider == test_provider1
+
     @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_provider(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_provider.py
+++ b/test/data/observatory/test_provider.py
@@ -88,7 +88,7 @@ class TestProvider(unittest.TestCase):
         assert isinstance(provider_dict, dict)
         assert provider_dict == db_provider1
 
-    def test_provider_is_represented_with_id(self):
+    def test_provider_is_represented_with_classname_and_id(self):
         # Given
         provider = Provider(db_provider1)
 
@@ -121,7 +121,7 @@ class TestProvider(unittest.TestCase):
         assert isinstance(providers, CatalogList)
         assert providers == test_providers
 
-    def test_provider_list_is_printed_with_classname(self):
+    def test_provider_list_is_printed_with_classname_and_ids(self):
         # Given
         providers = CatalogList([test_provider1, test_provider2])
 
@@ -132,7 +132,7 @@ class TestProvider(unittest.TestCase):
         assert providers_str == "[<Provider('{id1}')>, <Provider('{id2}')>]" \
                                 .format(id1=db_provider1['id'], id2=db_provider2['id'])
 
-    def test_provider_list_is_represented_with_ids(self):
+    def test_provider_list_is_represented_with_classname_and_ids(self):
         # Given
         providers = CatalogList([test_provider1, test_provider2])
 

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -28,7 +28,7 @@ class TestVariable(unittest.TestCase):
         assert isinstance(variable, Variable)
         assert variable == test_variable1
 
-    @patch.object(DatasetRepository, 'get_by_variable')
+    @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_variable(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_datasets
@@ -37,6 +37,7 @@ class TestVariable(unittest.TestCase):
         datasets = test_variable1.datasets
 
         # Then
+        mocked_repo.assert_called_once_with({'variable_id': test_variable1.id})
         assert isinstance(datasets, list)
         assert isinstance(datasets, CatalogList)
         assert datasets == test_datasets

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -147,19 +147,6 @@ class TestVariable(unittest.TestCase):
         assert variables_repr == "[<Variable('{id1}')>, <Variable('{id2}')>]"\
                                  .format(id1=db_variable1['slug'], id2=db_variable2['slug'])
 
-    @patch.object(VariableRepository, 'get_by_id')
-    def test_get_variable_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_variable1
-
-        # When
-        variable = Variable.get(test_variable1.id)
-
-        # Then
-        assert isinstance(variable, object)
-        assert isinstance(variable, Variable)
-        assert variable == test_variable1
-
     def test_variables_items_are_obtained_as_variable(self):
         # Given
         variables = test_variables

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -110,13 +110,14 @@ class TestVariable(unittest.TestCase):
     def test_variable_is_exported_as_dict(self):
         # Given
         variable = Variable(db_variable1)
+        expected_dict = {key: value for key, value in db_variable1.items() if key is not 'summary_jsonb'}
 
         # When
         variable_dict = variable.to_dict()
 
         # Then
         assert isinstance(variable_dict, dict)
-        assert variable_dict == db_variable1
+        assert variable_dict == expected_dict
 
     def test_variable_is_represented_with_id(self):
         # Given

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -72,6 +72,7 @@ class TestVariable(unittest.TestCase):
 
         # When
         variable_id = variable.id
+        slug = variable.slug
         name = variable.name
         description = variable.description
         column_name = variable.column_name
@@ -84,6 +85,7 @@ class TestVariable(unittest.TestCase):
 
         # Then
         assert variable_id == db_variable1['id']
+        assert slug == db_variable1['slug']
         assert name == db_variable1['name']
         assert description == db_variable1['description']
         assert column_name == db_variable1['column_name']

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -28,6 +28,30 @@ class TestVariable(unittest.TestCase):
         assert isinstance(variable, Variable)
         assert variable == test_variable1
 
+    def test_get_variable_by_id_from_variables_list(self):
+        # Given
+        variables = CatalogList([test_variable1, test_variable2])
+
+        # When
+        variable = variables.get(test_variable1.id)
+
+        # Then
+        assert isinstance(variable, object)
+        assert isinstance(variable, Variable)
+        assert variable == test_variable1
+
+    def test_get_variable_by_slug_from_variables_list(self):
+        # Given
+        variables = CatalogList([test_variable1, test_variable2])
+
+        # When
+        variable = variables.get(test_variable1.slug)
+
+        # Then
+        assert isinstance(variable, object)
+        assert isinstance(variable, Variable)
+        assert variable == test_variable1
+
     @patch.object(DatasetRepository, 'get_all')
     def test_get_datasets_by_variable(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_variable.py
+++ b/test/data/observatory/test_variable.py
@@ -119,7 +119,7 @@ class TestVariable(unittest.TestCase):
         assert isinstance(variable_dict, dict)
         assert variable_dict == expected_dict
 
-    def test_variable_is_represented_with_id(self):
+    def test_variable_is_represented_with_slug_and_description(self):
         # Given
         variable = Variable(db_variable1)
 
@@ -127,7 +127,8 @@ class TestVariable(unittest.TestCase):
         variable_repr = repr(variable)
 
         # Then
-        assert variable_repr == "<Variable('{id}')>".format(id=db_variable1['slug'])
+        assert variable_repr == "<Variable('{slug}','{descr}')>"\
+                                .format(slug=db_variable1['slug'], descr=db_variable1['description'])
 
     def test_variable_is_printed_with_classname(self):
         # Given
@@ -152,27 +153,31 @@ class TestVariable(unittest.TestCase):
         assert isinstance(variables, CatalogList)
         assert variables == test_variables
 
-    def test_variable_list_is_printed_with_classname(self):
+    def test_variable_list_is_printed_correctly(self):
         # Given
         variables = CatalogList([test_variable1, test_variable2])
+        shorten_description = test_variable2.description[0:20] + '...'
 
         # When
         variables_str = str(variables)
 
         # Then
-        assert variables_str == "[<Variable('{id1}')>, <Variable('{id2}')>]" \
-                                .format(id1=db_variable1['slug'], id2=db_variable2['slug'])
+        assert variables_str == "[<Variable('{id1}','{descr1}')>, <Variable('{id2}','{descr2}')>]" \
+                                .format(id1=db_variable1['slug'], descr1=db_variable1['description'],
+                                        id2=db_variable2['slug'], descr2=shorten_description)
 
-    def test_variable_list_is_represented_with_ids(self):
+    def test_variable_list_is_represented_correctly(self):
         # Given
         variables = CatalogList([test_variable1, test_variable2])
+        shorten_description = test_variable2.description[0:20] + '...'
 
         # When
         variables_repr = repr(variables)
 
         # Then
-        assert variables_repr == "[<Variable('{id1}')>, <Variable('{id2}')>]"\
-                                 .format(id1=db_variable1['slug'], id2=db_variable2['slug'])
+        assert variables_repr == "[<Variable('{id1}','{descr1}')>, <Variable('{id2}','{descr2}')>]" \
+                                .format(id1=db_variable1['slug'], descr1=db_variable1['description'],
+                                        id2=db_variable2['slug'], descr2=shorten_description)
 
     def test_variables_items_are_obtained_as_variable(self):
         # Given

--- a/test/data/observatory/test_variable_group.py
+++ b/test/data/observatory/test_variable_group.py
@@ -136,19 +136,6 @@ class TestVariableGroup(unittest.TestCase):
         assert variables_groups_repr == "[<VariableGroup('{id1}')>, <VariableGroup('{id2}')>]"\
                                         .format(id1=db_variable_group1['slug'], id2=db_variable_group2['slug'])
 
-    @patch.object(VariableGroupRepository, 'get_by_id')
-    def test_get_variable_group_by_id(self, mocked_repo):
-        # Given
-        mocked_repo.return_value = test_variable_group1
-
-        # When
-        variable_group = VariableGroup.get(test_variable_group1.id)
-
-        # Then
-        assert isinstance(variable_group, object)
-        assert isinstance(variable_group, VariableGroup)
-        assert variable_group == test_variable_group1
-
     def test_variables_groups_items_are_obtained_as_variable_group(self):
         # Given
         variables_groups = test_variables_groups

--- a/test/data/observatory/test_variable_group.py
+++ b/test/data/observatory/test_variable_group.py
@@ -73,12 +73,14 @@ class TestVariableGroup(unittest.TestCase):
 
         # When
         variable_group_id = variable_group.id
+        slug = variable_group.slug
         name = variable_group.name
         dataset = variable_group.dataset
         starred = variable_group.starred
 
         # Then
         assert variable_group_id == db_variable_group1['id']
+        assert slug == db_variable_group1['slug']
         assert name == db_variable_group1['name']
         assert dataset == db_variable_group1['dataset_id']
         assert starred == db_variable_group1['starred']

--- a/test/data/observatory/test_variable_group.py
+++ b/test/data/observatory/test_variable_group.py
@@ -29,6 +29,30 @@ class TestVariableGroup(unittest.TestCase):
         assert isinstance(variable_group, VariableGroup)
         assert variable_group == test_variable_group1
 
+    def test_get_variable_group_by_id_from_variables_groups_list(self):
+        # Given
+        variables_groups = CatalogList([test_variable_group1, test_variable_group2])
+
+        # When
+        variable_group = variables_groups.get(test_variable_group1.id)
+
+        # Then
+        assert isinstance(variable_group, object)
+        assert isinstance(variable_group, VariableGroup)
+        assert variable_group == test_variable_group1
+
+    def test_get_variable_group_by_slug_from_variables_groups_leist(selef):
+        # Given
+        variables_groups = CatalogList([test_variable_group1, test_variable_group2])
+
+        # When
+        variable_group = variables_groups.get(test_variable_group1.slug)
+
+        # Then
+        assert isinstance(variable_group, object)
+        assert isinstance(variable_group, VariableGroup)
+        assert variable_group == test_variable_group1
+
     @patch.object(VariableRepository, 'get_all')
     def test_get_variables_by_variable_group(self, mocked_repo):
         # Given

--- a/test/data/observatory/test_variable_group.py
+++ b/test/data/observatory/test_variable_group.py
@@ -107,7 +107,7 @@ class TestVariableGroup(unittest.TestCase):
         assert isinstance(variable_group_dict, dict)
         assert variable_group_dict == db_variable_group1
 
-    def test_variable_group_is_represented_with_id(self):
+    def test_variable_group_is_represented_with_classname_and_slug(self):
         # Given
         variable_group = VariableGroup(db_variable_group1)
 
@@ -140,7 +140,7 @@ class TestVariableGroup(unittest.TestCase):
         assert isinstance(variables_groups, CatalogList)
         assert variables_groups == test_variables_groups
 
-    def test_variable_group_list_is_printed_with_classname(self):
+    def test_variable_group_list_is_printed_with_classname_and_slug(self):
         # Given
         variables_groups = CatalogList([test_variable_group1, test_variable_group2])
 
@@ -151,7 +151,7 @@ class TestVariableGroup(unittest.TestCase):
         assert variables_groups_str == "[<VariableGroup('{id1}')>, <VariableGroup('{id2}')>]" \
                                        .format(id1=db_variable_group1['slug'], id2=db_variable_group2['slug'])
 
-    def test_variable_group_list_is_represented_with_ids(self):
+    def test_variable_group_list_is_represented_with_classname_and_slug(self):
         # Given
         variables_groups = CatalogList([test_variable_group1, test_variable_group2])
 

--- a/test/data/observatory/test_variable_group.py
+++ b/test/data/observatory/test_variable_group.py
@@ -29,7 +29,7 @@ class TestVariableGroup(unittest.TestCase):
         assert isinstance(variable_group, VariableGroup)
         assert variable_group == test_variable_group1
 
-    @patch.object(VariableRepository, 'get_by_variable_group')
+    @patch.object(VariableRepository, 'get_all')
     def test_get_variables_by_variable_group(self, mocked_repo):
         # Given
         mocked_repo.return_value = test_variables
@@ -38,6 +38,7 @@ class TestVariableGroup(unittest.TestCase):
         variables = test_variable_group1.variables
 
         # Then
+        mocked_repo.assert_called_once_with({'variable_group_id': test_variable_group1.id})
         assert isinstance(variables, list)
         assert isinstance(variables, CatalogList)
         assert variables == test_variables


### PR DESCRIPTION
Closes #1100 

- Exclude `summary_jsonb` field when exporting to dict
- Rename Dataset to CatalogDataset
- Add description to the Variable `__repr__` method with a character limit set to 20