### PR TITLE
Doc: fixed credentials link for set_default_credentials

### DIFF
--- a/cartoframes/auth/defaults.py
+++ b/cartoframes/auth/defaults.py
@@ -13,7 +13,7 @@ def set_default_credentials(
 
     Args:
         credentials (:py:class:`Credentials <cartoframes.credentials.Credentials>`, optional):
-          A :py:class:`Credentials <cartoframes.credentials.Credentials>`
+          A :py:class:`Credentials <cartoframes.auth.Credentials>`
           instance can be used in place of a `username | base_url`/`api_key` combination.
         base_url (str, optional): Base URL of CARTO user account. Cloud-based accounts
           should use the form ``https://{username}.carto.com`` (e.g.,


### PR DESCRIPTION
GH issue: [CARTOframes#1210](https://github.com/CartoDB/cartoframes/issues/1210)
CH story: [ch93700](https://app.clubhouse.io/cartoteam/story/93700/fix-links-in-reference-docs-for-py-class)