### PR TITLE
Remove None from geometry_types to check validity

### DIFF
--- a/cartoframes/viz/source.py
+++ b/cartoframes/viz/source.py
@@ -95,7 +95,7 @@ class Source:
             self.gdf = self.gdf[~self.gdf.geometry.is_empty]
 
             # Checking the uniqueness of the geometry type
-            geometry_types = set(self.gdf.geom_type.unique())
+            geometry_types = set(self.gdf.geom_type.unique()).difference({None})
             if geometry_types not in VALID_GEOMETRY_TYPES:
                 raise ValueError('No valid geometry column types ({}), it has '.format(geometry_types) +
                                  'to be one of the next type sets: {}.'.format(VALID_GEOMETRY_TYPES))

--- a/tests/unit/viz/test_source.py
+++ b/tests/unit/viz/test_source.py
@@ -7,6 +7,7 @@ from cartoframes.auth import Credentials
 from cartoframes.viz.source import Source
 from cartoframes.io.managers.context_manager import ContextManager
 
+
 POINT = {
     "type": "Feature",
     "geometry": {
@@ -82,6 +83,14 @@ EMPTY = {
     "properties": {}
 }
 
+NONE_GEOMETRY = {
+    "type": "Feature",
+    "geometry": None,
+    "properties": {
+        "prop0": "value0"
+    }
+}
+
 
 def setup_mocks(mocker):
     mocker.patch.object(ContextManager, 'compute_query')
@@ -151,6 +160,26 @@ class TestSource(object):
         [POLYGON, MULTIPOLYGON]
     ])
     def test_different_geometry_types_source(self, features):
+        geojson = {
+            "type": "FeatureCollection",
+            "features": features
+        }
+        gdf = gpd.GeoDataFrame.from_features(geojson)
+        source = Source(gdf)
+
+        assert source.gdf.equals(gdf)
+
+    @pytest.mark.parametrize('features', [
+        [POINT, NONE_GEOMETRY],
+        [MULTIPOINT, NONE_GEOMETRY],
+        [LINESTRING, NONE_GEOMETRY],
+        [MULTILINESTRING, NONE_GEOMETRY],
+        [LINESTRING, MULTILINESTRING, NONE_GEOMETRY],
+        [POLYGON, NONE_GEOMETRY],
+        [MULTIPOLYGON, NONE_GEOMETRY],
+        [POLYGON, MULTIPOLYGON, NONE_GEOMETRY]
+    ])
+    def test_different_geometry_types_source_plus_none(self, features):
         geojson = {
             "type": "FeatureCollection",
             "features": features


### PR DESCRIPTION
The error was:
```
ValueError: No valid geometry column types ({None, 'Point'}), it has to be one of the next type sets: [{'Point'}, {'MultiPoint'}, {'LineString'}, {'MultiLineString'}, {'LineString', 'MultiLineString'}, {'Polygon'}, {'MultiPolygon'}, {'MultiPolygon', 'Polygon'}].
```
when doing
```
from cartoframes.viz import Map, Layer
Map([Layer(geo_gdf)])
```
The workaround is pretty easy:
```
from cartoframes.viz import Map, Layer
Map([Layer(geo_gdf[geo_gdf.the_geom != None])])
```
but we can do it more straightforward by just removing the `None` from the set (`None` can be returned by the geocoder if no results are found for a given address for example).