### PR TITLE
Use 'safe' option to avoid autoescaping

### DIFF
--- a/cartoframes/assets/templates/viz/legends.html.j2
+++ b/cartoframes/assets/templates/viz/legends.html.j2
@@ -13,7 +13,7 @@
             description="{{legend.description}}">
             {{ createLegend(legend, 'layer%d_map%d_legend%d' | format(layer_index, 0, loop.index0)) }}
             {% if legend.footer %}
-              <span slot="footer">{{legend.footer}}</span>
+              <span slot="footer">{{legend.footer | safe }}</span>
             {% endif %}
           </as-legend>
         {% endfor %}
@@ -23,7 +23,7 @@
           description="{{layer.legends.description}}">
           {{ createLegend(layer.legends, 'layer%d_map%d_legend%d' | format(layer_index, 0, 0)) }}
           {% if layer.legends.footer %}
-            <span slot="footer">{{layer.legends.footer}}</span>
+            <span slot="footer">{{layer.legends.footer | safe }}</span>
           {% endif %}
         </as-legend>
       {% endif %}

--- a/cartoframes/assets/templates/viz/legends_layout.html.j2
+++ b/cartoframes/assets/templates/viz/legends_layout.html.j2
@@ -12,7 +12,7 @@
       >
         {{ createLegend(layer.legend, 'layer%d_map%d_legend' | format(loop.index0, index)) }}
         {% if layer.legend.footer %}
-          <span slot="footer">{{layer.legend.footer |safe }}</span>
+          <span slot="footer">{{layer.legend.footer | safe }}</span>
         {% endif %}
       </as-legend>
     {% endif %}

--- a/cartoframes/assets/templates/viz/legends_layout.html.j2
+++ b/cartoframes/assets/templates/viz/legends_layout.html.j2
@@ -12,7 +12,7 @@
       >
         {{ createLegend(layer.legend, 'layer%d_map%d_legend' | format(loop.index0, index)) }}
         {% if layer.legend.footer %}
-          <span slot="footer">{{layer.legend.footer}}</span>
+          <span slot="footer">{{layer.legend.footer |safe }}</span>
         {% endif %}
       </as-legend>
     {% endif %}

--- a/cartoframes/assets/templates/viz/widgets/animation.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/animation.html.j2
@@ -6,6 +6,6 @@
     description="{{widget.description}}"
   ></as-animation-controls-widget>
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>

--- a/cartoframes/assets/templates/viz/widgets/basic.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/basic.html.j2
@@ -4,6 +4,6 @@
     subheader="{{widget.description}}">
   </as-widget-header>
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>

--- a/cartoframes/assets/templates/viz/widgets/category.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/category.html.j2
@@ -5,6 +5,6 @@
     heading="{{widget.title}}">
   </as-category-widget>
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>

--- a/cartoframes/assets/templates/viz/widgets/formula.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/formula.html.j2
@@ -13,6 +13,6 @@
   </p>
 
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>

--- a/cartoframes/assets/templates/viz/widgets/histogram.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/histogram.html.j2
@@ -5,6 +5,6 @@
     heading="{{widget.title}}">
   </as-histogram-widget>
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>

--- a/cartoframes/assets/templates/viz/widgets/time-series.html.j2
+++ b/cartoframes/assets/templates/viz/widgets/time-series.html.j2
@@ -7,6 +7,6 @@
     heading="{{widget.title}}">
   </as-time-series-widget>
   {% if widget.footer %}
-    <footer>{{widget.footer}}</footer>
+    <footer>{{widget.footer | safe }}</footer>
   {% endif %}
 </div>


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/cartoframes/issues/1523

Added a `safe` filter to safely escape html content in legends and widgets footer section.

Published map example: https://team.carto.com/u/elena-carto/kuviz/ea0e30da-f9dd-4bee-b9df-ce143e3eba43