### PR TITLE
Add cartodbfy step for create_table_from_query and copy_table functions

### DIFF
--- a/cartoframes/io/carto.py
+++ b/cartoframes/io/carto.py
@@ -304,12 +304,7 @@ def copy_table(table_name, new_table_name, credentials=None, if_exists='fail', l
     query = 'SELECT * FROM {}'.format(table_name)
 
     context_manager = ContextManager(credentials)
-    new_table_name = context_manager.create_table_from_query(query, new_table_name, if_exists)
-
-    if cartodbfy is True:
-        schema = context_manager.get_schema()
-        cartodbfy_query = _cartodbfy_query(new_table_name, schema)
-        context_manager.execute_long_running_query(cartodbfy_query)
+    new_table_name = context_manager.create_table_from_query(query, new_table_name, if_exists, cartodbfy)
 
     if log_enabled:
         log.info('Success! Table "{0}" copied to table "{1}" correctly'.format(table_name, new_table_name))
@@ -348,12 +343,7 @@ def create_table_from_query(
             ', '.join(IF_EXISTS_OPTIONS)))
 
     context_manager = ContextManager(credentials)
-    new_table_name = context_manager.create_table_from_query(query, new_table_name, if_exists)
-
-    if cartodbfy is True:
-        schema = context_manager.get_schema()
-        cartodbfy_query = _cartodbfy_query(new_table_name, schema)
-        context_manager.execute_long_running_query(cartodbfy_query)
+    new_table_name = context_manager.create_table_from_query(query, new_table_name, if_exists, cartodbfy)
 
     if log_enabled:
         log.info('Success! Table "{0}" created correctly'.format(new_table_name))

--- a/cartoframes/io/carto.py
+++ b/cartoframes/io/carto.py
@@ -6,7 +6,7 @@ from geopandas import GeoDataFrame
 
 from carto.exceptions import CartoException
 
-from .managers.context_manager import ContextManager, _compute_copy_data, get_dataframe_columns_info, _cartodbfy_query
+from .managers.context_manager import ContextManager, _compute_copy_data, get_dataframe_columns_info
 from ..utils.geom_utils import is_reprojection_needed, reproject, has_geometry, set_geometry
 from ..utils.logger import log
 from ..utils.utils import is_valid_str, is_sql_query

--- a/cartoframes/io/managers/context_manager.py
+++ b/cartoframes/io/managers/context_manager.py
@@ -122,7 +122,7 @@ class ContextManager:
 
         return table_name
 
-    def create_table_from_query(self, query, table_name, if_exists):
+    def create_table_from_query(self, query, table_name, if_exists, cartodbfy=True):
         schema = self.get_schema()
         table_name = self.normalize_table_name(table_name)
 
@@ -139,6 +139,10 @@ class ContextManager:
                 pass
         else:
             self._drop_create_table_from_query(table_name, schema, query)
+
+        if cartodbfy is True:
+            cartodbfy_query = _cartodbfy_query(table_name, schema)
+            self.execute_long_running_query(cartodbfy_query)
 
         return table_name
 

--- a/tests/unit/io/managers/test_context_manager.py
+++ b/tests/unit/io/managers/test_context_manager.py
@@ -291,3 +291,16 @@ class TestContextManager(object):
 
         # Then
         mock.assert_called_with("SELECT CDB_CartodbfyTable('schema', '__new_table_name__')")
+
+    def test_create_table_from_query_cartodbfy_default(self, mocker):
+        # Given
+        mocker.patch.object(ContextManager, 'has_table', return_value=False)
+        mocker.patch.object(ContextManager, 'get_schema', return_value='schema')
+        mock = mocker.patch.object(ContextManager, 'execute_long_running_query')
+
+        # When
+        cm = ContextManager(self.credentials)
+        cm.create_table_from_query('SELECT * FROM table_name', '__new_table_name__', if_exists='fail')
+
+        # Then
+        mock.assert_called_with("SELECT CDB_CartodbfyTable('schema', '__new_table_name__')")

--- a/tests/unit/io/managers/test_context_manager.py
+++ b/tests/unit/io/managers/test_context_manager.py
@@ -278,3 +278,16 @@ class TestContextManager(object):
 
         with pytest.raises(CartoRateLimitException):
             test_function(retry_times=0)
+
+    def test_create_table_from_query_cartodbfy(self, mocker):
+        # Given
+        mocker.patch.object(ContextManager, 'has_table', return_value=False)
+        mocker.patch.object(ContextManager, 'get_schema', return_value='schema')
+        mock = mocker.patch.object(ContextManager, 'execute_long_running_query')
+
+        # When
+        cm = ContextManager(self.credentials)
+        cm.create_table_from_query('SELECT * FROM table_name', '__new_table_name__', if_exists='fail', cartodbfy=True)
+
+        # Then
+        mock.assert_called_with("SELECT CDB_CartodbfyTable('schema', '__new_table_name__')")

