### PR TITLE
Add isolines layer helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add isolines_layer helper method (#1135)
+
 ## [1.0b4] - 2019-10-25
 ### Added
 - Add support for variable groups in the catalog (#983)

--- a/cartoframes/viz/helpers/__init__.py
+++ b/cartoframes/viz/helpers/__init__.py
@@ -3,14 +3,15 @@ These functions save time by giving great out-of-the-box cartography, legends,
 and popups. The layer can be further customized using optional overrides."""
 from __future__ import absolute_import
 
-from .animation_layer import animation_layer
-from .cluster_size_layer import cluster_size_layer
 from .color_bins_layer import color_bins_layer
 from .color_category_layer import color_category_layer
 from .color_continuous_layer import color_continuous_layer
 from .size_bins_layer import size_bins_layer
 from .size_category_layer import size_category_layer
 from .size_continuous_layer import size_continuous_layer
+from .cluster_size_layer import cluster_size_layer
+from .animation_layer import animation_layer
+from .isolines_layer import isolines_layer
 
 
 def _inspect(helper):
@@ -27,5 +28,6 @@ __all__ = [
     'size_category_layer',
     'size_continuous_layer',
     'cluster_size_layer',
-    'animation_layer'
+    'animation_layer',
+    'isolines_layer'
 ]

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -19,8 +19,7 @@ def color_category_layer(
         title (str, optional): Title of legend.
         top (int, optional): Number of category for map. Default is 11. Values
           can range from 1 to 16.
-        cat (str, optional): Category list. Must be a valid CARTO VL category
-          list.
+        cat (list<str>, optional): Category list. Must be a valid list of categories.
         palette (str, optional): Palette that can be a named CARTOColor palette
           or other valid CARTO VL palette expression. Default is `bold`.
         size (int, optional): Size of point or line features.

--- a/cartoframes/viz/helpers/isolines_layer.py
+++ b/cartoframes/viz/helpers/isolines_layer.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+
+from . import color_category_layer
+from ...data.dataset.dataset import Dataset
+
+
+def isolines_layer(source, value='data_range', **kwargs):
+    """Helper function for quickly creating an isolines color map.
+
+    Args:
+        source (:py:class:`cartoframes.data.Dataset>`, DataFrame or str): Dataset
+          or text representing a table or query associated with user account.
+        value (str): Column to symbolize by. By default is "data_range".
+        title (str, optional): Title of legend.
+        top (int, optional): Number of category for map. Default is 11. Values
+          can range from 1 to 16.
+        cat (str, optional): Category list. Must be a valid CARTO VL category
+          list.
+        palette (str, optional): Palette that can be a named CARTOColor palette
+          or other valid CARTO VL palette expression. Default is `bold`.
+        size (int, optional): Size of point or line features.
+        opacity (int, optional): Opacity value for point color and line features.
+          Default is '0.8'.
+        stroke_width (int, optional): Size of the stroke on point features.
+        stroke_color (str, optional): Color of the stroke on point features.
+          Default is '#222'.
+        description (str, optional): Description text legend placed under legend title.
+        footer (str, optional): Footer text placed under legend items.
+        legend (bool, optional): Display map legend: "True" or "False".
+          Set to "True" by default.
+        popup (bool, optional): Display popups on hover and click: "True" or "False".
+          Set to "True" by default.
+        widget (bool, optional): Display a widget for mapped data.
+          Set to "False" by default.
+        animate (str, optional): Animate features by date/time or other numeric field.
+
+    Example:
+
+        Create a layer with a custom popup, legend, and widget.
+
+        .. code::
+
+            from cartoframes.viz.helpers import isolines_layer
+
+            [...]
+
+            isochrones = Isolines().isodistances(df, [1200, 2400, 3600], exclusive=True)
+
+            isolines_layer(isochrones.data, palette='purpor')
+
+    Returns:
+        cartoframes.viz.Layer: Layer styled by `value`.
+        Includes a legend, popup and widget on `value`.
+    """
+    df = source
+    if isinstance(source, Dataset):
+        df = source.dataframe
+
+    df = df.copy()
+    if value not in df:
+        raise ValueError('Input source must contain a "{}" column'.format(value))
+
+    RANGE_LABEL_KEY = 'range_label'
+    df[RANGE_LABEL_KEY] = df.apply(
+        lambda r: '%.0f min.' % (r[value]/60), axis=1)
+
+    if 'palette' not in kwargs:
+        kwargs['palette'] = 'purpor'
+
+    if 'title' not in kwargs:
+        kwargs['title'] = 'Isolines Areas'
+
+    return color_category_layer(df, RANGE_LABEL_KEY, **kwargs)

--- a/cartoframes/viz/helpers/isolines_layer.py
+++ b/cartoframes/viz/helpers/isolines_layer.py
@@ -72,7 +72,7 @@ def isolines_layer(source, value='data_range', **kwargs):
         lambda r: '%.0f min.' % (r[value]/60), axis=1)
 
     if 'palette' not in kwargs:
-        kwargs['palette'] = 'purpor'
+        kwargs['palette'] = 'pinkyl'
 
     if 'title' not in kwargs:
         kwargs['title'] = 'Isolines Areas'

--- a/cartoframes/viz/helpers/isolines_layer.py
+++ b/cartoframes/viz/helpers/isolines_layer.py
@@ -77,6 +77,9 @@ def isolines_layer(source, value='data_range', **kwargs):
     if 'stroke_color' not in kwargs:
         kwargs['stroke_color'] = 'rgba(150,150,150,0.4)'
 
+    if 'opacity' not in kwargs:
+        kwargs['opacity'] = '0.8'
+
     if 'title' not in kwargs:
         kwargs['title'] = 'Isolines Areas'
 

--- a/cartoframes/viz/helpers/isolines_layer.py
+++ b/cartoframes/viz/helpers/isolines_layer.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from pandas import DataFrame
+
 from . import color_category_layer
 from ...data.dataset.dataset import Dataset
 
@@ -14,8 +16,7 @@ def isolines_layer(source, value='data_range', **kwargs):
         title (str, optional): Title of legend.
         top (int, optional): Number of category for map. Default is 11. Values
           can range from 1 to 16.
-        cat (str, optional): Category list. Must be a valid CARTO VL category
-          list.
+        cat (list<str>, optional): Category list. Must be a valid list of categories.
         palette (str, optional): Palette that can be a named CARTOColor palette
           or other valid CARTO VL palette expression. Default is `bold`.
         size (int, optional): Size of point or line features.
@@ -44,21 +45,27 @@ def isolines_layer(source, value='data_range', **kwargs):
 
             [...]
 
-            isochrones = Isolines().isodistances(df, [1200, 2400, 3600], exclusive=True)
+            isodistances = Isolines().isodistances(df, [1200, 2400, 3600], exclusive=True)
 
-            isolines_layer(isochrones.data, palette='purpor')
+            isolines_layer(isodistances, palette='purpor')
 
     Returns:
-        cartoframes.viz.Layer: Layer styled by `value`.
+        :py:class:`cartoframes.viz.Layer`: Layer styled by `value`.
         Includes a legend, popup and widget on `value`.
     """
-    df = source
-    if isinstance(source, Dataset):
+
+    if isinstance(source, DataFrame):
+        df = source
+    elif isinstance(source, Dataset):
         df = source.dataframe
+    elif isinstance(source, tuple) and hasattr(source, 'data'):
+        df = source.data
+    else:
+        raise ValueError('Invalid input source. It must be a DataFrame, Dataset or a namedtuple with data.')
 
     df = df.copy()
     if value not in df:
-        raise ValueError('Input source must contain a "{}" column'.format(value))
+        raise ValueError('Input DataFrame source must contain a "{}" column'.format(value))
 
     RANGE_LABEL_KEY = 'range_label'
     df[RANGE_LABEL_KEY] = df.apply(

--- a/cartoframes/viz/helpers/isolines_layer.py
+++ b/cartoframes/viz/helpers/isolines_layer.py
@@ -74,6 +74,9 @@ def isolines_layer(source, value='data_range', **kwargs):
     if 'palette' not in kwargs:
         kwargs['palette'] = 'pinkyl'
 
+    if 'stroke_color' not in kwargs:
+        kwargs['stroke_color'] = 'rgba(150,150,150,0.4)'
+
     if 'title' not in kwargs:
         kwargs['title'] = 'Isolines Areas'
 


### PR DESCRIPTION
This method renders the isolines, using internally the `color_category_layer` method from the result of the Isolines service. This service must be called with **`exclusive=True`** flag to obtain non-overlapping areas. Then, the data of the response (DataFrame) is passed to the helper method.

It supports the same parameters as the `color_category_layer`

Note: this method internally clones the dataframe and adds an extra column to represent the ranges.

![](https://user-images.githubusercontent.com/2227572/67790825-b322d480-fa76-11e9-9193-b3200e65fbef.gif)
