### PR TITLE
Fix empty popups

### DIFF
--- a/cartoframes/assets/src/bundle.js
+++ b/cartoframes/assets/src/bundle.js
@@ -585,7 +585,7 @@ var init = (function () {
           .setLngLat([event.coordinates.lng, event.coordinates.lat])
           .setHTML(`<div class="popup-content">${popupHTML}</div>`);
 
-      if (!popup.isOpen()) {
+      if (popupHTML.length > 0 && !popup.isOpen()) {
         popup.addTo(map);
       }
     } else {

--- a/cartoframes/assets/src/map/popups.js
+++ b/cartoframes/assets/src/map/popups.js
@@ -51,7 +51,7 @@ export function updatePopup(map, popup, event, attrs) {
         .setLngLat([event.coordinates.lng, event.coordinates.lat])
         .setHTML(`<div class="popup-content">${popupHTML}</div>`);
 
-    if (!popup.isOpen()) {
+    if (popupHTML.length > 0 && !popup.isOpen()) {
       popup.addTo(map);
     }
   } else {


### PR DESCRIPTION
In a map with several layers CF allows us to define different behaviors for the popups of the different layer, but in the front-end the behavior of the popups is defined by map (instead of by layer).

This PR removes the popups from the entities that show empty ones. It's not the ideal fix but the perfect fix would force us to revisit the `Map` and `Layer` models (and maybe the `Feature` one, not sure...).

For now this PR should be harmless because it only removes completely empty popups (if the popup shows the name of the feld it won't be removed), and it works for both hover and click popups