### PR TITLE
Bug/ch155055/emily mo inconsistent to carto error

### DIFF
--- a/cartoframes/data/services/service.py
+++ b/cartoframes/data/services/service.py
@@ -1,4 +1,3 @@
-import uuid
 from collections import namedtuple
 
 from ...io.managers.context_manager import ContextManager

--- a/cartoframes/data/services/service.py
+++ b/cartoframes/data/services/service.py
@@ -2,6 +2,7 @@ import uuid
 from collections import namedtuple
 
 from ...io.managers.context_manager import ContextManager
+from ...utils.utils import create_tmp_name
 
 SERVICE_KEYS = ('hires_geocoder', 'isolines')
 QUOTA_INFO_KEYS = ('monthly_quota', 'used_quota', 'soft_limit', 'provider')
@@ -48,7 +49,7 @@ class Service:
         return self._context_manager.get_schema()
 
     def _new_temporary_table_name(self, base=None):
-        return (base or 'table') + '_' + uuid.uuid4().hex[:10]
+        return create_tmp_name(base=base or 'table')
 
     def _execute_query(self, query):
         return self._context_manager.execute_query(query)

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -166,7 +166,8 @@ class ContextManager:
         self.execute_query(query)
         return function_name
 
-    def _create_function(self, schema, statement, function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
+    def _create_function(self, schema, statement,
+        function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
         function_name = function_name or create_tmp_name(base='tmp_func')
         safe_schema = double_quote(schema)
         query, qualified_func_name = _create_function_query(

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -420,6 +420,7 @@ class ContextManager:
             log.debug('Table name normalized: "{}"'.format(norm_table_name))
         return norm_table_name
 
+
 def _drop_table_query(table_name, if_exists=True):
     return 'DROP TABLE {if_exists} {table_name}'.format(
         table_name=table_name,

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -167,7 +167,7 @@ class ContextManager:
         return function_name
 
     def _create_function(self, schema, statement,
-        function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
+    function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
         function_name = function_name or create_tmp_name(base='tmp_func')
         safe_schema = double_quote(schema)
         query, qualified_func_name = _create_function_query(

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -167,13 +167,14 @@ class ContextManager:
 
     def _create_function(self, schema, statement, function_name=None, language='plpgsql'):
         function_name = function_name or create_tmp_name(base='tmp_func')
+        safe_schema = '"{schema}"'.format(schema=schema)
         query = _create_function_query(
-            schema=schema,
+            schema=safe_schema,
             function_name=function_name,
             statement=statement,
             language=language)
         self.execute_query(query)
-        return '{schema}.{function_name}'.format(schema=schema, function_name=function_name)
+        return '{safe_schema}.{function_name}'.format(safe_schema=safe_schema, function_name=function_name)
 
     def rename_table(self, table_name, new_table_name, if_exists='fail'):
         new_table_name = self.normalize_table_name(new_table_name)

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -437,7 +437,7 @@ def _drop_function_query(function_name, columns_types=None, if_exists=True):
     return 'DROP FUNCTION {if_exists} {function_name}{columns_str_call}'.format(
         function_name=function_name,
         if_exists='IF EXISTS' if if_exists else '',
-        columns_str_call='({columns_str})' if columns else '')
+        columns_str_call='({columns_str})'.format(columns_str=columns_str) if columns else '')
 
 
 def _truncate_table_query(table_name):

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -430,7 +430,7 @@ def _drop_table_query(table_name, if_exists=True):
 
 def _drop_function_query(function_name, columns_types=None, if_exists=True):
     if columns_types and not isinstance(columns_types, dict):
-            raise ValueError('The columns_types parameter should be a dictionary of column names and types.')
+        raise ValueError('The columns_types parameter should be a dictionary of column names and types.')
     columns_types = columns_types or {}
     columns = ['{0} {1}'.format(cname, ctype) for cname, ctype in columns_types.items()]
     columns_str = ','.join(columns)

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -167,7 +167,7 @@ class ContextManager:
         return function_name
 
     def _create_function(self, schema, statement,
-    function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
+                         function_name=None, columns_types=None, return_value='VOID', language='plpgsql'):
         function_name = function_name or create_tmp_name(base='tmp_func')
         safe_schema = double_quote(schema)
         query, qualified_func_name = _create_function_query(

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -420,11 +420,11 @@ class ContextManager:
             log.debug('Table name normalized: "{}"'.format(norm_table_name))
         return norm_table_name
 
-
 def _drop_table_query(table_name, if_exists=True):
     return 'DROP TABLE {if_exists} {table_name}'.format(
         table_name=table_name,
         if_exists='IF EXISTS' if if_exists else '')
+
 
 def _drop_function_query(function_name, params_dtypes=None, if_exists=True):
     return 'DROP FUNCTION {if_exists} {function_name}({params_dtypes})'.format(
@@ -432,9 +432,11 @@ def _drop_function_query(function_name, params_dtypes=None, if_exists=True):
         if_exists='IF EXISTS' if if_exists else '',
         params_dtypes=params_dtypes or '')
 
+
 def _truncate_table_query(table_name):
     return 'TRUNCATE TABLE {table_name}'.format(
         table_name=table_name)
+
 
 def _create_function_query(schema, function_name, statement, language):
     function_query = '''
@@ -449,6 +451,7 @@ def _create_function_query(schema, function_name, statement, language):
                statement=statement,
                language=language)
     return function_query
+
 
 def _drop_columns_query(table_name, columns):
     columns = ['DROP COLUMN {name}'.format(name=double_quote(c.dbname))

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -400,6 +400,9 @@ def encode_row(row):
 def create_hash(value):
     return hashlib.md5(str(value).encode()).hexdigest()
 
+def create_tmp_name(base=None):
+    from uuid import uuid4
+    return (base + '_' if base else '') + uuid4().hex[:10]
 
 def extract_viz_columns(viz):
     """Extract columns prop('name') in viz"""

--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -400,9 +400,12 @@ def encode_row(row):
 def create_hash(value):
     return hashlib.md5(str(value).encode()).hexdigest()
 
+
 def create_tmp_name(base=None):
+    """Create temporary name using uuid"""
     from uuid import uuid4
     return (base + '_' if base else '') + uuid4().hex[:10]
+
 
 def extract_viz_columns(viz):
     """Extract columns prop('name') in viz"""


### PR DESCRIPTION
### Context

In this small PR from Support we aim to avoid hitting the Batch API 16 kb payload limit when using the [`_truncate_and_drop_add_columns`](https://github.com/CartoDB/cartoframes/blob/1fbad8406b864ea6b1b6b040af2c6fe622e6e129/cartoframes/io/managers/context_manager.py#L295-L303) function, which is called from `to_carto` (through `copy_from`) with `if_exists='replace'` collision strategy if the table structure changes used and the table has a considerable amount of columns. 

Further context can be found here: https://app.clubhouse.io/cartoteam/story/155055/emily-mo-inconsistent-to-carto-error 

### Proposed solution

1. Create a temporary PostgreSQL user defined function through a standard SQL API call with the required changes
2. Apply this function in the transaction (after the _TRUNCATE_ operation and before the cartodbfication process)
3. Drop the temporary function

Example output with the current logic 

```python
CartoException: ['Your payload is too large: 18745 bytes. Max size allowed is 16384 bytes (16kb). Are you trying to import data?. Please, check out import api http://docs.cartodb.com/cartodb-platform/import-api/']
```

Example output with the changes implemented

```
Success! Data uploaded to table "test_to_carto_truncate_drop_add_" correctly
'test_to_carto_truncate_drop_add_'
```

We have also verified that the temporary function is dropped as expected.

### PR changes

#### Relevant
- `io/managers/context_manager.py` where the logic referred above is implemented. Add helper functions for query definition, add functions to create and drop UDFs and perform necessary changes in the `_truncate_and_drop_add_columns` function

#### Minor
- `utils/utils.py` add a function `create_tmp_name` to create temporary-like names using uuid
- `/data/services/service.py` adapt the `_new_temporary_table_name` method to make use of the `create_tmp_name` function