### PR TITLE
Avoid renaming geometry if geometry name is already GEOM_COLUMN_NAME

### DIFF
--- a/cartoframes/io/carto.py
+++ b/cartoframes/io/carto.py
@@ -156,7 +156,8 @@ def to_carto(dataframe, table_name, credentials=None, if_exists='fail', geom_col
             gdf.drop(columns=[GEOM_COLUMN_NAME], inplace=True)
 
         # Prepare geometry column for the upload
-        gdf.rename_geometry(GEOM_COLUMN_NAME, inplace=True)
+        if dataframe.geometry.name != GEOM_COLUMN_NAME:
+            gdf.rename_geometry(GEOM_COLUMN_NAME, inplace=True)
 
     elif isinstance(dataframe, GeoDataFrame):
         log.warning('Geometry column not found in the GeoDataFrame.')


### PR DESCRIPTION
### Context

In this small PR from Support we aim to fix an undesired behavior when using the `rename_geometry` method from the `to_carto` function. 

Since the latest additions to GeoPandas, if the column name to be used as input for the referred function is already present in the GeoDataFrame columns, an error would be raised, which seems to break data uploads when the geometry column is named `the_geom`.

Further details can be found in [this CH story](https://app.clubhouse.io/cartoteam/story/141147/cartoframes-geopandas-rename-geometry-raises-error-in-to-carto-if-geometry-name-is-the-geom).

### PR changes
io/carto.py: Avoid using the `rename_geometry` method if the GeoDataFrame's geometry column is named as *GEOM_COLUMN_NAME* (the_geom)

### Result with PR changes

```python
>>> import cartoframes
>>> cartoframes.auth.set_default_credentials(username='mmoncada', api_key='master_api_key')
>>> gdf = cartoframes.read_carto('cod')
>>> gdf.head()
   cartodb_id                                           the_geom  fid  cod_postal
0          18  MULTIPOLYGON (((-2.21981 43.03500, -2.21978 43...    5     20213.0
1          23  MULTIPOLYGON (((-3.05027 37.78892, -3.04790 37...    7     23487.0
2          32  MULTIPOLYGON (((-3.50303 40.52600, -3.50304 40...   10     28864.0
3          39  MULTIPOLYGON (((-2.54156 38.20036, -2.52919 38...   12     23297.0
4          43  MULTIPOLYGON (((-5.95369 37.99535, -5.95369 37...   13     41250.0
>>> cartoframes.to_carto(gdf, 'cod_test_2')
Success! Data uploaded to table "cod_test_2" correctly
'cod_test_2'
```
