### PR TITLE
Use Dollar-quoted strings when getting table names for publishing viz [ch69140]

### DIFF
--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -179,7 +179,7 @@ class ContextManager:
 
     def get_table_names(self, query):
         # Used to detect tables in queries in the publication.
-        query = 'SELECT CDB_QueryTablesText(\'{}\') as tables'.format(query)
+        query = 'SELECT CDB_QueryTablesText($q${}$q$) as tables'.format(query)
         result = self.execute_query(query)
         tables = []
         if result['total_rows'] > 0 and result['rows'][0]['tables']:


### PR DESCRIPTION
Related to https://app.clubhouse.io/cartoteam/story/69140/escaping-single-quotes-inside-functions-calls