### PR TITLE
Fix COPY data types issues

### DIFF
--- a/cartoframes/data/clients/data_obs_client.py
+++ b/cartoframes/data/clients/data_obs_client.py
@@ -659,9 +659,9 @@ class DataObsClient(object):
 
     def _fetch(self, query, decode_geom=False, table_name=None):
         dataset = Dataset(query, credentials=self._credentials)
+        dataset.download(decode_geom=decode_geom)
         if table_name:
             dataset.upload(table_name=table_name)
-        dataset.download(decode_geom=decode_geom)
         return dataset
 
     def _geom_type(self, table):

--- a/cartoframes/data/dataset/registry/dataframe_dataset.py
+++ b/cartoframes/data/dataset/registry/dataframe_dataset.py
@@ -139,17 +139,18 @@ def _is_valid_index_for_cartodb_id(index):
 
 
 def _rows(df, dataframe_columns_info, with_lnglat):
-    for i, row in df.iterrows():
+    num_rows = df.shape[0]
+    for index in range(num_rows):
         row_data = []
         for c in dataframe_columns_info.columns:
             col = c.dataframe
             if col not in df.columns:
                 if df.index.name and col == df.index.name:
-                    val = i
+                    val = index
                 else:  # we could have filtered columns in the df. See DataframeColumnsInfo
                     continue
             else:
-                val = row[col]
+                val = df[col][index]
 
             if _is_null(val):
                 val = ''
@@ -164,8 +165,8 @@ def _rows(df, dataframe_columns_info, with_lnglat):
             row_data.append(encode_row(val))
 
         if with_lnglat:
-            lng_val = row[with_lnglat[0]]
-            lat_val = row[with_lnglat[1]]
+            lng_val = df[with_lnglat[0]][index]
+            lat_val = df[with_lnglat[1]][index]
             if lng_val and lat_val:
                 val = 'SRID=4326;POINT ({lng} {lat})'.format(lng=lng_val, lat=lat_val)
             else:

--- a/cartoframes/data/dataset/registry/dataframe_dataset.py
+++ b/cartoframes/data/dataset/registry/dataframe_dataset.py
@@ -152,7 +152,7 @@ def _rows(df, dataframe_columns_info, with_lnglat):
                 else:  # we could have filtered columns in the df. See DataframeColumnsInfo
                     continue
             else:
-                val = df[col][index]
+                val = df.at[index, col]
 
             if dataframe_columns_info.geom_column and col == dataframe_columns_info.geom_column:
                 geom = decode_geometry(val, dataframe_columns_info.enc_type)
@@ -164,8 +164,8 @@ def _rows(df, dataframe_columns_info, with_lnglat):
             row_data.append(encode_row(val))
 
         if with_lnglat:
-            lng_val = df[with_lnglat[0]][index]
-            lat_val = df[with_lnglat[1]][index]
+            lng_val = df.at[index, with_lnglat[0]]
+            lat_val = df.at[index, with_lnglat[1]]
             if lng_val is not None and lat_val is not None:
                 val = 'SRID=4326;POINT ({lng} {lat})'.format(lng=lng_val, lat=lat_val)
             else:

--- a/cartoframes/data/dataset/registry/dataframe_dataset.py
+++ b/cartoframes/data/dataset/registry/dataframe_dataset.py
@@ -141,8 +141,7 @@ def _is_valid_index_for_cartodb_id(index):
 
 
 def _rows(df, dataframe_columns_info, with_lnglat):
-    num_rows = df.shape[0]
-    for index in range(num_rows):
+    for index, _ in df.iterrows():
         row_data = []
         for c in dataframe_columns_info.columns:
             col = c.dataframe

--- a/cartoframes/data/dataset/registry/dataframe_dataset.py
+++ b/cartoframes/data/dataset/registry/dataframe_dataset.py
@@ -166,7 +166,7 @@ def _rows(df, dataframe_columns_info, with_lnglat):
         if with_lnglat:
             lng_val = df[with_lnglat[0]][index]
             lat_val = df[with_lnglat[1]][index]
-            if lng_val and lat_val:
+            if lng_val is not None and lat_val is not None:
                 val = 'SRID=4326;POINT ({lng} {lat})'.format(lng=lng_val, lat=lat_val)
             else:
                 val = ''

