### PR TITLE
Removed the batch_size parameter in the call to bulk_geocode

### DIFF
--- a/cartoframes/data/services/utils/geocoding_constants.py
+++ b/cartoframes/data/services/utils/geocoding_constants.py
@@ -1,6 +1,5 @@
 __all__ = [
     'HASH_COLUMN',
-    'BATCH_SIZE',
     'DEFAULT_STATUS',
     'QUOTA_SERVICE',
     'STATUS_FIELDS',
@@ -11,8 +10,6 @@ __all__ = [
 ]
 
 HASH_COLUMN = 'carto_geocode_hash'
-
-BATCH_SIZE = 200
 
 DEFAULT_STATUS = {'gc_status_rel': 'relevance'}
 

--- a/cartoframes/data/services/utils/geocoding_utils.py
+++ b/cartoframes/data/services/utils/geocoding_utils.py
@@ -144,16 +144,14 @@ def geocode_query(table, schema, street, city, state, country, status):
             {street},
             {city},
             {state},
-            {country},
-            {batch_size}
+            {country}
         )
     """.format(
         query=query,
         street=column_name(street),
         city=column_name(city),
         state=column_name(state),
-        country=column_name(country),
-        batch_size=geocoding_constants.BATCH_SIZE
+        country=column_name(country)
     )
 
     status_assignment, status_columns = status_assignment_columns(status)


### PR DESCRIPTION
Removed the `batch_size` parameter in the call to `cdb_dataservices_client.cdb_bulk_geocode_street_point`
Removed `BATCH_SIZE` from `geocoding_constants.py`

https://app.clubhouse.io/cartoteam/story/91890/sociallydetermined-onprem-user-can-t-geocode-in-cf-due-to-batch-size-must-be-lower-than-error