### PR TITLE
Use the the default credentials if present for anonymous calls.

### DIFF
--- a/cartoframes/auth/credentials.py
+++ b/cartoframes/auth/credentials.py
@@ -41,6 +41,7 @@ class Credentials:
             <http://docs.python-requests.org/en/master/user/advanced/>`__
             for more information.
         allow_non_secure (bool, optional): Allow non secure http connections.
+            By default is not allowed.
 
     Raises:
         ValueError: if not available `username` or `base_url` are found.
@@ -203,7 +204,7 @@ class Credentials:
             'username': self._username,
             'api_key': self._api_key,
             'base_url': self._base_url,
-            'allow_non_secure': self._base_url
+            'allow_non_secure': self._allow_non_secure
         }
 
         if config_file is None:

--- a/cartoframes/auth/credentials.py
+++ b/cartoframes/auth/credentials.py
@@ -2,7 +2,6 @@
 
 import os
 
-from urllib.parse import urlparse
 from carto.auth import APIKeyAuthClient
 from carto.do_token import DoTokenManager
 

--- a/cartoframes/auth/credentials.py
+++ b/cartoframes/auth/credentials.py
@@ -52,9 +52,6 @@ class Credentials:
         if not is_valid_str(username) and not is_valid_str(base_url):
             raise ValueError('You must set at least a `username` or a `base_url` parameters')
 
-        if base_url is not None and urlparse(base_url).scheme != 'https':
-            raise ValueError('`base_url`s need to be over `https`. Update your `base_url`.')
-
         self._api_key = api_key
         self._username = username
         self._base_url = base_url or self._base_url_from_username()

--- a/cartoframes/auth/credentials.py
+++ b/cartoframes/auth/credentials.py
@@ -2,6 +2,7 @@
 
 import os
 
+from urllib.parse import urlparse
 from carto.auth import APIKeyAuthClient
 from carto.do_token import DoTokenManager
 
@@ -39,6 +40,7 @@ class Credentials:
             documentation
             <http://docs.python-requests.org/en/master/user/advanced/>`__
             for more information.
+        allow_non_secure (bool, optional): Allow non secure http connections.
 
     Raises:
         ValueError: if not available `username` or `base_url` are found.
@@ -47,9 +49,12 @@ class Credentials:
         >>> creds = Credentials(username='johnsmith', api_key='abcdefg')
 
     """
-    def __init__(self, username=None, api_key='default_public', base_url=None, session=None):
+    def __init__(self, username=None, api_key='default_public', base_url=None, session=None, allow_non_secure=False):
         if not is_valid_str(username) and not is_valid_str(base_url):
             raise ValueError('You must set at least a `username` or a `base_url` parameters')
+
+        if base_url is not None and urlparse(base_url).scheme != 'https' and not allow_non_secure:
+            raise ValueError('`base_url`s need to be over `https`. Update your `base_url` or set `allow_non_secure`.')
 
         self._api_key = api_key
         self._username = username
@@ -57,6 +62,7 @@ class Credentials:
         self._session = session
         self._user_id = None
         self._api_key_auth_client = None
+        self._allow_non_secure = allow_non_secure
 
         self._norm_credentials()
 
@@ -86,6 +92,11 @@ class Credentials:
     def base_url(self):
         """Credentials base_url"""
         return self._base_url
+
+    @property
+    def allow_non_secure(self):
+        """Allow connections non secure over http"""
+        return self._allow_non_secure
 
     @property
     def session(self):
@@ -141,7 +152,9 @@ class Credentials:
                 credentials.get('username'),
                 credentials.get('api_key'),
                 credentials.get('base_url'),
-                session)
+                session,
+                credentials.get('allow_non_secure'),
+            )
         except FileNotFoundError:
             raise FileNotFoundError('There is no default credentials file. '
                                     'Run `Credentials(...).save()` to create a credentials file.')
@@ -169,7 +182,8 @@ class Credentials:
             credentials.username,
             credentials.api_key,
             credentials.base_url,
-            credentials.session)
+            credentials.session,
+            credentials.allow_non_secure)
 
     def save(self, config_file=None):
         """Saves current user credentials to user directory.
@@ -188,7 +202,8 @@ class Credentials:
         content = {
             'username': self._username,
             'api_key': self._api_key,
-            'base_url': self._base_url
+            'base_url': self._base_url,
+            'allow_non_secure': self._base_url
         }
 
         if config_file is None:

--- a/cartoframes/auth/defaults.py
+++ b/cartoframes/auth/defaults.py
@@ -6,7 +6,7 @@ _default_credentials = None
 
 def set_default_credentials(
         first=None, second=None, credentials=None, filepath=None,
-        username=None, base_url=None, api_key=None, session=None):
+        username=None, base_url=None, api_key=None, session=None, allow_non_secure=False):
     """Set default credentials for all operations that require authentication
     against a CARTO account.
 
@@ -100,9 +100,9 @@ def set_default_credentials(
 
     elif isinstance(_base_url or _username, str) and isinstance(_api_key, str):
         if _base_url and is_url(_base_url):
-            _default_credentials = Credentials(base_url=_base_url, api_key=_api_key)
+            _default_credentials = Credentials(base_url=_base_url, api_key=_api_key, allow_non_secure=allow_non_secure)
         else:
-            _default_credentials = Credentials(username=_username, api_key=_api_key)
+            _default_credentials = Credentials(username=_username, api_key=_api_key, allow_non_secure=allow_non_secure)
 
     else:
         _default_credentials = Credentials.from_file()

--- a/cartoframes/data/observatory/catalog/repository/repo_client.py
+++ b/cartoframes/data/observatory/catalog/repository/repo_client.py
@@ -3,6 +3,7 @@ import os
 from carto.do_dataset import DODataset
 
 from .....auth import Credentials
+from .....utils import utils
 
 DEFAULT_USER = 'do-metadata'
 
@@ -11,7 +12,7 @@ class RepoClient:
 
     def __init__(self):
         self._do_dataset = None
-        default_credentials = Credentials(DEFAULT_USER)
+        default_credentials = utils.get_credentials() or Credentials(DEFAULT_USER)
         default_auth_client = default_credentials.get_api_key_auth_client()
         self._default_do_dataset = DODataset(auth_client=default_auth_client)
 

--- a/cartoframes/data/observatory/catalog/repository/repo_client.py
+++ b/cartoframes/data/observatory/catalog/repository/repo_client.py
@@ -2,8 +2,7 @@ import os
 
 from carto.do_dataset import DODataset
 
-from .....auth import Credentials
-from .....utils import utils
+from .....auth import Credentials, defaults
 
 DEFAULT_USER = 'do-metadata'
 
@@ -12,7 +11,7 @@ class RepoClient:
 
     def __init__(self):
         self._do_dataset = None
-        default_credentials = utils.get_credentials() or Credentials(DEFAULT_USER)
+        default_credentials = defaults.get_default_credentials() or Credentials(DEFAULT_USER)
         default_auth_client = default_credentials.get_api_key_auth_client()
         self._default_do_dataset = DODataset(auth_client=default_auth_client)
 


### PR DESCRIPTION
This allows `repo_client` to use the default config set by `set_default_credentials` if present.
Also, I'm removing the `https` requirement for `base_url`


Issue: https://app.clubhouse.io/cartoteam/story/59469/cartoframes-be-able-to-customize-base-path-in-credentials