### PR TITLE
Avoid double logger in Jupyter

### DIFF
--- a/cartoframes/core/logger.py
+++ b/cartoframes/core/logger.py
@@ -3,13 +3,11 @@ import logging
 
 
 def init_logger():
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-    log = logging.getLogger('CARTOframes')
-    log.setLevel(logging.INFO)
-    log.addHandler(handler)
-    return log
+    logging.basicConfig(
+        stream=sys.stdout,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        level=logging.INFO)
+    return logging.getLogger('CARTOframes')
 
 
 def set_log_level(level):


### PR DESCRIPTION
This PR removed the double log in Jupyter notebooks

![](https://user-images.githubusercontent.com/2227572/70689481-b5529280-1cb4-11ea-8e2c-0b86cf628085.png)
