### PR TITLE
Generate carto_geocode_hash with NULL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Allow to set a value for null geometries in the `read_carto` and `Geocoding.geocode` methods (#1667)
 
+### Fixed
+- Generate carto_geocode_hash with NULL values (#1702)
+
 ## [1.0.4] - 2020-07-06
 
 ### Added

--- a/cartoframes/data/services/utils/geocoding_utils.py
+++ b/cartoframes/data/services/utils/geocoding_utils.py
@@ -55,8 +55,8 @@ def prefixed_column_or_value(attr, prefix):
 
 def hash_expr(street, city, state, country, table_prefix=None):
     street, city, state, country = (prefixed_column_or_value(v, table_prefix) for v in (street, city, state, country))
-    hashed_expr = " || '<>' || ".join([street, city or "''", state or "''", country or "''"])
-    return "md5({hashed_expr})".format(hashed_expr=hashed_expr)
+    hashed_cols = ", '<>' , ".join([street, city or "''", state or "''", country or "''"])
+    return "md5(concat({hashed_cols}))".format(hashed_cols=hashed_cols)
 
 
 def needs_geocoding_expr(hash_expr):


### PR DESCRIPTION
Use concat instead of || to avoid generating NULL strings

References ch102254