### PR TITLE
Allow to set a value for null geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Pending]
+
+### Changed
+- Allow to set a value for null geometries in the `read_carto` and `Geocoding.geocode` methods (#1667)
+
 ## [1.0.4] - 2020-07-06
 
-## Added
+### Added
 - Add list_tables function (#1649)
 - Add catalog public filter to providers, countries and categories (#1658)
 - Add set_default_do_credentials function for DO authentication (#1655)
 
-## Changed
+### Changed
 - Open publication link in another window (#1647)
 - Show a warning when uploading a GeoDataFrame without geometry (#1650)
 - Improve GeoDataFrame CRS check, docs and examples (#1656)
 
-## Fixed
+### Fixed
 - Fix empty geometries issue (#1652)
 - Fix Layout publication API key issue (#1654)
 - Fix ColumnInfo comparison when replacing a table (#1660)

--- a/cartoframes/data/services/geocoding.py
+++ b/cartoframes/data/services/geocoding.py
@@ -57,7 +57,8 @@ class Geocoding(Service):
                 city=None, state=None, country=None,
                 status=geocoding_constants.DEFAULT_STATUS,
                 table_name=None, if_exists='fail',
-                dry_run=False, cached=None):
+                dry_run=False, cached=None,
+                null_geom_value=None):
         """Geocode method.
 
         Args:
@@ -92,6 +93,8 @@ class Geocoding(Service):
                 table. This parameter should be used along with ``table_name``.
             dry_run (bool, optional): no actual geocoding will be performed (useful to
                 check the needed quota)
+            null_geom_value (Object, optional): value for the `the_geom` column when it's null.
+                Defaults to None
 
         Returns:
             A named-tuple ``(data, metadata)`` containing  either a ``data`` geopandas.GeoDataFrame
@@ -184,7 +187,7 @@ class Geocoding(Service):
         if dry_run:
             return self.result(data=None, metadata=metadata)
 
-        gdf = read_carto(input_table_name, self._credentials)
+        gdf = read_carto(input_table_name, self._credentials, null_geom_value=null_geom_value)
 
         if self._source_manager.is_dataframe() and CARTO_INDEX_KEY in gdf:
             del gdf[CARTO_INDEX_KEY]

--- a/cartoframes/io/carto.py
+++ b/cartoframes/io/carto.py
@@ -17,7 +17,8 @@ IF_EXISTS_OPTIONS = ['fail', 'replace', 'append']
 
 
 @send_metrics('data_downloaded')
-def read_carto(source, credentials=None, limit=None, retry_times=3, schema=None, index_col=None, decode_geom=True):
+def read_carto(source, credentials=None, limit=None, retry_times=3, schema=None, index_col=None, decode_geom=True,
+               null_geom_value=None):
     """Read a table or a SQL query from the CARTO account.
 
     Args:
@@ -32,6 +33,8 @@ def read_carto(source, credentials=None, limit=None, retry_times=3, schema=None,
             `current_schema()` using the credentials.
         index_col (str, optional): name of the column to be loaded as index. It can be used also to set the index name.
         decode_geom (bool, optional): convert the "the_geom" column into a valid geometry column.
+        null_geom_value (Object, optional): value for the `the_geom` column when it's null.
+            Defaults to None
 
     Returns:
         geopandas.GeoDataFrame
@@ -58,6 +61,9 @@ def read_carto(source, credentials=None, limit=None, retry_times=3, schema=None,
     if decode_geom and GEOM_COLUMN_NAME in gdf:
         # Decode geometry column
         set_geometry(gdf, GEOM_COLUMN_NAME, inplace=True)
+
+        if null_geom_value is not None:
+            gdf[GEOM_COLUMN_NAME].fillna(null_geom_value, inplace=True)
 
     return gdf
 

--- a/tests/unit/io/test_carto.py
+++ b/tests/unit/io/test_carto.py
@@ -3,6 +3,7 @@ import pytest
 from pandas import Index
 from geopandas import GeoDataFrame
 from shapely.geometry import Point
+from shapely.geometry.base import BaseGeometry
 
 from cartoframes.auth import Credentials
 from cartoframes.io.managers.context_manager import ContextManager
@@ -36,6 +37,58 @@ def test_read_carto(mocker):
     gdf = read_carto('__source__', CREDENTIALS)
 
     # Then
+    cm_mock.assert_called_once_with('__source__', None, None, 3)
+    assert expected.equals(gdf)
+    assert gdf.crs == 'epsg:4326'
+
+
+def test_read_carto_none_as_null_geom_value(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'copy_to')
+    cm_mock.return_value = GeoDataFrame({
+        'cartodb_id': [1],
+        'the_geom': [
+            None
+        ]
+    })
+
+    # When
+    gdf = read_carto('__source__', CREDENTIALS)
+
+    # Then
+    expected = GeoDataFrame({
+        'cartodb_id': [1],
+        'the_geom': [
+            None
+        ]
+    }, geometry='the_geom')
+
+    cm_mock.assert_called_once_with('__source__', None, None, 3)
+    assert expected.equals(gdf)
+    assert gdf.crs == 'epsg:4326'
+
+
+def test_read_carto_basegeometry_as_null_geom_value(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'copy_to')
+    cm_mock.return_value = GeoDataFrame({
+        'cartodb_id': [1],
+        'the_geom': [
+            None
+        ]
+    })
+
+    # When
+    gdf = read_carto('__source__', CREDENTIALS, null_geom_value=BaseGeometry())
+
+    # Then
+    expected = GeoDataFrame({
+        'cartodb_id': [1],
+        'the_geom': [
+            BaseGeometry()
+        ]
+    }, geometry='the_geom')
+
     cm_mock.assert_called_once_with('__source__', None, None, 3)
     assert expected.equals(gdf)
     assert gdf.crs == 'epsg:4326'


### PR DESCRIPTION
Allow to set a value for null geometries.

The `null_geom_value` can be set when calling `read_carto` or when calling `Geocoding.geocode`. Example:
```
gc = Geocoding()
gdf, metadata = gc.geocode(df, street='address', city='city', country={'value': 'Spain'}, null_geom_value=BaseGeometry())
```

Created new tests in `test_carto.py` but not for `test_geocoding.py` as they are all skipped.

Related to https://app.clubhouse.io/cartoteam/story/94476/axa-group-error-performing-geopandas-operations-on-carto-dataset-because-of-none-values