### PR TITLE
No set user_id when no user is logged for reading public tables

### DIFF
--- a/cartoframes/utils/metrics.py
+++ b/cartoframes/utils/metrics.py
@@ -115,7 +115,9 @@ def build_extra_metrics_data(decorated_function, *args, **kwargs):
         credentials = get_credentials(credentials)
         return {'user_id': credentials.user_id} if credentials and credentials.user_id else {}
 
-    except ValueError:  # When the decorated function doesn't contain `credentials`
+    # ValueError: When the decorated function doesn't contain `credentials`, e.g. creating a map
+    # AttributeError: When no user is set, e.g., reading a public table
+    except (ValueError, AttributeError):
         return {}
 
 


### PR DESCRIPTION
Issue https://app.clubhouse.io/cartoteam/story/60217/metrics-fail-when-reading-a-carto-public-table-without-api-key