### PR TITLE
fix deprecation warning

### DIFF
--- a/cartoframes/utils/utils.py
+++ b/cartoframes/utils/utils.py
@@ -549,7 +549,7 @@ def get_parameter_from_decorator(parameter_name, decorated_function, *args, **kw
         parameter = kwargs[parameter_name]
     except KeyError:
         try:
-            parameter_args = inspect.getargspec(decorated_function).args
+            parameter_args = inspect.getfullargspec(decorated_function).args
             if parameter_name in parameter_args:
                 parameter_arg_index = parameter_args.index(parameter_name)
                 parameter = args[parameter_arg_index]


### PR DESCRIPTION
/cartoframes/utils/utils.py:552: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
    parameter_args = inspect.getargspec(decorated_function).args

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html