--- a/cartoframes/data/dataset/registry/dataframe_dataset.py
+++ b/cartoframes/data/dataset/registry/dataframe_dataset.py
@@ -90,7 +90,7 @@ class DataFrameDataset(BaseDataset):
             COPY {table_name}({columns}) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '{null}');
         """.format(
             table_name=self._table_name, null=PG_NULL,
-            columns=','.join(c.database for c in dataframe_columns_info.columns))
+            columns=','.join(c.database for c in dataframe_columns_info.columns)).strip()
 
         data = _rows(self._df, dataframe_columns_info, with_lnglat)
 

--- a/cartoframes/data/services/geocoding.py
+++ b/cartoframes/data/services/geocoding.py
@@ -264,9 +264,9 @@ def _dup_dataset(dataset):
     # with a `table_name` attribute (of the temporary table, that will be deleted),
     # so we'll use duplicates of the datasets for temporary uploads`
     if dataset.get_query():
-        return Dataset(dataset.get_query())
+        return Dataset(dataset.get_query(), credentials=dataset.credentials)
     elif dataset.table_name:
-        return Dataset(dataset.table_name)
+        return Dataset(dataset.table_name, credentials=dataset.credentials)
     return Dataset(dataset.dataframe)
 
 
@@ -543,7 +543,7 @@ class Geocoding(Service):
                 # TODO: select only needed columns
                 query = 'SELECT * FROM {table}'.format(table=input_dataset.table_name)
                 input_table_name = table_name
-                input_dataset = Dataset(query)
+                input_dataset = Dataset(query, credentials=self._credentials)
                 input_dataset.upload(table_name=input_table_name, credentials=self._credentials, if_exists=if_exists)
             else:
                 input_table_name = input_dataset.table_name

--- a/cartoframes/utils/columns.py
+++ b/cartoframes/utils/columns.py
@@ -5,7 +5,7 @@ import sys
 
 from unidecode import unidecode
 
-from .utils import dtypes2pg
+from .utils import dtypes2pg, pg2dtypes
 from .geom_utils import decode_geometry, detect_encoding_type
 
 
@@ -257,30 +257,6 @@ def date_columns_names(columns):
 
 def bool_columns_names(columns):
     return [x.name for x in columns if x.dtype == 'bool']
-
-
-def pg2dtypes(pgtype):
-    """Returns equivalent dtype for input `pgtype`."""
-    mapping = {
-        'bigint': 'float64',
-        'boolean': 'bool',
-        'date': 'datetime64[D]',
-        'double precision': 'float64',
-        'geometry': 'object',
-        'int': 'int64',
-        'integer': 'float64',
-        'number': 'float64',
-        'numeric': 'float64',
-        'real': 'float64',
-        'smallint': 'float64',
-        'string': 'object',
-        'timestamp': 'datetime64[ns]',
-        'timestampz': 'datetime64[ns]',
-        'timestamp with time zone': 'datetime64[ns]',
-        'timestamp without time zone': 'datetime64[ns]',
-        'USER-DEFINED': 'object',
-    }
-    return mapping.get(str(pgtype), 'object')
 
 
 def _first_value(series):

--- a/cartoframes/utils/columns.py
+++ b/cartoframes/utils/columns.py
@@ -5,6 +5,7 @@ import sys
 
 from unidecode import unidecode
 
+from .utils import dtypes2pg
 from .geom_utils import decode_geometry, detect_encoding_type
 
 
@@ -117,7 +118,7 @@ class DataframeColumnInfo(object):
         if geom_column and self.dataframe == geom_column:
             db_type = 'geometry({}, 4326)'.format(geom_type or 'Point')
         else:
-            db_type = _dtypes2pg(dtype)
+            db_type = dtypes2pg(dtype)
 
         return db_type
 
@@ -280,21 +281,6 @@ def pg2dtypes(pgtype):
         'USER-DEFINED': 'object',
     }
     return mapping.get(str(pgtype), 'object')
-
-
-def _dtypes2pg(dtype):
-    """Returns equivalent PostgreSQL type for input `dtype`"""
-    mapping = {
-        'float64': 'numeric',
-        'int64': 'bigint',
-        'float32': 'numeric',
-        'int32': 'integer',
-        'object': 'text',
-        'bool': 'boolean',
-        'datetime64[ns]': 'timestamp',
-        'datetime64[ns, UTC]': 'timestamp',
-    }
-    return mapping.get(str(dtype), 'text')
 
 
 def _first_value(series):

--- a/cartoframes/utils/columns.py
+++ b/cartoframes/utils/columns.py
@@ -33,8 +33,8 @@ class Column(object):
     NORMALIZED_GEOM_COL_NAME = 'the_geom'
 
     @staticmethod
-    def from_sql_api_fields(sql_api_fields):
-        return [Column(column, normalize=False, pgtype=sql_api_fields[column]['type']) for column in sql_api_fields]
+    def from_sql_api_fields(fields):
+        return [Column(column, normalize=False, pgtype=_extract_pgtype(fields[column])) for column in fields]
 
     def __init__(self, name, normalize=True, pgtype=None):
         if not name:
@@ -90,6 +90,12 @@ class Column(object):
         value = re.sub(r'-', '_', value)
 
         return value
+
+
+def _extract_pgtype(fields):
+    if 'pgtype' in fields:
+        return fields['pgtype']
+    return None
 
 
 class DataframeColumnInfo(object):

--- a/cartoframes/utils/columns.py
+++ b/cartoframes/utils/columns.py
@@ -15,6 +15,7 @@ class Column(object):
     INT_DTYPES = ['int16', 'int32', 'int64']
     FLOAT_DTYPES = ['float32', 'float64']
     DATETIME_DTYPES = ['datetime64[D]', 'datetime64[ns]', 'datetime64[ns, UTC]']
+    INDEX_COLUMN_NAME = 'cartodb_id'
     SUPPORTED_GEOM_COL_NAMES = ['the_geom', 'geom', 'geometry']
     FORBIDDEN_COLUMN_NAMES = ['the_geom_webmercator']
     MAX_LENGTH = 63
@@ -254,16 +255,11 @@ def normalize_name(column_name):
     return normalize_names([column_name])[0]
 
 
-def obtain_dtypes(columns):
-    return {
-        x.name: x.dtype if not x.name == 'cartodb_id' else 'int64'
-        for x in columns if not (x.dtype in Column.DATETIME_DTYPES)
-        and not(x.name in Column.SUPPORTED_GEOM_COL_NAMES)
-        and not(x.dtype in Column.INT_DTYPES)
-        and not(x.dtype in Column.FLOAT_DTYPES)
-        and not(x.dtype == Column.BOOL_DTYPE)
-        and not(x.dtype == Column.OBJECT_DTYPE)
-    }
+def obtain_index_col(columns):
+    for column in columns:
+        if column.name == Column.INDEX_COLUMN_NAME:
+            return Column.INDEX_COLUMN_NAME
+    return False
 
 
 def obtain_converters(columns, decode_geom):

--- a/cartoframes/utils/geom_utils.py
+++ b/cartoframes/utils/geom_utils.py
@@ -255,17 +255,6 @@ def get_context_with_public_creds(credentials):
     return context.create_context(public_creds)
 
 
-def convert_bool(x):
-    if x:
-        if x == 't':
-            return True
-        if x == 'f':
-            return False
-        return bool(x)
-    else:
-        return None
-
-
 def save_index_as_column(df):
     index_name = df.index.name
     if index_name is not None:

--- a/cartoframes/utils/geom_utils.py
+++ b/cartoframes/utils/geom_utils.py
@@ -44,7 +44,7 @@ ENC_EWKT = 'ewkt'
 if sys.version_info < (3, 0):
     ENC_WKB_BHEX = ENC_WKB_HEX
 
-RESERVED_GEO_COLUMN_NAME = '__cartoframes_geometry'
+RESERVED_GEO_COLUMN_NAME = '__carto_geometry'
 
 
 def compute_query(dataset):

--- a/cartoframes/utils/table.py
+++ b/cartoframes/utils/table.py
@@ -14,7 +14,8 @@ def tables(credentials=None):
     Returns:
         :obj:`list` of :py:class:`Dataset <cartoframes.data.Dataset>`
     """
