### PR TITLE
Add type filter to get_subscription_ids

### DIFF
--- a/cartoframes/data/observatory/catalog/dataset.py
+++ b/cartoframes/data/observatory/catalog/dataset.py
@@ -4,7 +4,7 @@ import geopandas as gpd
 from shapely import wkt
 
 from .entity import CatalogEntity
-from .repository.dataset_repo import get_dataset_repo
+from .repository.dataset_repo import get_dataset_repo, DATASET_TYPE
 from .repository.geography_repo import get_geography_repo
 from .repository.variable_repo import get_variable_repo
 from .repository.variable_group_repo import get_variable_group_repo
@@ -16,8 +16,6 @@ from . import utils
 from ....utils.logger import log
 from ....utils.utils import get_credentials, check_credentials, check_do_enabled
 from ....exceptions import DOError
-
-DATASET_TYPE = 'dataset'
 
 
 class Dataset(CatalogEntity):
@@ -468,7 +466,7 @@ class Dataset(CatalogEntity):
 
         """
         _credentials = get_credentials(credentials)
-        _subscribed_ids = subscriptions.get_subscription_ids(_credentials)
+        _subscribed_ids = subscriptions.get_subscription_ids(_credentials, DATASET_TYPE)
 
         if self.id in _subscribed_ids:
             utils.display_existing_subscription_message(self.id, DATASET_TYPE)

--- a/cartoframes/data/observatory/catalog/geography.py
+++ b/cartoframes/data/observatory/catalog/geography.py
@@ -1,14 +1,12 @@
 from .entity import CatalogEntity
 from .repository.dataset_repo import get_dataset_repo
-from .repository.geography_repo import get_geography_repo
+from .repository.geography_repo import get_geography_repo, GEOGRAPHY_TYPE
 from .repository.constants import GEOGRAPHY_FILTER
 from . import subscription_info
 from . import subscriptions
 from . import utils
 from ....utils.utils import get_credentials, check_credentials, check_do_enabled
 from ....exceptions import DOError
-
-GEOGRAPHY_TYPE = 'geography'
 
 
 class Geography(CatalogEntity):
@@ -270,7 +268,7 @@ class Geography(CatalogEntity):
 
         """
         _credentials = get_credentials(credentials)
-        _subscribed_ids = subscriptions.get_subscription_ids(_credentials)
+        _subscribed_ids = subscriptions.get_subscription_ids(_credentials, GEOGRAPHY_TYPE)
 
         if self.id in _subscribed_ids:
             utils.display_existing_subscription_message(self.id, GEOGRAPHY_TYPE)

--- a/cartoframes/data/observatory/catalog/repository/dataset_repo.py
+++ b/cartoframes/data/observatory/catalog/repository/dataset_repo.py
@@ -2,6 +2,7 @@ from .constants import CATEGORY_FILTER, COUNTRY_FILTER, GEOGRAPHY_FILTER, PROVID
 from ..subscriptions import get_subscription_ids
 from .entity_repo import EntityRepository
 
+DATASET_TYPE = 'dataset'
 
 _DATASET_ID_FIELD = 'id'
 _DATASET_SLUG_FIELD = 'slug'
@@ -19,7 +20,7 @@ class DatasetRepository(EntityRepository):
 
     def get_all(self, filters=None, credentials=None):
         if credentials is not None:
-            ids = get_subscription_ids(credentials)
+            ids = get_subscription_ids(credentials, DATASET_TYPE)
             if len(ids) == 0:
                 return []
             elif len(ids) > 0:

--- a/cartoframes/data/observatory/catalog/repository/geography_repo.py
+++ b/cartoframes/data/observatory/catalog/repository/geography_repo.py
@@ -6,6 +6,8 @@ from ..subscriptions import get_subscription_ids
 from .constants import COUNTRY_FILTER, CATEGORY_FILTER, PROVIDER_FILTER
 from .entity_repo import EntityRepository
 
+GEOGRAPHY_TYPE = 'geography'
+
 _GEOGRAPHY_ID_FIELD = 'id'
 _GEOGRAPHY_SLUG_FIELD = 'slug'
 _ALLOWED_FILTERS = [COUNTRY_FILTER, CATEGORY_FILTER, PROVIDER_FILTER]
