### PR TITLE
Change iterrows method for index attribute in row data generation

### DIFF
--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -443,7 +443,7 @@ def _create_auth_client(credentials, public=False):
 
 
 def _compute_copy_data(df, columns):
-    for index, _ in df.iterrows():
+    for index in df.index:
         row_data = []
         for column in columns:
             val = df.at[index, column.name]


### PR DESCRIPTION
## Context

This small PR from Support aims to perform a minor change on the `_compute_copy_data` function [used by `_copy_from`](https://github.com/CartoDB/cartoframes/blob/9c41177d9593219d83ba10c7db78e39d87d4352c/cartoframes/io/managers/context_manager.py#L368) and at the same time by `to_carto`, to improve performance when dealing with large datasets in terms of rows and columns.

The referred function is currently using the [`pandas.DataFrame.iterrows()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iterrows.html) method, which retrieves both the row index and a Series containing column values but only using the index afterward.

Further context can be found in [this CH story](https://app.clubhouse.io/cartoteam/story/119037/cartoframes-to-carto-chance-for-performance-improvement).

## PR changes

This PR contains one file modification:

- context_manager: previously referred change in the `_compute_copy_data` function

## Detected potential improvement

After performing a test with a 100.000 x 10 (rows x cols) dummy DataFrame, it seems that there could be a timing difference,

```python
df = pd.DataFrame([np.arange(10) for number_rows in range(100000)])
```
![image](https://user-images.githubusercontent.com/48254102/99994234-0883ff00-2db9-11eb-9993-3f35f923af7b.png)

Moreover, a single `to_carto` test performed against `mmoncada` account using a 722720 rows x 172 columns retrieved the following results,

### A) With index instead of iterrows()

```
Geometry column not found in the GeoDataFrame.
Success! Data uploaded to table "test_upload_full_1" correctly
CPU times: user 18min 55s, sys: 20.2 s, total: 19min 15s
Wall time: 23min 26s
'test_upload_full_1'
```

### B) With actual iterrows()

```
Geometry column not found in the GeoDataFrame.
Success! Data uploaded to table "test_upload_full_2" correctly
CPU times: user 23min 30s, sys: 50.3 s, total: 24min 21s
Wall time: 30min 27s
```