-    auth_client = _create_auth_client(credentials or get_default_credentials())
+    credentials = credentials or get_default_credentials()
+    auth_client = _create_auth_client(credentials)
     table_names = DatasetManager(auth_client).filter(
         show_table_size_and_row_count='false',
         show_table='false',
@@ -25,7 +26,7 @@ def tables(credentials=None):
         show_uses_builder_features='false',
         show_synchronization='false',
         load_totals='false')
-    return [Dataset(str(table_name)) for table_name in table_names]
+    return [Dataset(str(table_name), credentials=credentials) for table_name in table_names]
 
 
 def _create_auth_client(credentials):

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -131,7 +131,7 @@ def pg2dtypes(pgtype):
         'double precision': 'float64', 'float8': 'float64',
         'numeric': 'float64', 'decimal': 'float64',
         'text': 'object',
-        'boolean': 'bool',
+        'boolean': 'bool', 'bool': 'bool',
         'date': 'datetime64[D]',
         'timestamp': 'datetime64[ns]', 'timestamp without time zone': 'datetime64[ns]',
         'timestampz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -350,7 +350,7 @@ def encode_row(row):
     if row is None:
         row = PG_NULL
 
-    if isinstance(row, float):
+    elif isinstance(row, float):
         if str(row) == 'inf':
             row = 'Infinity'
         elif str(row) == '-inf':
@@ -358,7 +358,7 @@ def encode_row(row):
         elif str(row) == 'nan':
             row = 'NaN'
 
-    if isinstance(row, type(b'')):
+    elif isinstance(row, type(b'')):
         # Decode the input if it's a bytestring
         row = row.decode('utf-8')
 

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -118,6 +118,30 @@ def dtypes2pg(dtype):
     return mapping.get(str(dtype), 'text')
 
 
+def pg2dtypes(pgtype):
+    """Returns equivalent dtype for input `pgtype`."""
+    mapping = {
+        'bigint': 'float64',
+        'boolean': 'bool',
+        'date': 'datetime64[D]',
+        'double precision': 'float64',
+        'geometry': 'object',
+        'int': 'int64',
+        'integer': 'float64',
+        'number': 'float64',
+        'numeric': 'float64',
+        'real': 'float64',
+        'smallint': 'float64',
+        'string': 'object',
+        'timestamp': 'datetime64[ns]',
+        'timestampz': 'datetime64[ns]',
+        'timestamp with time zone': 'datetime64[ns]',
+        'timestamp without time zone': 'datetime64[ns]',
+        'USER-DEFINED': 'object',
+    }
+    return mapping.get(str(pgtype), 'object')
+
+
 def gen_variable_name(value):
     return 'v' + get_hash(value)[:6]
 

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -25,6 +25,8 @@ GEOM_TYPE_POINT = 'point'
 GEOM_TYPE_LINE = 'line'
 GEOM_TYPE_POLYGON = 'polygon'
 
