### PR TITLE
stroke_width, size, and opacity to none

### DIFF
--- a/cartoframes/viz/defaults.py
+++ b/cartoframes/viz/defaults.py
@@ -9,15 +9,18 @@ STYLE = {
         'color': 'hex("#EE4D5A")',
         'width': 'ramp(linear(zoom(),0,18),[2,10])',
         'strokeWidth': 'ramp(linear(zoom(),0,18),[0,1])',
-        'strokeColor': 'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))'
+        'strokeColor': 'opacity(#222,ramp(linear(zoom(),0,18),[0,0.6]))',
+        'opacity': '1'
     },
     'line': {
         'color': 'hex("#4CC8A3")',
-        'width': 'ramp(linear(zoom(),0,18),[0.5,4])'
+        'width': 'ramp(linear(zoom(),0,18),[0.5,4])',
+        'opacity': '1'
     },
     'polygon': {
         'color': 'hex("#826DBA")',
         'strokeWidth': 'ramp(linear(zoom(),2,18),[0.5,1])',
-        'strokeColor': 'opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))'
+        'strokeColor': 'opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))',
+        'opacity': '0.9'
     }
 }

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .utils import serialize_palette, get_value
+from .utils import get_value
 
 from ..layer import Layer
 

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import serialize_palette, get_value
+
 from ..layer import Layer
 
 
