### PR TITLE
Mmoncadaisla/formula widget count operation

### DIFF
--- a/cartoframes/viz/widgets/formula_widget.py
+++ b/cartoframes/viz/widgets/formula_widget.py
@@ -50,7 +50,7 @@ def formula_widget(value, operation=None, title=None, description=None, footer=N
 
 
 def _get_value_expression(operation, value, is_global):
-    if value == 'count' or operation == 'count':
+    if operation == 'count':
         formula_operation = _get_formula_operation('count', is_global)
         return formula_operation + '()'
     elif operation in ['avg', 'max', 'min', 'sum']:

--- a/tests/unit/viz/widgets/test_formula_widget.py
+++ b/tests/unit/viz/widgets/test_formula_widget.py
@@ -16,13 +16,13 @@ class TestFormulaWidget(object):
 
     def test_count_formula_viewport(self):
         "should create a formula widget to count viewport features"
-        widget = widgets.formula_widget('count')
+        widget = widgets.formula_widget('value', operation='count')
         widget_info = widget.get_info()
         assert widget_info.get('value') == 'viewportCount()'
 
     def test_count_formula_global(self):
         "should create a formula widget to count global features"
-        widget = widgets.formula_widget('count', is_global=True)
+        widget = widgets.formula_widget('value', operation='count', is_global=True)
         widget_info = widget.get_info()
         assert widget_info.get('value') == 'globalCount()'
 


### PR DESCRIPTION
This small PR from Support aims to fix a small bug, in which if the column to be used in a formula widget is named 'count', the aggregation performed is currently `'count'` regardless of the `operation`.

More details here: https://app.clubhouse.io/cartoteam/story/119026/cartoframes-formula-widget-misbehavior-when-column-is-named-count 

This PR contains two file modifications:

- Formula widget: perform an evaluation on 'operation' parameter only 

- Formula widget unit tests (viewport + global): create a formula widget with `operation='count'` 

Result after changes using `sum` operation:

![image](https://user-images.githubusercontent.com/48254102/99071715-f59c4e00-25b2-11eb-8afe-e76340a64b3e.png)
