### PR TITLE
Fix CDF plot

### DIFF
--- a/cartoframes/core/cartodataframe.py
+++ b/cartoframes/core/cartodataframe.py
@@ -1,5 +1,5 @@
 from numpy import ndarray
-from pandas import Series
+from pandas import DataFrame, Series
 from geopandas import GeoDataFrame, points_from_xy
 
 from ..utils.geom_utils import decode_geometry_column
@@ -354,3 +354,9 @@ class CartoDataFrame(GeoDataFrame):
         result = super(self._constructor, self).explode(*args, **kwargs)
         result.__class__ = self._constructor
         return result
+
+    def plot(self, *args, **kwargs):
+        if self.has_geometry():
+            return GeoDataFrame.plot(self, *args, **kwargs)
+        else:
+            return DataFrame(self).plot(*args, **kwargs)

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,6 +97,8 @@ def test_simple_mocking(mocker):
     mock_db_service.assert_called_with('foo')
 ```
 
+NOTE: avoid `assert_called_once` because it does not work in Python 3.5.
+
 **Classes**
 
 ```py

--- a/tests/unit/core/test_cartodataframe.py
+++ b/tests/unit/core/test_cartodataframe.py
@@ -128,3 +128,11 @@ class TestCartoDataFrame(object):
         cdf2 = CartoDataFrame({'a': [2], 'geometry': [Point(1, 1)]})
         cdf = concat([cdf1, cdf2])
         assert isinstance(cdf, CartoDataFrame)
+
+    def test_plot(self):
+        cdf = CartoDataFrame({'x': [1], 'y': [1], 'geometry': [Point(0, 0)]})
+        # Assert it works without exception
+        cdf['x'].plot()
+        cdf['geometry'].plot()
+        cdf[['x', 'y']].plot()
+        cdf[['x', 'geometry']].plot(column='x')

--- a/tests/unit/core/test_cartodataframe.py
+++ b/tests/unit/core/test_cartodataframe.py
@@ -1,7 +1,8 @@
 """Unit tests for cartoframes.data."""
 
 from pandas import concat
-from geopandas import GeoDataFrame
+from pandas import DataFrame, Series
+from geopandas import GeoDataFrame, GeoSeries
 from shapely.geometry import box, Point
 
 from cartoframes import CartoDataFrame
@@ -129,10 +130,26 @@ class TestCartoDataFrame(object):
         cdf = concat([cdf1, cdf2])
         assert isinstance(cdf, CartoDataFrame)
 
-    def test_plot(self):
-        cdf = CartoDataFrame({'x': [1], 'y': [1], 'geometry': [Point(0, 0)]})
-        # Assert it works without exception
+    def test_plot_series(self, mocker):
+        series_plot_mock = mocker.patch.object(Series, 'plot')
+        cdf = CartoDataFrame({'x': [1]})
         cdf['x'].plot()
+        series_plot_mock.assert_called_once()
+
+    def test_plot_geoseries(self, mocker):
+        geoseries_plot_mock = mocker.patch.object(GeoSeries, 'plot')
+        cdf = CartoDataFrame({'geometry': [Point(0, 0)]})
         cdf['geometry'].plot()
+        geoseries_plot_mock.assert_called_once()
+
+    def test_plot_dataframe(self, mocker):
+        dataframe_plot_mock = mocker.patch.object(DataFrame, 'plot')
+        cdf = CartoDataFrame({'x': [1], 'y': [1]})
         cdf[['x', 'y']].plot()
+        dataframe_plot_mock.assert_called_once()
+
+    def test_plot_geodataframe(self, mocker):
+        geodataframe_plot_mock = mocker.patch.object(GeoDataFrame, 'plot')
+        cdf = CartoDataFrame({'x': [1], 'geometry': [Point(0, 0)]})
         cdf[['x', 'geometry']].plot(column='x')
+        geodataframe_plot_mock.assert_called_once()

--- a/tests/unit/core/test_cartodataframe.py
+++ b/tests/unit/core/test_cartodataframe.py
@@ -134,22 +134,23 @@ class TestCartoDataFrame(object):
         series_plot_mock = mocker.patch.object(Series, 'plot')
         cdf = CartoDataFrame({'x': [1]})
         cdf['x'].plot()
-        series_plot_mock.assert_called_once()
+        series_plot_mock.assert_called_once_with()
 
     def test_plot_geoseries(self, mocker):
         geoseries_plot_mock = mocker.patch.object(GeoSeries, 'plot')
         cdf = CartoDataFrame({'geometry': [Point(0, 0)]})
         cdf['geometry'].plot()
-        geoseries_plot_mock.assert_called_once()
+        geoseries_plot_mock.assert_called_once_with()
 
     def test_plot_dataframe(self, mocker):
         dataframe_plot_mock = mocker.patch.object(DataFrame, 'plot')
         cdf = CartoDataFrame({'x': [1], 'y': [1]})
         cdf[['x', 'y']].plot()
-        dataframe_plot_mock.assert_called_once()
+        dataframe_plot_mock.assert_called_once_with()
 
     def test_plot_geodataframe(self, mocker):
         geodataframe_plot_mock = mocker.patch.object(GeoDataFrame, 'plot')
         cdf = CartoDataFrame({'x': [1], 'geometry': [Point(0, 0)]})
-        cdf[['x', 'geometry']].plot(column='x')
-        geodataframe_plot_mock.assert_called_once()
+        subset = cdf[['x', 'geometry']]
+        subset.plot(column='x')
+        geodataframe_plot_mock.assert_called_once_with(subset, column='x')


### PR DESCRIPTION
This PR wraps the plot method in CDF to allow plotting geo and non-geo data.

A `Series` is rendered in pandas, a `GeoSeries` in geopandas, but in case there is a subset and it contains a geometry column, it is rendered with GeoDataFrame.plot, otherwise it uses DataFrame.plot.

![](https://user-images.githubusercontent.com/2227572/70616970-e88f1600-1c0f-11ea-9b17-2fb83721139b.png)

![](https://user-images.githubusercontent.com/2227572/70616983-ed53ca00-1c0f-11ea-9b9c-d79a9146bf35.png)

![](https://user-images.githubusercontent.com/2227572/70617002-f0e75100-1c0f-11ea-9326-2ee8ca7ebc54.png)