@@ -37,32 +38,25 @@ def animation_layer(
         source,
         style={
             'point': {
-                'width': '{0}'.format(
-                    size or defaults.STYLE['point']['width']),
+                'width': get_value(size, 'point', 'width'),
                 'color': 'opacity({0}, {1})'.format(
                     color or '#EE4D5A', opacity or '0.8'),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': 'animation(linear(${0}), {1}, fade{2})'.format(
                     value, duration or 20, fade or '(1, 1)')
             },
             'line': {
-                'width': '{0}'.format(
-                    size or defaults.STYLE['line']['width']),
+                'width': get_value(size, 'line', 'width'),
                 'color': 'opacity({0}, {1})'.format(
                     color or '#4CC8A3', opacity or '0.8'),
                 'filter': 'animation(linear(${0}), {1}, fade{2})'.format(
                     value, duration or 20, fade or '(1, 1)')
             },
             'polygon': {
-                'color': 'opacity({0}, {1})'.format(
-                    color or defaults.STYLE['polygon']['color'], opacity or '0.9'),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
+                'color': get_value(color, 'polygon', 'color'),
+                'strokeColor': get_value(stroke_color, 'polygon', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'polygon', 'strokeWidth'),
                 'filter': 'animation(linear(${0}), {1}, fade{2})'.format(
                     value, duration or 20, fade or '(1, 1)')
             }

--- a/cartoframes/viz/helpers/animation_layer.py
+++ b/cartoframes/viz/helpers/animation_layer.py
@@ -34,13 +34,16 @@ def animation_layer(
         cartoframes.viz.Layer: Layer styled by `value`. Includes Widget `value`.
     """
 
+    if opacity is None:
+        opacity = '0.8'
+
     return Layer(
         source,
         style={
             'point': {
                 'width': get_value(size, 'point', 'width'),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#EE4D5A', opacity or '0.8'),
+                    color or '#EE4D5A', opacity),
                 'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
                 'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': 'animation(linear(${0}), {1}, fade{2})'.format(
@@ -49,7 +52,7 @@ def animation_layer(
             'line': {
                 'width': get_value(size, 'line', 'width'),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#4CC8A3', opacity or '0.8'),
+                    color or '#4CC8A3', opacity),
                 'filter': 'animation(linear(${0}), {1}, fade{2})'.format(
                     value, duration or 20, fade or '(1, 1)')
             },

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -50,6 +50,9 @@ def cluster_size_layer(
     breakpoints = _get_breakpoints(resolution)
     animation_filter = _get_animation(animate, cluster_operation)
 
+    if opacity is None:
+        opacity = '{0}'.format(opacity or '0.8')
+
     return Layer(
         source,
         style={
@@ -57,7 +60,7 @@ def cluster_size_layer(
                 'width': 'ramp(linear({0}, viewportMIN({0}), viewportMAX({0})), [{1}])'.format(
                     cluster_operation, breakpoints),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#FFB927', opacity or '0.8'),
+                    color or '#FFB927', opacity),
                 'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
                 'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter,

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -51,7 +51,7 @@ def cluster_size_layer(
     animation_filter = _get_animation(animate, cluster_operation)
 
     if opacity is None:
-        opacity = '{0}'.format(opacity or '0.8')
+        opacity = '0.8'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/cluster_size_layer.py
+++ b/cartoframes/viz/helpers/cluster_size_layer.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division
 
 from carto.exceptions import CartoException
 
-from .. import defaults
+from .utils import get_value
 from ..constants import CLUSTER_KEYS, CLUSTER_OPERATIONS
 from ..layer import Layer
 
@@ -58,10 +58,8 @@ def cluster_size_layer(
                     cluster_operation, breakpoints),
                 'color': 'opacity({0}, {1})'.format(
                     color or '#FFB927', opacity or '0.8'),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter,
                 'resolution': '{0}'.format(resolution)
             }

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import serialize_palette, get_value
+
 from ..layer import Layer
-from .utils import serialize_palette
 
 
 def color_bins_layer(
@@ -65,32 +65,32 @@ def color_bins_layer(
         style={
             'point': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette,
-                    opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['point']['width']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
+                    func, value, breaks or bins, 
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'point', 'opacity')
+                ),
+                'width': get_value(size, 'point', 'width'),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter
             },
             'line': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette,
-                    opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['line']['width']),
+                    func, value, breaks or bins, 
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'line', 'opacity')
+                ),
+                'width': get_value(size, 'line', 'width'),
                 'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), {4})'.format(
-                    func, value, breaks or bins, serialize_palette(palette) or default_palette,
-                    opacity or '0.9'),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
+                    func, value, breaks or bins, 
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'polygon', 'opacity')
+                ),
+                'strokeColor': get_value(stroke_color, 'polygon', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'polygon', 'strokeWidth'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_bins_layer.py
+++ b/cartoframes/viz/helpers/color_bins_layer.py
@@ -65,7 +65,7 @@ def color_bins_layer(
         style={
             'point': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, breaks or bins, 
+                    func, value, breaks or bins,
                     serialize_palette(palette) or default_palette,
                     get_value(opacity, 'point', 'opacity')
                 ),
@@ -76,7 +76,7 @@ def color_bins_layer(
             },
             'line': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, breaks or bins, 
+                    func, value, breaks or bins,
                     serialize_palette(palette) or default_palette,
                     get_value(opacity, 'line', 'opacity')
                 ),
@@ -85,7 +85,7 @@ def color_bins_layer(
             },
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), {4})'.format(
-                    func, value, breaks or bins, 
+                    func, value, breaks or bins,
                     serialize_palette(palette) or default_palette,
                     get_value(opacity, 'polygon', 'opacity')
                 ),

--- a/cartoframes/viz/helpers/color_category_layer.py
+++ b/cartoframes/viz/helpers/color_category_layer.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import serialize_palette, get_value
+
 from ..layer import Layer
-from .utils import serialize_palette
 
 
 def color_category_layer(
@@ -51,32 +51,32 @@ def color_category_layer(
         style={
             'point': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette,
-                    opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['point']['width']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
+                    func, value, cat or top,
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'point', 'opacity')
+                ),
+                'width': get_value(size, 'point', 'width'),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter
             },
             'line': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}),{4})'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette,
-                    opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['line']['width']),
+                    func, value, cat or top,
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'line', 'opacity')
+                ),
+                'width': get_value(size, 'line', 'width'),
                 'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp({0}(${1}, {2}), {3}), {4})'.format(
-                    func, value, cat or top, serialize_palette(palette) or default_palette,
-                    opacity or '0.9'),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
+                    func, value, cat or top,
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'polygon', 'opacity')
+                ),
+                'strokeColor': get_value(stroke_color, 'polygon', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'polygon', 'strokeWidth'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
-from .utils import serialize_palette
+from .utils import serialize_palette, get_value
 
 from ..layer import Layer
-from .. import defaults
 
 
 def color_continuous_layer(
@@ -53,44 +52,37 @@ def color_continuous_layer(
     if range_max is None:
         range_max = 'globalMAX(${0})'.format(value)
 
-    if stroke_width is None:
-        stroke_width = defaults.STYLE['point']['strokeWidth']
-
-    if size is None:
-        size = defaults.STYLE['point']['width']
-
-    if opacity is None:
-        opacity = '1'
-
     return Layer(
         source,
         style={
             'point': {
                 'color': 'opacity(ramp(linear(${0}, {1}, {2}), {3}), {4})'.format(
                     value, range_min, range_max,
-                    serialize_palette(palette) or default_palette, opacity),
-                'width': size,
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
-                'strokeWidth': stroke_width,
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'point', 'opacity')
+                ),
+                'width': get_value(size, 'point', 'width'),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter
             },
             'line': {
                 'color': 'opacity(ramp(linear(${0}, {1}, {2}), {3}), {4})'.format(
                     value, range_min, range_max,
-                    serialize_palette(palette) or default_palette, opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['line']['width']),
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'line', 'opacity')
+                ),
+                'width': get_value(size, 'line', 'width'),
                 'filter': animation_filter
             },
             'polygon': {
                 'color': 'opacity(ramp(linear(${0}, {1}, {2}), {3}), {4})'.format(
                     value, range_min, range_max,
-                    serialize_palette(palette) or default_palette, opacity or '0.9'),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['polygon']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['polygon']['strokeWidth']),
+                    serialize_palette(palette) or default_palette,
+                    get_value(opacity, 'polygon', 'opacity')
+                ),
+                'strokeColor': get_value(stroke_color, 'polygon', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'polygon', 'strokeWidth'),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -53,19 +53,26 @@ def color_continuous_layer(
     if range_max is None:
         range_max = 'globalMAX(${0})'.format(value)
 
+    if stroke_width is None:
+        stroke_width = '{0}'.format(stroke_width or defaults.STYLE['point']['strokeWidth'])
+
+    if size is None:
+        size = '{0}'.format(size or defaults.STYLE['point']['width'])
+
+    if opacity is None:
+        opacity = '{0}'.format(opacity or '1')
+
     return Layer(
         source,
         style={
             'point': {
                 'color': 'opacity(ramp(linear(${0}, {1}, {2}), {3}), {4})'.format(
                     value, range_min, range_max,
-                    serialize_palette(palette) or default_palette, opacity or '1'),
-                'width': '{0}'.format(
-                    size or defaults.STYLE['point']['width']),
+                    serialize_palette(palette) or default_palette, opacity),
+                'width': size,
                 'strokeColor': '{0}'.format(
                     stroke_color or defaults.STYLE['point']['strokeColor']),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
+                'strokeWidth': stroke_width,
                 'filter': animation_filter
             },
             'line': {

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -60,7 +60,7 @@ def color_continuous_layer(
         size = defaults.STYLE['point']['width']
 
     if opacity is None:
-        opacity = '{0}'.format(opacity or '1')
+        opacity = '1'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -54,7 +54,7 @@ def color_continuous_layer(
         range_max = 'globalMAX(${0})'.format(value)
 
     if stroke_width is None:
-        stroke_width = '{0}'.format(stroke_width or defaults.STYLE['point']['strokeWidth'])
+        stroke_width = defaults.STYLE['point']['strokeWidth']
 
     if size is None:
         size = '{0}'.format(size or defaults.STYLE['point']['width'])

--- a/cartoframes/viz/helpers/color_continuous_layer.py
+++ b/cartoframes/viz/helpers/color_continuous_layer.py
@@ -57,7 +57,7 @@ def color_continuous_layer(
         stroke_width = defaults.STYLE['point']['strokeWidth']
 
     if size is None:
-        size = '{0}'.format(size or defaults.STYLE['point']['width'])
+        size = defaults.STYLE['point']['width']
 
     if opacity is None:
         opacity = '{0}'.format(opacity or '1')

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -57,7 +57,7 @@ def size_bins_layer(
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
     if opacity is None:
-        opacity = '{0}'.format(opacity or '0.8')
+        opacity = '0.8'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/size_bins_layer.py
+++ b/cartoframes/viz/helpers/size_bins_layer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import get_value
 from ..layer import Layer
 
 
@@ -56,6 +56,9 @@ def size_bins_layer(
 
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
+    if opacity is None:
+        opacity = '{0}'.format(opacity or '0.8')
+
     return Layer(
         source,
         style={
@@ -63,18 +66,16 @@ def size_bins_layer(
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [2, 14]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#EE4D5A', opacity or '0.8'),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
+                    color or '#EE4D5A', opacity),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, breaks or bins, size or [1, 10]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#4CC8A3', opacity or '0.8'),
+                    color or '#4CC8A3', opacity),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import get_value
 from ..layer import Layer
 
 
@@ -47,6 +47,9 @@ def size_category_layer(
     func = 'buckets' if cat else 'top'
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
+    if opacity is None:
+        opacity = '{0}'.format(opacity or '0.8')
+
     return Layer(
         source,
         style={
@@ -54,18 +57,16 @@ def size_category_layer(
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [2, 20]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#F46D43', opacity or '0.8'),
-                'filter': animation_filter,
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor'])
+                    color or '#F46D43', opacity),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
+                'filter': animation_filter
             },
             'line': {
                 'width': 'ramp({0}(${1}, {2}), {3})'.format(
                     func, value, cat or top, size or [1, 10]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#4CC8A3', opacity or '0.8'),
+                    color or '#4CC8A3', opacity),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_category_layer.py
+++ b/cartoframes/viz/helpers/size_category_layer.py
@@ -48,7 +48,7 @@ def size_category_layer(
     animation_filter = 'animation(linear(${}), 20, fade(1,1))'.format(animate) if animate else '1'
 
     if opacity is None:
-        opacity = '{0}'.format(opacity or '0.8')
+        opacity = '0.8'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -51,7 +51,7 @@ def size_continuous_layer(
 
     if range_max is None:
         range_max = 'globalMAX(${0})'.format(value)
-    
+
     if opacity is None:
         opacity = '{0}'.format(opacity or '0.8')
 

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .. import defaults
+from .utils import get_value
 from ..layer import Layer
 
 
@@ -51,6 +51,9 @@ def size_continuous_layer(
 
     if range_max is None:
         range_max = 'globalMAX(${0})'.format(value)
+    
+    if opacity is None:
+        opacity = '{0}'.format(opacity or '0.8')
 
     return Layer(
         source,
@@ -61,11 +64,9 @@ def size_continuous_layer(
                 'width': 'ramp(linear(sqrt(${0}), sqrt({1}), sqrt({2})), {3})'.format(
                     value, range_min, range_max, size or [2, 40]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#FFB927', opacity or '0.8'),
-                'strokeWidth': '{0}'.format(
-                    stroke_width or defaults.STYLE['point']['strokeWidth']),
-                'strokeColor': '{0}'.format(
-                    stroke_color or defaults.STYLE['point']['strokeColor']),
+                    color or '#FFB927', opacity),
+                'strokeColor': get_value(stroke_color, 'point', 'strokeColor'),
+                'strokeWidth': get_value(stroke_width, 'point', 'strokeWidth'),
                 'filter': animation_filter
             },
             'line': {
@@ -74,7 +75,7 @@ def size_continuous_layer(
                 'width': 'ramp(linear(${0}, {1}, {2}), {3})'.format(
                     value, range_min, range_max, size or [1, 10]),
                 'color': 'opacity({0}, {1})'.format(
-                    color or '#4CC8A3', opacity or '0.8'),
+                    color or '#4CC8A3', opacity),
                 'filter': animation_filter
             }
         },

--- a/cartoframes/viz/helpers/size_continuous_layer.py
+++ b/cartoframes/viz/helpers/size_continuous_layer.py
@@ -53,7 +53,7 @@ def size_continuous_layer(
         range_max = 'globalMAX(${0})'.format(value)
 
     if opacity is None:
-        opacity = '{0}'.format(opacity or '0.8')
+        opacity = '0.8'
 
     return Layer(
         source,

--- a/cartoframes/viz/helpers/utils.py
+++ b/cartoframes/viz/helpers/utils.py
@@ -1,5 +1,14 @@
 
+from .. import defaults
+
+
 def serialize_palette(palette):
     if isinstance(palette, (list, tuple)):
         return '[{}]'.format(','.join(palette))
     return palette
+
+
+def get_value(value, geom_type, prop):
+    if value is None:
+        return defaults.STYLE.get(geom_type, {}).get(prop)
+    return value

--- a/examples/visualization_layers/animation_layer.ipynb
+++ b/examples/visualization_layers/animation_layer.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -946,7 +946,7 @@
        "    const default_legend = 'False' === 'true';\n",
        "    const has_legends = 'False' === 'true';\n",
        "    const is_static = 'None' === 'true';\n",
-       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: opacity(hex(\\&quot;#826DBA\\&quot;), 0.9)\\nstrokeWidth: ramp(linear(zoom(),2,18),[0.5,1])\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nfilter: animation(linear($ccyrblt), 20, fade(1, 1))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
+       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: hex(\\&quot;#826DBA\\&quot;)\\nstrokeWidth: 0\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nopacity: 0.9\\nfilter: animation(linear($ccyrblt), 20, fade(1, 1))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
        "    const mapboxtoken = '';\n",
        "    const show_info = 'None' === 'true';\n",
        "\n",
@@ -970,10 +970,10 @@
        "</iframe>"
       ],
       "text/plain": [
-       "<cartoframes.viz.layer.Layer at 0x7fea4425d080>"
+       "<cartoframes.viz.layer.Layer at 0x11106d748>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -981,12 +981,12 @@
    "source": [
     "from cartoframes.viz.helpers import animation_layer\n",
     "\n",
-    "animation_layer('parcels', 'ccyrblt')"
+    "animation_layer('parcels', 'ccyrblt', stroke_width=0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -1901,7 +1901,7 @@
        "    const default_legend = 'False' === 'true';\n",
        "    const has_legends = 'False' === 'true';\n",
        "    const is_static = 'None' === 'true';\n",
-       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: opacity(hex(\\&quot;#826DBA\\&quot;), 0.9)\\nstrokeWidth: ramp(linear(zoom(),2,18),[0.5,1])\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nfilter: animation(linear($ccyrblt), 20, fade(0,hold))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
+       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: hex(\\&quot;#826DBA\\&quot;)\\nstrokeWidth: 0\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nopacity: 0.9\\nfilter: animation(linear($ccyrblt), 20, fade(0,hold))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
        "    const mapboxtoken = '';\n",
        "    const show_info = 'None' === 'true';\n",
        "\n",
@@ -1925,10 +1925,10 @@
        "</iframe>"
       ],
       "text/plain": [
-       "<cartoframes.viz.layer.Layer at 0x7fea4422e748>"
+       "<cartoframes.viz.layer.Layer at 0x1110a2160>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1937,9 +1937,17 @@
     "animation_layer(\n",
     "    'parcels', \n",
     "    'ccyrblt',\n",
+    "    stroke_width=0,\n",
     "    fade='(0,hold)'\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1958,7 +1966,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/visualization_layers/animation_layer.ipynb
+++ b/examples/visualization_layers/animation_layer.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -946,7 +946,7 @@
        "    const default_legend = 'False' === 'true';\n",
        "    const has_legends = 'False' === 'true';\n",
        "    const is_static = 'None' === 'true';\n",
-       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: hex(\\&quot;#826DBA\\&quot;)\\nstrokeWidth: 0\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nopacity: 0.9\\nfilter: animation(linear($ccyrblt), 20, fade(1, 1))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
+       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: opacity(hex(\\&quot;#826DBA\\&quot;), 0.9)\\nstrokeWidth: ramp(linear(zoom(),2,18),[0.5,1])\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nfilter: animation(linear($ccyrblt), 20, fade(1, 1))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
        "    const mapboxtoken = '';\n",
        "    const show_info = 'None' === 'true';\n",
        "\n",
@@ -970,10 +970,10 @@
        "</iframe>"
       ],
       "text/plain": [
-       "<cartoframes.viz.layer.Layer at 0x11106d748>"
+       "<cartoframes.viz.layer.Layer at 0x7fea4425d080>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -981,12 +981,12 @@
    "source": [
     "from cartoframes.viz.helpers import animation_layer\n",
     "\n",
-    "animation_layer('parcels', 'ccyrblt', stroke_width=0)"
+    "animation_layer('parcels', 'ccyrblt')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -1901,7 +1901,7 @@
        "    const default_legend = 'False' === 'true';\n",
        "    const has_legends = 'False' === 'true';\n",
        "    const is_static = 'None' === 'true';\n",
-       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: hex(\\&quot;#826DBA\\&quot;)\\nstrokeWidth: 0\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nopacity: 0.9\\nfilter: animation(linear($ccyrblt), 20, fade(0,hold))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
+       "    const layers = [{&quot;credentials&quot;: {&quot;api_key&quot;: &quot;default_public&quot;, &quot;base_url&quot;: &quot;https://cartoframes.carto.com&quot;, &quot;username&quot;: &quot;cartoframes&quot;}, &quot;has_legend_list&quot;: false, &quot;interactivity&quot;: [], &quot;legend&quot;: {}, &quot;query&quot;: &quot;SELECT * FROM \\&quot;public\\&quot;.\\&quot;parcels\\&quot;&quot;, &quot;type&quot;: &quot;Query&quot;, &quot;viz&quot;: &quot;@v52277c: $ccyrblt\\ncolor: opacity(hex(\\&quot;#826DBA\\&quot;), 0.9)\\nstrokeWidth: ramp(linear(zoom(),2,18),[0.5,1])\\nstrokeColor: opacity(#2c2c2c,ramp(linear(zoom(),2,18),[0.2,0.6]))\\nfilter: animation(linear($ccyrblt), 20, fade(0,hold))\\n&quot;, &quot;widgets&quot;: [{&quot;description&quot;: &quot;&quot;, &quot;footer&quot;: &quot;&quot;, &quot;has_bridge&quot;: true, &quot;options&quot;: {&quot;buckets&quot;: 20, &quot;readOnly&quot;: false}, &quot;prop&quot;: &quot;filter&quot;, &quot;title&quot;: &quot;&quot;, &quot;type&quot;: &quot;time-series&quot;, &quot;value&quot;: &quot;ccyrblt&quot;, &quot;variable_name&quot;: &quot;v52277c&quot;}]}];\n",
        "    const mapboxtoken = '';\n",
        "    const show_info = 'None' === 'true';\n",
        "\n",
@@ -1925,10 +1925,10 @@
        "</iframe>"
       ],
       "text/plain": [
-       "<cartoframes.viz.layer.Layer at 0x1110a2160>"
+       "<cartoframes.viz.layer.Layer at 0x7fea4422e748>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1937,17 +1937,9 @@
     "animation_layer(\n",
     "    'parcels', \n",
     "    'ccyrblt',\n",
-    "    stroke_width=0,\n",
     "    fade='(0,hold)'\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1966,7 +1958,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
hi @Jesus89!

here is my first attempt!

I was testing in the `color_continuous_layer.py` so you'll find my changes there only. I was able to fix the `stroke_width`, `opacity` and `size` but only for points! 

as I was explaining, I don't know how to build in the logic to have separate cases for each geometry type to read in their default symbology individually. 

If you show me the pattern, I can update the other ones!

Look forward to seeing your code/example :)

thanks!!

related ticket: https://github.com/CartoDB/cartoframes/issues/971