### PR TITLE
Avoid batch api to carto create table

### DIFF
--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -283,7 +283,7 @@ class ContextManager:
         query = 'BEGIN; {create}; {cartodbfy}; COMMIT;'.format(
             create=_create_table_from_columns_query(table_name, columns),
             cartodbfy=_cartodbfy_query(table_name, schema) if cartodbfy else '')
-        self.execute_long_running_query(query)
+        self.execute_query(query)
 
     def _truncate_table(self, table_name, schema, cartodbfy):
         log.debug('TRUNCATE table "{}"'.format(table_name))

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -290,7 +290,7 @@ class ContextManager:
         query = 'BEGIN; {truncate}; {cartodbfy}; COMMIT;'.format(
             truncate=_truncate_table_query(table_name),
             cartodbfy=_cartodbfy_query(table_name, schema) if cartodbfy else '')
-        self.execute_long_running_query(query)
+        self.execute_query(query)
 
     def _truncate_and_drop_add_columns(self, table_name, schema, df_columns, table_columns, cartodbfy):
         log.debug('TRUNCATE AND DROP + ADD columns table "{}"'.format(table_name))

--- a/tests/unit/io/managers/test_context_manager.py
+++ b/tests/unit/io/managers/test_context_manager.py
@@ -62,7 +62,7 @@ class TestContextManager(object):
         mocker.patch('cartoframes.io.managers.context_manager._create_auth_client')
         mocker.patch.object(ContextManager, 'has_table', return_value=False)
         mocker.patch.object(ContextManager, 'get_schema', return_value='schema')
-        mock_create_table = mocker.patch.object(ContextManager, 'execute_long_running_query')
+        mock_create_table = mocker.patch.object(ContextManager, 'execute_query')
         mock = mocker.patch.object(ContextManager, '_copy_from')
         df = DataFrame({'A': [1]})
         columns = [ColumnInfo('A', 'a', 'bigint', False)]


### PR DESCRIPTION
### Context

In this small PR from Support we aim to avoid an undesired behavior when using the `to_carto` function while a Batch API job is already running, by using the standard SQL API endpoint when possible. 

If the table wouldn't exist in the target CARTO account, it'd be created through the `_create_table_from_columns` method which seems to be using the Batch API for what seems a light operation (create table + _cartodbfy_ an empty table).

This could lead to an undesired behavior if there is an active long-time running job, as the referred operation would be enqueued. 

Further details can be found in [this CH story](https://app.clubhouse.io/cartoteam/story/146492/cartoframes-to-carto-create-table-is-enqueued-if-another-batch-api-job-is-running).

>NOTE: We're unsure there's any other block where this could be implemented safely without reaching any timeout limitation, such as [here](https://github.com/CartoDB/cartoframes/blob/1fbad8406b864ea6b1b6b040af2c6fe622e6e129/cartoframes/io/managers/context_manager.py#L288-L293), and please let us know if there is any approach that'd make more sense for this purpose 🙏🏼 

### PR changes
- io/managers/context_manager.py: Use `execute_query` instead of `execute_long_running_query` in `_create_table_from_columns`
- tests/unit/io/managers/test_context_manager.py: Check that `execute_query` is ran instead of `execute_long_running_query` in `test_copy_from` 