### PR TITLE
Bug/ch166870/cardamon dna cartoframes kuviz uses cached

### DIFF
--- a/cartoframes/data/clients/auth_api_client.py
+++ b/cartoframes/data/clients/auth_api_client.py
@@ -38,6 +38,11 @@ class AuthAPIClient:
         except Exception as e:
             if str(e) == 'Validation failed: Name has already been taken':
                 api_key = self._api_key_manager.get(name)
+                granted_tables = list(map(lambda x: x.name, api_key.grants.tables))
+                if name == 'cartoframes_{}'.format(create_hash(tables_names)):
+                    if len(granted_tables) == 0 or any(table not in granted_tables for table in tables_names):
+                        api_key.delete()
+                        api_key = self._api_key_manager.create(name, apis, tables)
             else:
                 raise e
 

--- a/cartoframes/data/clients/auth_api_client.py
+++ b/cartoframes/data/clients/auth_api_client.py
@@ -41,7 +41,7 @@ class AuthAPIClient:
                 api_key = self._api_key_manager.get(name)
                 granted_tables = list(map(lambda x: x.name, api_key.grants.tables))
                 if name == 'cartoframes_{}'.format(create_hash(tables_names)):
-                    if len(granted_tables) == 0 or any(table not in granted_tables for table in tables_names):
+                    if not granted_tables or any(table not in granted_tables for table in tables_names):
                         api_key.delete()
                         api_key = self._api_key_manager.create(name, apis, tables)
             else:

--- a/cartoframes/data/clients/auth_api_client.py
+++ b/cartoframes/data/clients/auth_api_client.py
@@ -30,18 +30,25 @@ class AuthAPIClient:
                 tables.append(_get_table_dict(source.schema(), table_name, permissions))
                 tables_names.append(table_name)
 
+        tables_names.sort()
+        gen_name = 'cartoframes_{}'.format(create_hash(tables_names))
+
         if name is None:
-            tables_names.sort()
-            name = 'cartoframes_{}'.format(create_hash(tables_names))
+            name = gen_name
 
         try:
+            # Try to create the API key
             api_key = self._api_key_manager.create(name, apis, tables)
         except Exception as e:
             if str(e) == 'Validation failed: Name has already been taken':
+                # If the API key already exists, use it
                 api_key = self._api_key_manager.get(name)
-                granted_tables = list(map(lambda x: x.name, api_key.grants.tables))
-                if name == 'cartoframes_{}'.format(create_hash(tables_names)):
+                if name == gen_name:
+                    # For auto-generated API key, check its grants for the tables
+                    granted_tables = list(map(lambda x: x.name, api_key.grants.tables))
                     if not granted_tables or any(table not in granted_tables for table in tables_names):
+                        # If the API key does not grant all the tables (broken API key),
+                        # delete it and create a new one with the same name
                         api_key.delete()
                         api_key = self._api_key_manager.create(name, apis, tables)
             else:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_version():
 
 REQUIRES = [
     'appdirs>=1.4.3,<2.0',
-    'carto>=1.11.2,<2.0',
+    'carto>=1.11.3,<2.0',
     'jinja2>=2.10.1,<3.0',
     'pandas>=0.25.0',
     'geopandas>=0.6.0,<1.0',

--- a/tests/unit/auth/test_auth_api_client.py
+++ b/tests/unit/auth/test_auth_api_client.py
@@ -29,8 +29,8 @@ class TestAuthAPIClient(object):
     def test_create_api_key(self, mocker):
         setup_mocks(mocker)
 
-        source = Source('fake_table', credentials=Credentials('fakeuser'))
-        api_key_name = 'fake_name'
+        source = Source('fake_table', credentials=Credentials('fake_user'))
+        api_key_name = 'fake_api_key_name'
 
         auth_api_client = AuthAPIClient()
         name, token, tables = auth_api_client.create_api_key([source], name=api_key_name)
@@ -41,11 +41,37 @@ class TestAuthAPIClient(object):
     def test_create_api_key_several_sources(self, mocker):
         setup_mocks(mocker)
 
-        source = Source('fake_table', credentials=Credentials('fakeuser'))
-        api_key_name = 'fake_name'
+        source = Source('fake_table', credentials=Credentials('fake_user'))
+        api_key_name = 'fake_api_key_name'
 
         auth_api_client = AuthAPIClient()
         name, token, tables = auth_api_client.create_api_key([source, source, source], name=api_key_name)
+
+        assert name == api_key_name
+        assert token == TOKEN_MOCK
+
+    def test_create_api_key_exists(self, mocker):
+        setup_mocks(mocker)
+
+        source = Source('fake_table', credentials=Credentials('fake_user'))
+        api_key_name = 'cartoframes_d751713988987e9331980363e24189ce'
+
+        auth_api_client = AuthAPIClient()
+        auth_api_client.create_api_key([source], name=api_key_name)  # Create working API key
+        name, token, tables = auth_api_client.create_api_key([source], name=api_key_name)
+
+        assert name == api_key_name
+        assert token == TOKEN_MOCK
+
+    def test_create_api_key_exists_broken(self, mocker):
+        setup_mocks(mocker)
+
+        source = Source('fake_table', credentials=Credentials('fake_user'))
+        api_key_name = 'cartoframes_d751713988987e9331980363e24189ce'
+
+        auth_api_client = AuthAPIClient()
+        auth_api_client.create_api_key([], name=api_key_name)  # Create broken API key
+        name, token, tables = auth_api_client.create_api_key([source], name=api_key_name)
 
         assert name == api_key_name
         assert token == TOKEN_MOCK

--- a/tests/unit/mocks/api_key_mock.py
+++ b/tests/unit/mocks/api_key_mock.py
@@ -1,16 +1,37 @@
+class TableMock():
+    def __init__(self, name):
+        self.name = name
+
+
+class GrantsMock():
+    def __init__(self, tables):
+        self.tables = [TableMock(table) for table in tables]
+
+
 class APIKeyMock():
-    def __init__(self, name, token):
+    def __init__(self, name, token, tables):
         self.name = name
         self.token = token
         self.type = None
         self.created_at = None
         self.updated_at = None
-        self.grants = None
+        self.grants = GrantsMock(tables)
+        self.exists = True
+
+    def delete(self):
+        self.exists = False
 
 
 class APIKeyManagerMock():
     def __init__(self, token=''):
         self.token = token
+        self.api_keys = {}
 
     def create(self, name, apis, tables):
-        return APIKeyMock(name, self.token)
+        if name in self.api_keys and self.api_keys[name].exists:
+            raise Exception('Validation failed: Name has already been taken')
+        self.api_keys[name] = APIKeyMock(name, self.token, tables)
+        return self.api_keys[name]
+
+    def get(self, name):
+        return self.api_keys[name]


### PR DESCRIPTION
## Resources
[Clubhouse story](https://app.clubhouse.io/cartoteam/story/166870/cardamon-dna-cartoframes-kuviz-uses-cached-api-key-without-permissions-upon-map-publication)

## Context
When a user follows these steps, the visualization is not working correctly:

- Publish a map that depends on a table
- Delete this table
- Import a dataset with the same name as the erased table, so the table name will be the same
- Try to visualize the map

## Changes

- [x] Generate a new API KEY if the existing one does not have permissions on the needed tables when publishing a visualization

- [x] Add tests