### PR TITLE
Bump carto-python to version 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add geometry icon to single legends (#1580)
 - Publish Layout (#1598)
+- Upgrade carto-python to version [1.10.0](https://github.com/CartoDB/carto-python/releases/tag/v1.10.0)
 
 ### Changed
 - Use Enrichment API and Metadata API for DO features (#1575)
@@ -142,13 +143,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix DataObsClient (#1319)
 - Fix CartoDataFrame plot (#1339)
 - Fix enrichment without subscriptions (#1314)
-- Fix encoding detection with all Nones (#1346) 
+- Fix encoding detection with all Nones (#1346)
 
 ## [1.0b6] - 2019-12-02
 ### Added
 - Add new properties in Catalog Dataset and Geography (#1209)
 - Add IO functions and CartoDataFrame class (#1130, #1245)
-  - IO functions: read_carto, to_carto, has_table, describe_table, 
+  - IO functions: read_carto, to_carto, has_table, describe_table,
     update_table, copy_table, create_table_from_query, delete_table.
   - CartoDataFrame class: inherit GeoDataFrame class + from_carto, to_carto, viz.
   - Refactor internals: ContextManager, SourceManager.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_version():
 
 REQUIRES = [
     'appdirs>=1.4.3,<2.0',
-    'carto>=1.9.1,<2.0',
+    'carto>=1.10.0,<2.0',
     'jinja2>=2.10.1,<3.0',
     'geopandas>=0.6.0,<1.0',
     'tqdm>=4.32.1,<5.0',


### PR DESCRIPTION
Missing from https://github.com/CartoDB/cartoframes/pull/1594