### PR TITLE
add message in requirements.txt to communicate where requirements are specified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+# check setup.py's REQUIRES variable for requirements
 .


### PR DESCRIPTION
I'm pretty sure that most people aren't aware that a `.` in the requirements.txt file means that requirements are pulled from setup.py. Adding a comment here to help people know where to look in case they don't know what the `.` syntax means.

cc @Jesus89 