--- a/tests/unit/io/test_carto.py
+++ b/tests/unit/io/test_carto.py
@@ -522,6 +522,17 @@ def test_copy_table_cartodbfy(mocker):
     assert cm_mock.call_args[0][3] is True
 
 
+def test_copy_table_cartodbfy_default(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    copy_table('__table_name__', '__new_table_name__', CREDENTIALS)
+
+    # Then
+    assert cm_mock.call_args[0][3] is True
+
+
 def test_create_table_from_query_wrong_query(mocker):
     # When
     with pytest.raises(ValueError) as e:
@@ -576,6 +587,17 @@ def test_create_table_from_query_cartodbfy(mocker):
 
     # When
     create_table_from_query('SELECT * FROM table', '__new_table_name__', CREDENTIALS, cartodbfy=True)
+
+    # Then
+    assert cm_mock.call_args[0][3] is True
+
+
+def test_create_table_from_query_cartodbfy_default(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    create_table_from_query('SELECT * FROM table', '__new_table_name__', CREDENTIALS)
 
     # Then
     assert cm_mock.call_args[0][3] is True

--- a/tests/unit/io/test_carto.py
+++ b/tests/unit/io/test_carto.py
@@ -521,6 +521,7 @@ def test_copy_table_cartodbfy(mocker):
     # Then
     assert cm_mock.call_args[0][3] is True
 
+
 def test_create_table_from_query_wrong_query(mocker):
     # When
     with pytest.raises(ValueError) as e:

--- a/tests/unit/io/test_carto.py
+++ b/tests/unit/io/test_carto.py
@@ -500,6 +500,27 @@ def test_copy_table_wrong_if_exists(mocker):
     assert str(e.value) == 'Wrong option for the `if_exists` param. You should provide: fail, replace, append.'
 
 
+def test_copy_table_no_cartodbfy(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    copy_table('__table_name__', '__new_table_name__', CREDENTIALS, cartodbfy=False)
+
+    # Then
+    assert cm_mock.call_args[0][3] is False
+
+
+def test_copy_table_cartodbfy(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    copy_table('__table_name__', '__new_table_name__', CREDENTIALS, cartodbfy=True)
+
+    # Then
+    assert cm_mock.call_args[0][3] is True
+
 def test_create_table_from_query_wrong_query(mocker):
     # When
     with pytest.raises(ValueError) as e:
@@ -535,3 +556,25 @@ def test_create_table_from_query_wrong_if_exists(mocker):
 
     # Then
     assert str(e.value) == 'Wrong option for the `if_exists` param. You should provide: fail, replace, append.'
+
+
+def test_create_table_from_query_no_cartodbfy(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    create_table_from_query('SELECT * FROM table', '__new_table_name__', CREDENTIALS, cartodbfy=False)
+
+    # Then
+    assert cm_mock.call_args[0][3] is False
+
+
+def test_create_table_from_query_cartodbfy(mocker):
+    # Given
+    cm_mock = mocker.patch.object(ContextManager, 'create_table_from_query')
+
+    # When
+    create_table_from_query('SELECT * FROM table', '__new_table_name__', CREDENTIALS, cartodbfy=True)
+
+    # Then
+    assert cm_mock.call_args[0][3] is True


### PR DESCRIPTION
### Context

After [this PR](https://github.com/CartoDB/cartoframes/pull/1735), the cartodbfication step for `to_carto` was removed from the [ContextManager's `_drop_create_table_from_query` method](https://github.com/CartoDB/cartoframes/blob/develop/cartoframes/io/managers/context_manager.py#L299-L304) to be performed later on this function instead. 

However, this has introduced a bug, causing that both `create_table_from_query` and `copy_table` functions (which relied on this step for cartodbfying tables) result in non-cartodbfied tables.

Further context can be found here: https://app.clubhouse.io/cartoteam/story/175987/economicalinsurance-cartoframes-datasets-generated-from-query-are-not-cartodbfyed 

### Relevant PR changes

- `cartoframes/io/managers/context_manager.py` Add cartodbfy parameter with default value `True` for `create_table_from_query` method to perform the table cartodbfication
- `cartoframes/io/carto.py` Add cartodbfy parameter for `create_table_from_query` and `copy_table` functions and pass it to ContextManager's `create_table_from_query` method 

- `tests/unit/io/managers/test_context_manager.py` Add test to verify that the cartodbfication step is executed via `execute_long_running_query` method
- `tests/unit/io/test_carto.py` Add tests to verify that the cartodbfy parameter is passed as expected to ContextManager's `create_table_from_query` method 