### PR TITLE
fix catalog datasets_filter

### DIFF
--- a/cartoframes/data/observatory/catalog/dataset.py
+++ b/cartoframes/data/observatory/catalog/dataset.py
@@ -211,7 +211,7 @@ class Dataset(CatalogEntity):
         matched_geographies_ids = cls._join_geographies_geodataframes(catalog_geographies_gdf, user_gdf)
 
         # Get Dataset objects
-        return get_dataset_repo().get_all({'geography_id': matched_geographies_ids})
+        return get_dataset_repo().get_all({'geography_id': list(matched_geographies_ids)})
 
     @staticmethod
     def _get_user_geodataframe(filter_dataset):


### PR DESCRIPTION
Fix https://github.com/CartoDB/cartoframes/issues/1229

Geopandas returns the matched geographies like a numpy array and we are expecting a list when the query is created. 

IMO It makes no sense to add a test for that since we are using external dependencies and we would need to mock everything...