+PG_NULL = '__null'
+
 
 def map_geom_type(geom_type):
     return {
@@ -349,8 +351,10 @@ def remove_column_from_dataframe(dataframe, name):
 
 
 def encode_row(row):
+    if row is None:
+        row = PG_NULL
+
     if isinstance(row, float):
-        # Convert numeric types
         if str(row) == 'inf':
             row = 'Infinity'
         elif str(row) == '-inf':

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -106,6 +106,7 @@ def temp_ignore_warnings(func):
 def dtypes2pg(dtype):
     """Returns equivalent PostgreSQL type for input `dtype`"""
     mapping = {
+        'int16': 'smallint',
         'int32': 'integer',
         'int64': 'bigint',
         'float32': 'real',
@@ -121,22 +122,21 @@ def dtypes2pg(dtype):
 def pg2dtypes(pgtype):
     """Returns equivalent dtype for input `pgtype`."""
     mapping = {
-        'bigint': 'float64',
+        'smallint': 'int16',
+        'integer': 'int32',
+        'bigint': 'int64',
+        'real': 'float32',
+        'double precision': 'float64',
+        'decimal': 'float64',
+        'numeric': 'float64',
+        'text': 'object',
         'boolean': 'bool',
         'date': 'datetime64[D]',
-        'double precision': 'float64',
-        'geometry': 'object',
-        'int': 'int64',
-        'integer': 'float64',
-        'number': 'float64',
-        'numeric': 'float64',
-        'real': 'float64',
-        'smallint': 'float64',
-        'string': 'object',
         'timestamp': 'datetime64[ns]',
         'timestampz': 'datetime64[ns]',
         'timestamp with time zone': 'datetime64[ns]',
         'timestamp without time zone': 'datetime64[ns]',
+        'geometry': 'object',
         'USER-DEFINED': 'object',
     }
     return mapping.get(str(pgtype), 'object')

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -325,6 +325,15 @@ def remove_column_from_dataframe(dataframe, name):
 
 
 def encode_row(row):
+    if isinstance(row, float):
+        # Convert numeric types
+        if str(row) == 'inf':
+            row = 'Infinity'
+        elif str(row) == '-inf':
+            row = '-Infinity'
+        elif str(row) == 'nan':
+            row = 'NaN'
+
     if isinstance(row, type(b'')):
         # Decode the input if it's a bytestring
         row = row.decode('utf-8')

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -103,17 +103,17 @@ def temp_ignore_warnings(func):
     return wrapper
 
 
-# schema definition functions
 def dtypes2pg(dtype):
     """Returns equivalent PostgreSQL type for input `dtype`"""
     mapping = {
-        'float64': 'numeric',
-        'int64': 'numeric',
-        'float32': 'numeric',
-        'int32': 'numeric',
+        'int32': 'integer',
+        'int64': 'bigint',
+        'float32': 'real',
+        'float64': 'double precision',
         'object': 'text',
         'bool': 'boolean',
         'datetime64[ns]': 'timestamp',
+        'datetime64[ns, UTC]': 'timestamp',
     }
     return mapping.get(str(dtype), 'text')
 

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -124,21 +124,17 @@ def dtypes2pg(dtype):
 def pg2dtypes(pgtype):
     """Returns equivalent dtype for input `pgtype`."""
     mapping = {
-        'smallint': 'int16',
-        'integer': 'int32',
-        'bigint': 'int64',
-        'real': 'float32',
-        'double precision': 'float64',
-        'decimal': 'float64',
-        'numeric': 'float64',
+        'smallint': 'int16', 'int2': 'int16',
+        'integer': 'int32', 'int4': 'int32', 'int': 'int32',
+        'bigint': 'int64', 'int8': 'int64',
+        'real': 'float32', 'float4': 'float32',
+        'double precision': 'float64', 'float8': 'float64',
+        'numeric': 'float64', 'decimal': 'float64',
         'text': 'object',
         'boolean': 'bool',
         'date': 'datetime64[D]',
-        'timestamp': 'datetime64[ns]',
-        'timestampz': 'datetime64[ns]',
-        'timestamp with time zone': 'datetime64[ns]',
-        'timestamp without time zone': 'datetime64[ns]',
-        'geometry': 'object',
+        'timestamp': 'datetime64[ns]', 'timestamp without time zone': 'datetime64[ns]',
+        'timestampz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
         'USER-DEFINED': 'object',
     }
     return mapping.get(str(pgtype), 'object')

--- a/tests/e2e/data/client/test_data_obs_client.py
+++ b/tests/e2e/data/client/test_data_obs_client.py
@@ -303,7 +303,7 @@ class TestDataObsClient(unittest.TestCase, _UserUrlLoader):
         df = Dataset(self.test_write_table, credentials=self.credentials).download(decode_geom=False)
 
         self.assertEqual(df.index.name, 'cartodb_id')
-        self.assertEqual(dataset.dataframe.index.dtype, 'int64')
+        self.assertEqual(df.index.dtype, 'int64')
 
         # same number of rows
         self.assertEqual(len(df), len(dataset.dataframe),

--- a/tests/e2e/data/dataset/test_dataset.py
+++ b/tests/e2e/data/dataset/test_dataset.py
@@ -220,7 +220,6 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        print(result)
         self.assertEqual(result['total_rows'], 100)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
@@ -247,7 +246,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049)
+        self.assertEqual(result['total_rows'], 2052)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_lnglat_dataset(self):
@@ -264,21 +263,6 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
         self.assertEqual(result['total_rows'], 50)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
-    def test_dataset_write_null_geometry_column(self):
-        self.assertNotExistsTable(self.test_write_table)
-
-        from cartoframes.examples import read_taxi
-        df = read_taxi(limit=100)
-        dataset = Dataset(df).upload(table_name=self.test_write_table, credentials=self.credentials)
-        self.test_write_table = dataset.table_name
-
-        self.assertExistsTable(self.test_write_table)
-
-        query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NULL'.format(self.test_write_table)
-        result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 100)
-
-    @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_with_different_geometry_column(self):
         self.assertNotExistsTable(self.test_write_table)
 
@@ -292,7 +276,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049)
+        self.assertEqual(result['total_rows'], 2052)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_with_different_geom_column(self):
@@ -309,7 +293,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049)
+        self.assertEqual(result['total_rows'], 2052)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_geopandas(self):
@@ -369,7 +353,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049)
+        self.assertEqual(result['total_rows'], 2052)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_if_exists_append(self):
@@ -388,7 +372,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049 * 2)
+        self.assertEqual(result['total_rows'], 2052 * 2)
 
     @unittest.skipIf(WILL_SKIP, 'no carto credentials, skipping this test')
     def test_dataset_write_if_exists_replace(self):
