### PR TITLE
Remove unneeded 'add_geom' parameter

### DIFF
--- a/cartoframes/data/observatory/catalog/geography.py
+++ b/cartoframes/data/observatory/catalog/geography.py
@@ -176,7 +176,7 @@ class Geography(CatalogEntity):
         return cls._entity_repo.get_all(filters, credentials)
 
     @check_do_enabled
-    def to_csv(self, file_path, credentials=None, limit=None, order_by=None, sql_query=None, add_geom=None):
+    def to_csv(self, file_path, credentials=None, limit=None, order_by=None, sql_query=None):
         """Download geography data as a local csv file. You need Data Observatory enabled in your CARTO
         account, please contact us at support@carto.com for more information.
 
@@ -203,10 +203,10 @@ class Geography(CatalogEntity):
             raise DOError('You are not subscribed to this Geography yet. '
                           'Please, use the subscribe method first.')
 
-        self._download(_credentials, file_path, limit=limit, order_by=order_by, sql_query=sql_query, add_geom=add_geom)
+        self._download(_credentials, file_path, limit=limit, order_by=order_by, sql_query=sql_query)
 
     @check_do_enabled
-    def to_dataframe(self, credentials=None, limit=None, order_by=None, sql_query=None, add_geom=None):
+    def to_dataframe(self, credentials=None, limit=None, order_by=None, sql_query=None):
         """Download geography data as a pandas.DataFrame. You need Data Observatory enabled in your CARTO
         account, please contact us at support@carto.com for more information.
 
@@ -235,7 +235,7 @@ class Geography(CatalogEntity):
             raise DOError('You are not subscribed to this Geography yet. '
                           'Please, use the subscribe method first.')
 
-        return self._download(_credentials, limit=limit, order_by=order_by, sql_query=sql_query, add_geom=add_geom)
+        return self._download(_credentials, limit=limit, order_by=order_by, sql_query=sql_query)
 
     @check_do_enabled
     def subscribe(self, credentials=None):


### PR DESCRIPTION
Fixes https://app.clubhouse.io/cartoteam/story/71127/remove-add-geom-param-from-the-download-methods-of-a-geography