### PR TITLE
Fix timestamptz read carto

### DIFF
--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -147,7 +147,7 @@ def pg2dtypes(pgtype):
         'boolean': 'bool', 'bool': 'bool',
         'date': 'datetime64[D]',
         'timestamp': 'datetime64[ns]', 'timestamp without time zone': 'datetime64[ns]',
-        'timestampz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
+        'timestamptz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
         'USER-DEFINED': 'object',
     }
     return mapping.get(str(pgtype), 'object')

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -155,7 +155,7 @@ class TestUtils(unittest.TestCase):
             'boolean': 'bool',
             'date': 'datetime64[D]',
             'timestamp': 'datetime64[ns]', 'timestamp without time zone': 'datetime64[ns]',
-            'timestampz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
+            'timestamptz': 'datetime64[ns]', 'timestamp with time zone': 'datetime64[ns]',
             'USER-DEFINED': 'object',
         }
         for i in results:


### PR DESCRIPTION
## Context 
In this small PR from Support we aim to fix a small bug in the `pg2dtypes` function which causes timestamp with time zone dtypes columns to be read as object data type columns in GeoPandas. 

Further details can be found in [this CH story](https://app.clubhouse.io/cartoteam/story/136771/cartoframes-timestamptz-is-read-as-object-when-using-read-carto).

## PR changes

- `utils`: fix the small typo causing the error for timestamptz dtype
- `test_utils`: fix corresponding unit test

## Result with PR changes

```python
>>> import cartoframes
>>> cartoframes.auth.set_default_credentials(username='mmoncada', api_key='1d9f28a0e83f7793c371ecc4cd4be5e87ac0687c')
>>> gdf = cartoframes.read_carto('test_timestamptz_cartoframes')
>>> gdf.dtypes
cartodb_id                  int64
the_geom                 geometry
field_1                     int64
county_fip                  int64
fips                        int64
housing_un                 object
county                     object
state_name                 object
created_at    datetime64[ns, UTC]
updated_at    datetime64[ns, UTC]
state_fips                  int64
monday                      int64
tuesday                     int64
wednesday                   int64
thursday                    int64
dtype: object
```