### PR TITLE
Optimize local data maps size

### DIFF
--- a/cartoframes/assets/src/bundle.js
+++ b/cartoframes/assets/src/bundle.js
@@ -436,7 +436,7 @@ var init = (function () {
   }
 
   function GeoJSON(layer) {
-    return new carto.source.GeoJSON(_decodeJSONQuery(layer.query));
+    return new carto.source.GeoJSON(_decodeJSONData(layer.data));
   }
 
   function Query(layer) {
@@ -449,15 +449,15 @@ var init = (function () {
       serverURL: layer.credentials.base_url || `https://${layer.credentials.username}.carto.com/`
     };
 
-    return new carto.source.SQL(layer.query, auth, config);
+    return new carto.source.SQL(layer.data, auth, config);
   }
 
   function MVT(layer) {
-    return new carto.source.MVT(layer.query.file, JSON.parse(layer.query.metadata));
+    return new carto.source.MVT(layer.data.file, JSON.parse(layer.data.metadata));
   }
 
-  function _decodeJSONQuery(query) {
-    return JSON.parse(Base64.decode(query.replace(/b\'/, '\'')));
+  function _decodeJSONData(data) {
+    return JSON.parse(Base64.decode(data.replace(/b\'/, '\'')));
   }
 
   const factory = new SourceFactory();

--- a/cartoframes/assets/src/map/SourceFactory.js
+++ b/cartoframes/assets/src/map/SourceFactory.js
@@ -7,7 +7,7 @@ export default function SourceFactory() {
 }
 
 function GeoJSON(layer) {
-  return new carto.source.GeoJSON(_decodeJSONQuery(layer.query));
+  return new carto.source.GeoJSON(_decodeJSONData(layer.data));
 }
 
 function Query(layer) {
@@ -20,13 +20,13 @@ function Query(layer) {
     serverURL: layer.credentials.base_url || `https://${layer.credentials.username}.carto.com/`
   };
 
-  return new carto.source.SQL(layer.query, auth, config);
+  return new carto.source.SQL(layer.data, auth, config);
 }
 
 function MVT(layer) {
-  return new carto.source.MVT(layer.query.file, JSON.parse(layer.query.metadata));
+  return new carto.source.MVT(layer.data.file, JSON.parse(layer.data.metadata));
 }
 
-function _decodeJSONQuery(query) {
-  return JSON.parse(Base64.decode(query.replace(/b\'/, '\'')));
+function _decodeJSONData(data) {
+  return JSON.parse(Base64.decode(data.replace(/b\'/, '\'')));
 }

--- a/cartoframes/data/dataset/dataset.py
+++ b/cartoframes/data/dataset/dataset.py
@@ -156,7 +156,6 @@ class Dataset(object):
 
     def get_query(self):
         """Get the computed query"""
-
         return self._strategy.get_query()
 
     def get_geodataframe(self):

--- a/cartoframes/utils/geom_utils.py
+++ b/cartoframes/utils/geom_utils.py
@@ -270,8 +270,22 @@ def save_index_as_column(df):
 
 
 def extract_viz_columns(viz):
+    """Extract columns ($name) in viz"""
     columns = [RESERVED_GEO_COLUMN_NAME]
-    viz_columns = re.search(r'\$([a-z_]+)', viz)
+    viz_nocomments = remove_comments(viz)
+    viz_columns = re.findall(r'\$([a-z_]+)', viz_nocomments)
     if viz_columns is not None:
-        columns += list(viz_columns.groups())
+        columns += viz_columns
     return columns
+
+
+def remove_comments(text):
+    """Remove C-style comments"""
+    def replacer(match):
+        s = match.group(0)
+        return ' ' if s.startswith('/') else s
+    pattern = re.compile(
+        r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"',
+        re.DOTALL | re.MULTILINE
+    )
+    return re.sub(pattern, replacer, text)

--- a/cartoframes/utils/geom_utils.py
+++ b/cartoframes/utils/geom_utils.py
@@ -267,3 +267,11 @@ def save_index_as_column(df):
         if index_name not in df.columns:
             df.reset_index(inplace=True)
             df.set_index(index_name, drop=False, inplace=True)
+
+
+def extract_viz_columns(viz):
+    columns = [RESERVED_GEO_COLUMN_NAME]
+    viz_columns = re.search(r'\$([a-z_]+)', viz)
+    if viz_columns is not None:
+        columns += list(viz_columns.groups())
+    return columns

--- a/cartoframes/viz/layer.py
+++ b/cartoframes/viz/layer.py
@@ -12,7 +12,7 @@ from .source import Source
 from .style import Style
 from .widget_list import WidgetList
 
-from ..utils.geom_utils import RESERVED_GEO_COLUMN_NAME
+from ..utils.geom_utils import extract_viz_columns
 
 
 class Layer(object):
@@ -148,9 +148,9 @@ class Layer(object):
         widget_variables = self.widgets.get_variables()
         external_variables = merge_dicts(popup_variables, widget_variables)
         self.viz = self.style.compute_viz(geom_type, external_variables)
-        columns = extract_columns(self.viz)
+        viz_columns = extract_viz_columns(self.viz)
 
-        self.source.compute_metadata(columns)
+        self.source.compute_metadata(viz_columns)
         self.source_type = self.source.type
         self.source_data = self.source.data
         self.bounds = bounds or self.source.bounds
@@ -163,10 +163,6 @@ class Layer(object):
     def _repr_html_(self):
         from .map import Map
         return Map(self)._repr_html_()
-
-
-def extract_columns(viz):
-    return [RESERVED_GEO_COLUMN_NAME]
 
 
 def _set_source(source, credentials):

--- a/cartoframes/viz/map.py
+++ b/cartoframes/viz/map.py
@@ -391,7 +391,7 @@ def _get_layer_def(layer):
         'legend': layer.legend_info,
         'has_legend_list': layer.has_legend_list,
         'widgets': layer.widgets_info,
-        'query': layer.source_data,
+        'data': layer.source_data,
         'type': layer.source_type,
         'viz': layer.viz
     }

--- a/cartoframes/viz/map.py
+++ b/cartoframes/viz/map.py
@@ -391,8 +391,8 @@ def _get_layer_def(layer):
         'legend': layer.legend_info,
         'has_legend_list': layer.has_legend_list,
         'widgets': layer.widgets_info,
-        'query': layer.source.query,
-        'type': layer.source.type,
+        'query': layer.source_data,
+        'type': layer.source_type,
         'viz': layer.viz
     }
 

--- a/cartoframes/viz/source.py
+++ b/cartoframes/viz/source.py
@@ -121,7 +121,7 @@ class Source(object):
 
     def _compute_query_bounds(self):
         context = self.dataset._strategy._context
-        return get_query_bounds(context, self.query)
+        return get_query_bounds(context, self.data)
 
     def _compute_geojson_data(self, gdf):
         return encode_geodataframe(gdf)

--- a/cartoframes/viz/source.py
+++ b/cartoframes/viz/source.py
@@ -81,33 +81,13 @@ class Source(object):
             credentials = Credentials('your_user_name', 'your api key')
 
             Source('table_name', credentials)
-
-        Setting the bounds.
-
-        .. code::
-
-            from cartoframes.auth import set_default_credentials
-            from cartoframes.viz import Source
-
-            set_default_credentials('your_user_name', 'your api key')
-
-            bounds = {
-                'west': -10,
-                'east': 10,
-                'north': -10,
-                'south': 10
-            }
-
-            Source('table_name', bounds=bounds)
     """
 
-    def __init__(self, data, credentials=None, bounds=None, schema=None):
+    def __init__(self, data, credentials=None, schema=None):
         if isinstance(data, Dataset):
             self.dataset = data
         else:
             self.dataset = Dataset(data, credentials, schema)
-
-        self._init_source_dataset(bounds)
 
     def get_geom_type(self):
         return self.dataset.compute_geom_type() or BaseDataset.GEOM_TYPE_POINT
@@ -125,20 +105,27 @@ class Source(object):
         else:
             return defaults.CREDENTIALS
 
-    def _init_source_dataset(self, bounds):
+    def compute_metadata(self, columns=None):
         if self.dataset.is_local():
             gdf = self.dataset.get_geodataframe()
+            gdf = gdf[columns] if columns is not None else gdf
             self.type = SourceType.GEOJSON
-            self.query = encode_geodataframe(gdf)
-            self.bounds = bounds or self._compute_geojson_bounds(gdf)
+            self.data = self._compute_geojson_data(gdf)
+            self.bounds = self._compute_geojson_bounds(gdf)
         else:
             self.type = SourceType.QUERY
-            self.query = self.dataset.get_query()
-            self.bounds = bounds or self._compute_query_bounds()
+            self.data = self._compute_query_data()
+            self.bounds = self._compute_query_bounds()
+
+    def _compute_query_data(self):
+        return self.dataset.get_query()
 
     def _compute_query_bounds(self):
         context = self.dataset._strategy._context
         return get_query_bounds(context, self.query)
+
+    def _compute_geojson_data(self, gdf):
+        return encode_geodataframe(gdf)
 
     def _compute_geojson_bounds(self, gdf):
         return get_geodataframe_bounds(gdf)

--- a/tests/unit/viz/helpers/test_color_bins_layer.py
+++ b/tests/unit/viz/helpers/test_color_bins_layer.py
@@ -9,7 +9,7 @@ from ..utils import simple_dataframe
 
 class TestColorBinsLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/helpers/test_color_category_layer.py
+++ b/tests/unit/viz/helpers/test_color_category_layer.py
@@ -7,7 +7,7 @@ from ..utils import simple_dataframe
 
 class TestColorCategoryLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/helpers/test_color_continuous_layer.py
+++ b/tests/unit/viz/helpers/test_color_continuous_layer.py
@@ -7,7 +7,7 @@ from ..utils import simple_dataframe
 
 class TestColorContinuousLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/helpers/test_size_bins_layer.py
+++ b/tests/unit/viz/helpers/test_size_bins_layer.py
@@ -9,7 +9,7 @@ from ..utils import simple_dataframe
 
 class TestSizeBinsLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/helpers/test_size_category_layer.py
+++ b/tests/unit/viz/helpers/test_size_category_layer.py
@@ -7,7 +7,7 @@ from ..utils import simple_dataframe
 
 class TestSizeCategoryLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/helpers/test_size_continuous_layer.py
+++ b/tests/unit/viz/helpers/test_size_continuous_layer.py
@@ -7,7 +7,7 @@ from ..utils import simple_dataframe
 
 class TestSizeContinuousLayerHelper(object):
     def setup_method(self):
-        self.source = simple_dataframe()
+        self.source = simple_dataframe(['name', 'time'])
 
     def test_helpers(self):
         "should be defined"

--- a/tests/unit/viz/test_layer.py
+++ b/tests/unit/viz/test_layer.py
@@ -20,7 +20,7 @@ class TestLayer(object):
         layer = Layer(Source('layer_source', credentials=Credentials('fakeuser')))
 
         assert layer.is_basemap is False
-        assert layer.orig_query == 'SELECT * FROM "public"."layer_source"'
+        assert layer.source_data == 'SELECT * FROM "public"."layer_source"'
         assert isinstance(layer.source, Source)
         assert isinstance(layer.style, Style)
         assert isinstance(layer.popup, Popup)
@@ -33,7 +33,7 @@ class TestLayer(object):
         layer = Layer('layer_source', '', credentials=Credentials('fakeuser'))
 
         assert layer.is_basemap is False
-        assert layer.orig_query == 'SELECT * FROM "public"."layer_source"'
+        assert layer.source_data == 'SELECT * FROM "public"."layer_source"'
         assert isinstance(layer.source, Source)
         assert isinstance(layer.style, Style)
         assert isinstance(layer.popup, Popup)

--- a/tests/unit/viz/test_map.py
+++ b/tests/unit/viz/test_map.py
@@ -97,7 +97,7 @@ class TestMapLayer(object):
 
     def test_interactive_layer(self):
         """Map layer should indicate if the layer has interactivity configured"""
-        source_1 = Source(build_geodataframe([-10, 0], [-10, 0]))
+        source_1 = Source(build_geodataframe([-10, 0], [-10, 0], ['pop', 'name']))
         layer = Layer(
             source_1,
             popup={

--- a/tests/unit/viz/test_map.py
+++ b/tests/unit/viz/test_map.py
@@ -80,7 +80,7 @@ class TestMapLayer(object):
         assert map.layer_defs[0].get('interactivity') == []
         assert map.layer_defs[0].get('credentials') is None
         assert map.layer_defs[0].get('legend') is not None
-        assert map.layer_defs[0].get('query') is not None
+        assert map.layer_defs[0].get('data') is not None
         assert map.layer_defs[0].get('type') == 'GeoJSON'
         assert map.layer_defs[0].get('viz') is not None
 

--- a/tests/unit/viz/utils.py
+++ b/tests/unit/viz/utils.py
@@ -3,11 +3,13 @@ from pandas import DataFrame
 from cartoframes.utils.geom_utils import geodataframe_from_dataframe
 
 
-def build_geodataframe(lats, lngs):
+def build_geodataframe(lats, lngs, extra_columns=[]):
     coordinates = {
         'latitude': lats,
         'longitude': lngs
     }
+    for extra_column in extra_columns:
+        coordinates[extra_column] = lats
 
     dataframe = DataFrame(coordinates)
 

--- a/tests/unit/viz/utils.py
+++ b/tests/unit/viz/utils.py
@@ -4,17 +4,23 @@ from cartoframes.utils.geom_utils import geodataframe_from_dataframe
 
 
 def build_geodataframe(lats, lngs, extra_columns=[]):
-    coordinates = {
+    columns = {
         'latitude': lats,
         'longitude': lngs
     }
     for extra_column in extra_columns:
-        coordinates[extra_column] = lats
+        columns[extra_column] = lats
 
-    dataframe = DataFrame(coordinates)
+    dataframe = DataFrame(columns)
 
     return geodataframe_from_dataframe(dataframe)
 
 
-def simple_dataframe():
-    return DataFrame({'lat': [0], 'lng': [0]})
+def simple_dataframe(extra_columns=[]):
+    default_data = [0]
+    columns = {'lat': default_data, 'lng': default_data}
+
+    for extra_column in extra_columns:
+        columns[extra_column] = default_data
+
+    return DataFrame(columns)


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartoframes/issues/551.

This PR implements an optimization in the visualization of local data (df, gdf, geojson, etc). It consists of detecting the columns used in the visualization (styling, popups, etc) and filtering the source by these columns using only the data that you need for the map.

If all the columns of the source are used in the visualization the filters won't be applied. However, for the normal cases, there is always extra data not used in the visualization. For example:

| Example notebook    | Orig size | After column filter |
|---------------------|-----------|---------------------|
| Create from CSV     | 1740 KB   | 208 KB (12%)        |
| Create from GeoJSON | 645 KB    | 87 KB (13%)         |