@@ -22,7 +24,7 @@ class GeographyRepository(EntityRepository):
 
     def get_all(self, filters=None, credentials=None):
         if credentials is not None:
-            ids = get_subscription_ids(credentials)
+            ids = get_subscription_ids(credentials, GEOGRAPHY_TYPE)
             if len(ids) == 0:
                 return []
             elif len(ids) > 0:

--- a/cartoframes/data/observatory/catalog/subscriptions.py
+++ b/cartoframes/data/observatory/catalog/subscriptions.py
@@ -41,10 +41,9 @@ class Subscriptions:
         return self._subscriptions_geographies
 
 
-def get_subscription_ids(credentials):
-    subscriptions = fetch_subscriptions(credentials)
-    subscriptions_ids = list(map(lambda pd: pd.id, subscriptions))
-    return subscriptions_ids
+def get_subscription_ids(credentials, stype=None):
+    subs = fetch_subscriptions(credentials)
+    return [s.id for s in subs if stype is None or stype == s.type]
 
 
 def fetch_subscriptions(credentials):

--- a/tests/unit/data/observatory/catalog/test_dataset.py
+++ b/tests/unit/data/observatory/catalog/test_dataset.py
@@ -378,7 +378,7 @@ class TestDataset(object):
         dataset.subscribe(credentials)
 
         # Then
-        mock_subscription_ids.assert_called_once_with(credentials)
+        mock_subscription_ids.assert_called_once_with(credentials, 'dataset')
         mock_display_form.assert_called_once_with(expected_id, 'dataset', credentials)
         assert not mock_display_message.called
 
@@ -397,7 +397,7 @@ class TestDataset(object):
         dataset.subscribe(credentials)
 
         # Then
-        mock_subscription_ids.assert_called_once_with(credentials)
+        mock_subscription_ids.assert_called_once_with(credentials, 'dataset')
         mock_display_message.assert_called_once_with(expected_id, 'dataset')
         assert not mock_display_form.called
 
@@ -414,7 +414,7 @@ class TestDataset(object):
         dataset.subscribe()
 
         # Then
-        mock_subscription_ids.assert_called_once_with(expected_credentials)
+        mock_subscription_ids.assert_called_once_with(expected_credentials, 'dataset')
         mock_display_form.assert_called_once_with(db_dataset1['id'], 'dataset', expected_credentials)
 
     def test_dataset_subscribe_wrong_credentials(self):

--- a/tests/unit/data/observatory/catalog/test_geography.py
+++ b/tests/unit/data/observatory/catalog/test_geography.py
@@ -327,7 +327,7 @@ class TestGeography(object):
         geography.subscribe(credentials)
 
         # Then
-        mock_subscription_ids.assert_called_once_with(credentials)
+        mock_subscription_ids.assert_called_once_with(credentials, 'geography')
         mock_display_form.assert_called_once_with(expected_id, 'geography', credentials)
         assert not mock_display_message.called
 
@@ -346,7 +346,7 @@ class TestGeography(object):
         geography.subscribe(credentials)
 
         # Then
-        mock_subscription_ids.assert_called_once_with(credentials)
+        mock_subscription_ids.assert_called_once_with(credentials, 'geography')
         mock_display_message.assert_called_once_with(expected_id, 'geography')
         assert not mock_display_form.called
 
@@ -364,7 +364,7 @@ class TestGeography(object):
         geography.subscribe()
 
         # Then
-        mock_subscription_ids.assert_called_once_with(expected_credentials)
+        mock_subscription_ids.assert_called_once_with(expected_credentials, 'geography')
         mock_display_form.assert_called_once_with(db_geography1['id'], 'geography', expected_credentials)
 
     def test_geography_subscribe_wrong_credentials(self):


### PR DESCRIPTION
The bug solved in https://github.com/CartoDB/cartoframes/pull/1583 was because the subscription_ids are mixed (datasets + geography). So the geography ones generate Nones when running `get_datasets` and vice-versa.

This PR implements a type filter in the `get_subscription_ids` so we avoid requesting geographies as datasets, and vice-versa, reducing also the number of requests.