@@ -404,7 +388,7 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
 
         query = 'SELECT cartodb_id FROM {} WHERE the_geom IS NOT NULL'.format(self.test_write_table)
         result = self.sql_client.query(query, verbose=True)
-        self.assertEqual(result['total_rows'], 2049)
+        self.assertEqual(result['total_rows'], 2052)
 
     def test_dataset_schema_from_parameter(self):
         schema = 'fake_schema'

--- a/tests/e2e/data/dataset/test_dataset.py
+++ b/tests/e2e/data/dataset/test_dataset.py
@@ -769,7 +769,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
+        expected_query = """
+        COPY {}(the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'SRID=4326;POINT (1 1)|0\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -785,7 +787,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
+        expected_query = """
+        COPY {}(the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'SRID=4326;POINT (1 1)|0\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -802,7 +806,7 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
         ds.upload(table_name=table, credentials=credentials)
 
         expected_query = ("COPY {}(geom,the_geom,geometry,cartodb_id)"
-                          " FROM stdin WITH (FORMAT csv, DELIMITER '|');").format(table)
+                          " FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');").format(table)
         expected_data = [b'POINT (0 0)|SRID=4326;POINT (1 1)|POINT (2 2)|0\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -821,7 +825,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(geom,the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
+        expected_query = """
+        COPY {}(geom,the_geom,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'POINT (0 0)|SRID=4326;POINT (2 2)|0\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -837,7 +843,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
+        expected_query = """
+        COPY {}(cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'1|SRID=4326;POINT (1 1)\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -854,7 +862,7 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
         ds.upload(table_name=table, credentials=credentials, with_lnglat=('lng', 'lat'))
 
         expected_query = ("COPY {}(lng,lat,cartodb_id,the_geom)"
-                          " FROM stdin WITH (FORMAT csv, DELIMITER '|');").format(table)
+                          " FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');").format(table)
         expected_data = [b'1|1|0|SRID=4326;POINT (1 1)\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -870,8 +878,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials, with_lnglat=('lng', 'lat'))
 
-        expected_query = "COPY {}(lng,lat,cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(
-            table)
+        expected_query = """
+        COPY {}(lng,lat,cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'1|1|0|SRID=4326;POINT (1 1)\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -887,8 +896,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials, with_lnglat=('lng', 'lat'))
 
-        expected_query = "COPY {}(lng,lat,cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(
-            table)
+        expected_query = """
+        COPY {}(lng,lat,cartodb_id,the_geom) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'1|1|0|SRID=4326;POINT (1 1)\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -904,7 +914,9 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(col1,col2,col3,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
+        expected_query = """
+        COPY {}(col1,col2,col3,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
         expected_data = [b'1|True|text|0\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
@@ -913,15 +925,17 @@ class TestDatasetUnit(unittest.TestCase, _UserUrlLoader):
     def test_dataset_upload_null_values(self):
         table = 'fake_table'
         credentials = 'fake'
-        df = pd.DataFrame.from_dict({'test': [None, [None, None]]})
+        df = pd.DataFrame.from_dict({'test': [None, None]})
         ds = Dataset(df)
 
         BaseDataset.exists = Mock(return_value=False)
 
         ds.upload(table_name=table, credentials=credentials)
 
-        expected_query = "COPY {}(test,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|');".format(table)
-        expected_data = [b'|0\n', b'|1\n']
+        expected_query = """
+        COPY {}(test,cartodb_id) FROM stdin WITH (FORMAT csv, DELIMITER '|', NULL '__null');
+        """.format(table).strip()
+        expected_data = [b'__null|0\n', b'__null|1\n']
 
         self.assertEqual(ds._strategy._context.query, expected_query)
         self.assertEqual(list(ds._strategy._context.response), expected_data)
@@ -937,12 +951,12 @@ class TestDataFrameDatasetUnit(unittest.TestCase, _UserUrlLoader):
         self.assertEqual(list(rows), [b'True\n', b'[1, 2]\n'])
 
     def test_rows_null(self):
-        df = pd.DataFrame.from_dict({'test': [None, [None, None]]})
+        df = pd.DataFrame.from_dict({'test': [None]})
         with_lnglat = None
         dataframe_columns_info = DataframeColumnsInfo(df, with_lnglat)
         rows = _rows(df, dataframe_columns_info, with_lnglat)
 
-        self.assertEqual(list(rows), [b'\n', b'\n'])
+        self.assertEqual(list(rows), [b'__null\n'])
 
     def test_rows_with_geom(self):
         df = pd.DataFrame.from_dict({'test': [True, [1, 2]], 'the_geom': ['Point (0 0)', 'Point (1 1)']})
@@ -953,12 +967,12 @@ class TestDataFrameDatasetUnit(unittest.TestCase, _UserUrlLoader):
         self.assertEqual(list(rows), [b'True|SRID=4326;POINT (0 0)\n', b'[1, 2]|SRID=4326;POINT (1 1)\n'])
 
     def test_rows_null_geom(self):
-        df = pd.DataFrame.from_dict({'test': [None, [None, None]], 'the_geom': [None, None]})
+        df = pd.DataFrame.from_dict({'test': [None], 'the_geom': [None]})
         with_lnglat = None
         dataframe_columns_info = DataframeColumnsInfo(df, with_lnglat)
         rows = _rows(df, dataframe_columns_info, with_lnglat)
 
-        self.assertEqual(list(rows), [b'|\n', b'|\n'])
+        self.assertEqual(list(rows), [b'__null|SRID=4326;GEOMETRYCOLLECTION EMPTY\n'])
 
     def test_rows_non_ascii(self):
         attribute = 'áéí'

--- a/tests/e2e/data/dataset/test_dataset.py
+++ b/tests/e2e/data/dataset/test_dataset.py
@@ -382,7 +382,8 @@ class TestDataset(unittest.TestCase, _UserUrlLoader):
         df = read_brooklyn_poverty()
         Dataset(df).upload(table_name=self.test_write_table, credentials=self.credentials)
 
-        # avoid uploading the same cartodb_id
+        # avoid uploading the same index or cartodb_id
+        df.index += df.index.max() + 1
         df['cartodb_id'] += df['cartodb_id'].max() + 1
 
         Dataset(df).upload(if_exists=Dataset.IF_EXISTS_APPEND,

--- a/tests/e2e/data/services/test_geocoding.py
+++ b/tests/e2e/data/services/test_geocoding.py
@@ -16,6 +16,7 @@ from cartoframes.auth import Credentials
 from cartoframes.data.clients import SQLClient
 from cartoframes.data.services import Geocoding
 from cartoframes.utils.columns import normalize_name
+from cartoframes.utils.geom_utils import RESERVED_GEO_COLUMN_NAME
 
 from ...helpers import _UserUrlLoader, _ReportQuotas
 
@@ -157,7 +158,7 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertEqual(self.used_quota(gc), quota)
 
         # Incremental geocoding: modify one row
-        gc_df.set_value(1, 'address', 'Gran Via 48')
+        gc_df.at[1, 'address'] = 'Gran Via 48'
         info = gc.geocode(gc_df, street='address', city='city', country={'value': 'Spain'}, dry_run=True).metadata
         self.assertEqual(info.get('required_quota'), 1)
         self.assertEqual(self.used_quota(gc), quota)
@@ -212,7 +213,7 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         dataset = Dataset(table_name, credentials=self.credentials)
         dl_df = dataset.download()
         self.assertIsNotNone(dl_df.the_geom)
-        self.assertTrue(dl_df.equals(gc_df.drop('geometry', 1)))
+        self.assertTrue(dl_df.equals(gc_df.drop(RESERVED_GEO_COLUMN_NAME, 1)))
         self.assertTrue('cartodb_id' in dataset.get_column_names())
         self.assertEqual(dl_df.index.name, 'cartodb_id')
 
@@ -435,8 +436,8 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertEqual(self.used_quota(gc), quota)
         self.assertIsNotNone(gc_df.the_geom)
         self.assertIsNotNone(gc_df.gc_status_rel)
-        expected_columns = [
-            'address', 'carto_geocode_hash', 'cartodb_id', 'city', 'gc_status_rel', 'geometry', 'the_geom']
+        expected_columns = [RESERVED_GEO_COLUMN_NAME, 'address', 'carto_geocode_hash', 'cartodb_id', 'city',
+                            'gc_status_rel', 'the_geom']
         self.assertEqual(sorted(gc_df.columns), expected_columns)
 
     def test_geocode_dataframe_with_json_status(self):
@@ -464,7 +465,8 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertIsNotNone(gc_df.the_geom)
         self.assertIsNotNone(gc_df.meta)
         self.assertEqual(sorted(gc_df['meta'].apply(json.loads)[1].keys()), ['match_types', 'precision', 'relevance'])
-        expected_columns = ['address', 'carto_geocode_hash', 'cartodb_id', 'city', 'geometry', 'meta', 'the_geom']
+        expected_columns = [RESERVED_GEO_COLUMN_NAME, 'address', 'carto_geocode_hash', 'cartodb_id', 'city', 'meta',
+                            'the_geom']
         self.assertEqual(sorted(gc_df.columns), expected_columns)
 
     def test_geocode_dataframe_with_json_legacy_status(self):
@@ -492,7 +494,8 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertIsNotNone(gc_df.the_geom)
         self.assertIsNotNone(gc_df.meta)
         self.assertEqual(sorted(gc_df['meta'].apply(json.loads)[1].keys()), ['match_types', 'precision', 'relevance'])
-        expected_columns = ['address', 'carto_geocode_hash', 'cartodb_id', 'city', 'geometry', 'meta', 'the_geom']
+        expected_columns = [RESERVED_GEO_COLUMN_NAME, 'address', 'carto_geocode_hash', 'cartodb_id', 'city', 'meta',
+                            'the_geom']
         self.assertEqual(sorted(gc_df.columns), expected_columns)
 
     def test_geocode_dataframe_with_no_status(self):
@@ -518,7 +521,7 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         quota += 2
         self.assertEqual(self.used_quota(gc), quota)
         self.assertIsNotNone(gc_df.the_geom)
-        expected_columns = ['address', 'carto_geocode_hash', 'cartodb_id', 'city', 'geometry', 'the_geom']
+        expected_columns = [RESERVED_GEO_COLUMN_NAME, 'address', 'carto_geocode_hash', 'cartodb_id', 'city', 'the_geom']
         self.assertEqual(sorted(gc_df.columns), expected_columns)
 
     def test_geocode_dataframe_with_custom_status(self):
@@ -547,7 +550,8 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertEqual(self.used_quota(gc), quota)
         self.assertIsNotNone(gc_df.the_geom)
         self.assertIsNotNone(gc_df.gc_rel)
-        expected_columns = ['address', 'carto_geocode_hash', 'cartodb_id', 'city', 'gc_rel', 'geometry', 'the_geom']
+        expected_columns = [RESERVED_GEO_COLUMN_NAME, 'address', 'carto_geocode_hash', 'cartodb_id', 'city', 'gc_rel',
+                            'the_geom']
         self.assertEqual(sorted(gc_df.columns), expected_columns)
 
     def test_geocode_dataframe_fails_with_invalid_status_fields(self):
@@ -606,7 +610,7 @@ class TestGeocoding(unittest.TestCase, _UserUrlLoader, _ReportQuotas):
         self.assertEqual(self.used_quota(gc), quota)
 
         # Incremental geocoding: modify one row
-        df.set_value(1, 'address', 'Gran Via 48')
+        df.at[1, 'address'] = 'Gran Via 48'
         info = gc.geocode(
             df, cached=table_name, street='address', city='city', country={'value': 'Spain'}, dry_run=True).metadata
         self.assertEqual(info.get('required_quota'), 1)

--- a/tests/unit/utils/test_columns.py
+++ b/tests/unit/utils/test_columns.py
@@ -6,8 +6,7 @@ import unittest
 import pandas as pd
 
 from cartoframes.utils.columns import (Column, DataframeColumnInfo,
-                                       DataframeColumnsInfo, normalize_names,
-                                       pg2dtypes)
+                                       DataframeColumnsInfo, normalize_names)
 
 
 class TestColumns(unittest.TestCase):
@@ -73,19 +72,6 @@ class TestColumns(unittest.TestCase):
 
     def test_normalize_names_unchanged(self):
         self.assertListEqual(normalize_names(self.cols_ans), self.cols_ans)
-
-    def test_pg2dtypes(self):
-        results = {
-            'date': 'datetime64[D]',
-            'number': 'float64',
-            'string': 'object',
-            'boolean': 'bool',
-            'geometry': 'object',
-            'unknown_pgdata': 'object'
-        }
-        for i in results:
-            result = pg2dtypes(i)
-            self.assertEqual(result, results[i])
 
     def test_database_column_name_the_geom(self):
         geom_column = 'the_geom'

--- a/tests/unit/utils/test_geom_utils.py
+++ b/tests/unit/utils/test_geom_utils.py
@@ -31,7 +31,7 @@ class TestDataUtils(object):
             Point([0, 0]),
             Point([10, 15]),
             Point([20, 30])
-        ], name='__cartoframes_geometry')
+        ], name='__carto_geometry')
         self.msg = 'No geographic data found. ' + \
             'If a geometry exists, change the column name ' + \
             '(geometry, the_geom, wkt_geometry, wkb_geometry, geom, wkt, wkb) ' + \

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from cartoframes.utils.utils import (camel_dictionary, cssify, debug_print,
                                      dict_items, importify_params,
-                                     snake_to_camel, encode_row)
+                                     snake_to_camel, dtypes2pg, encode_row)
 
 
 class TestUtils(unittest.TestCase):
@@ -127,16 +127,15 @@ class TestUtils(unittest.TestCase):
             self.assertTrue(importify_params(p), ans[idx])
 
     def test_dtypes2pg(self):
-        """utils.dtypes2pg"""
-        from cartoframes.utils.utils import dtypes2pg
         results = {
-            'float64': 'numeric',
-            'int64': 'numeric',
-            'float32': 'numeric',
-            'int32': 'numeric',
+            'int32': 'integer',
+            'int64': 'bigint',
+            'float32': 'real',
+            'float64': 'double precision',
             'object': 'text',
             'bool': 'boolean',
             'datetime64[ns]': 'timestamp',
+            'datetime64[ns, UTC]': 'timestamp',
             'unknown_dtype': 'text'
         }
         for i in results:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -128,6 +128,7 @@ class TestUtils(unittest.TestCase):
 
     def test_dtypes2pg(self):
         results = {
+            'int16': 'smallint',
             'int32': 'integer',
             'int64': 'bigint',
             'float32': 'real',
@@ -143,16 +144,26 @@ class TestUtils(unittest.TestCase):
 
     def test_pg2dtypes(self):
         results = {
-            'date': 'datetime64[D]',
-            'number': 'float64',
-            'string': 'object',
+            'smallint': 'int16',
+            'integer': 'int32',
+            'bigint': 'int64',
+            'real': 'float32',
+            'double precision': 'float64',
+            'decimal': 'float64',
+            'numeric': 'float64',
+            'text': 'object',
             'boolean': 'bool',
+            'date': 'datetime64[D]',
+            'timestamp': 'datetime64[ns]',
+            'timestampz': 'datetime64[ns]',
+            'timestamp with time zone': 'datetime64[ns]',
+            'timestamp without time zone': 'datetime64[ns]',
             'geometry': 'object',
+            'USER-DEFINED': 'object',
             'unknown_pgdata': 'object'
         }
         for i in results:
-            result = pg2dtypes(i)
-            self.assertEqual(result, results[i])
+            self.assertEqual(pg2dtypes(i), results[i])
 
     def test_snake_to_camel(self):
         self.assertEqual(snake_to_camel('sneaky_snake'), 'sneakySnake')

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -144,23 +144,18 @@ class TestUtils(unittest.TestCase):
 
     def test_pg2dtypes(self):
         results = {
-            'smallint': 'int16',
-            'integer': 'int32',
-            'bigint': 'int64',
-            'real': 'float32',
-            'double precision': 'float64',
-            'decimal': 'float64',
-            'numeric': 'float64',
+            'smallint': 'int16', 'int2': 'int16',
+            'integer': 'int32', 'int4': 'int32', 'int': 'int32',
+            'bigint': 'int64', 'int8': 'int64',
+            'real': 'float32', 'float4': 'float32',
+            'double precision': 'float64', 'float8': 'float64',
+            'numeric': 'float64', 'decimal': 'float64',
             'text': 'object',
             'boolean': 'bool',
             'date': 'datetime64[D]',
-            'timestamp': 'datetime64[ns]',
-            'timestampz': 'datetime64[ns]',
-            'timestamp with time zone': 'datetime64[ns]',
-            'timestamp without time zone': 'datetime64[ns]',
-            'geometry': 'object',
+            'timestamp': 'datetime64[ns]', 'timestamp without time zone': 'datetime64[ns]',
+            'timestampz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
             'USER-DEFINED': 'object',
-            'unknown_pgdata': 'object'
         }
         for i in results:
             self.assertEqual(pg2dtypes(i), results[i])

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -8,8 +8,8 @@ import requests
 import numpy as np
 
 from cartoframes.utils.utils import (camel_dictionary, cssify, debug_print,
-                                     dict_items, importify_params,
-                                     snake_to_camel, dtypes2pg, encode_row)
+                                     dict_items, importify_params, snake_to_camel,
+                                     dtypes2pg, pg2dtypes, encode_row)
 
 
 class TestUtils(unittest.TestCase):
@@ -140,6 +140,19 @@ class TestUtils(unittest.TestCase):
         }
         for i in results:
             self.assertEqual(dtypes2pg(i), results[i])
+
+    def test_pg2dtypes(self):
+        results = {
+            'date': 'datetime64[D]',
+            'number': 'float64',
+            'string': 'object',
+            'boolean': 'bool',
+            'geometry': 'object',
+            'unknown_pgdata': 'object'
+        }
+        for i in results:
+            result = pg2dtypes(i)
+            self.assertEqual(result, results[i])
 
     def test_snake_to_camel(self):
         self.assertEqual(snake_to_camel('sneaky_snake'), 'sneakySnake')

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -5,6 +5,7 @@ import unittest
 from collections import OrderedDict
 
 import requests
+import numpy as np
 
 from cartoframes.utils.utils import (camel_dictionary, cssify, debug_print,
                                      dict_items, importify_params,
@@ -187,3 +188,6 @@ class TestUtils(unittest.TestCase):
         assert encode_row(b'Hello "world"') == b'"Hello ""world"""'
         assert encode_row(b'Hello | world') == b'"Hello | world"'
         assert encode_row(b'Hello \n world') == b'"Hello \n world"'
+        assert encode_row(np.inf) == b'Infinity'
+        assert encode_row(-np.inf) == b'-Infinity'
+        assert encode_row(np.nan) == b'NaN'


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartoframes/issues/784.

This PR contains important fixes related to uploading and downloading data types :tada:

- **Fix upload types**: the old implementation it was iterating by the row. To get a row, panda unifies the type of all the columns in the row, so, if for example, you have a column with `int` and another with `float` it assumes that the row it type `float` so it will add your `int` column data as `float` causing a non-deterministic bug. Now the iteration is made using the index of the row, so the final type of the value is the correct one.
- **Encode numeric types NaN, Infinity, -Infinity**: tt adds a map between `numpy` types np.nan, np.inf and -np.inf.
- **Fix `dtypes` to `pgtypes` and `pgtypes` to `dtypes` conversion**: using PostgreSQL types instead: https://www.postgresql.org/docs/7.4/datatype.html. Using `pgtype` allows a better mapping for the DataFrame types. The PG types aliases have been added too (int4, float8, etc).
- **Allow upload NULL values**: in the old implementation, null values were ignored or converted to ' ' . In this PR NaN and None valued in the DataFrame are properly converted to `NaN` and `null` in the DB.
- **Fix download NULL and Infinite values**: it allows to download `null`, `NaN`, `Infinite`, `-Infinite` values from the CARTO table.
- **Fix upload coordinates (0, 0)**: there is also a small fix to enable uploading the geometry `POINT(0 0)`.