### PR TITLE
Bump carto-python version to v1.11.1

### DIFF
--- a/cartoframes/__init__.py
+++ b/cartoframes/__init__.py
@@ -5,7 +5,7 @@ from .io.carto import read_carto, to_carto, has_table, delete_table, rename_tabl
 
 
 # Check installed packages versions
-check_package('carto', '>=1.10.0')
+check_package('carto', '>=1.11.1')
 check_package('pandas', '>=0.23.0')
 check_package('geopandas', '>=0.6.0')
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_version():
 
 REQUIRES = [
     'appdirs>=1.4.3,<2.0',
-    'carto>=1.11.0,<2.0',
+    'carto>=1.11.1,<2.0',
     'jinja2>=2.10.1,<3.0',
     'geopandas>=0.6.0,<1.0',
     'tqdm>=4.32.1,<5.0',


### PR DESCRIPTION
It includes the fix for broken metadata queries in Windows (https://github.com/CartoDB/carto-python/pull/167)