### PR TITLE
Feature/ch157435/cartoframes to carto performance evaluation

### DIFF
--- a/tests/unit/io/managers/test_context_manager.py
+++ b/tests/unit/io/managers/test_context_manager.py
@@ -108,7 +108,7 @@ class TestContextManager(object):
         cm.copy_from(df, 'TABLE NAME', 'replace')
 
         # Then
-        mock.assert_called_once_with('table_name', 'schema', columns, [], True)
+        mock.assert_called_once_with('table_name', 'schema', columns, [])
 
     def test_copy_from_exists_replace_truncate(self, mocker):
         # Given
@@ -124,7 +124,7 @@ class TestContextManager(object):
         cm.copy_from(df, 'TABLE NAME', 'replace')
 
         # Then
-        mock.assert_called_once_with('table_name', 'schema', True)
+        mock.assert_called_once_with('table_name', 'schema')
 
     def test_internal_copy_from(self, mocker):
         # Given

--- a/tests/unit/io/managers/test_context_manager.py
+++ b/tests/unit/io/managers/test_context_manager.py
@@ -73,7 +73,7 @@ class TestContextManager(object):
 
         # Then
         mock_create_table.assert_called_once_with('''
-            BEGIN; CREATE TABLE table_name ("a" bigint); SELECT CDB_CartodbfyTable(\'schema\', \'table_name\'); COMMIT;
+            BEGIN; CREATE TABLE table_name ("a" bigint); COMMIT;
         '''.strip())
         mock.assert_called_once_with(df, 'table_name', columns, DEFAULT_RETRY_TIMES)
 


### PR DESCRIPTION
### Context

In this small PR from Support we aim the following two things:

1. Increase `to_carto` performance, further context can be found here: https://app.clubhouse.io/cartoteam/story/157435/cartoframes-to-carto-performance-evaluation 
2. Mitigate a corner case bug on the `CDB_TableMetadata_Trigger` from the CARTOframes side (except if using `to_carto` with `if_exists='append'` on a cartodbfied table), further context could be found here: https://app.clubhouse.io/cartoteam/story/149748/farmers-insurance-admin-duplicate-key-value-violates-unique-constraint-cdb-tablemetadata-pkey-using-to-carto#activity-159580

### Proposed solution

Change the order in which the cartodbfication process is being performed, to be performed after the COPY from operation is done to prevent triggers from 1) reducing the overall upload process performance, and 2) potentially raise an unexpected error due to the `CDB_TableMetadata_Trigger`.

### PR changes

- `io/managers/context_manager.py` remove the cartodbfication step from the corresponding functions (e.g:  `create_table_from_query`) and perform this step through the Batch API after the copy_from is performed (except if `'append'` is used or the user explicitly sets `cartodbfy=False` in the `to_carto` function call.
- `tests/unit/io/managers/test_context_manager.py` adapt corresponding tests (e.g: `test_copy_from_exists_replace_truncate`)